### PR TITLE
Making OS X binary wheels that include a GEOS dylib

### DIFF
--- a/build-scripts/macosx-10.6-intel.sh
+++ b/build-scripts/macosx-10.6-intel.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Dependent on the Kyngchaos Frameworks:
+# http://www.kyngchaos.com/software/frameworks
+
+export GEOS_CONFIG="/Library/Frameworks/GEOS.framework/Versions/3/unix/bin/geos-config"
+CFLAGS="`$GEOS_CONFIG --cflags`" LDFLAGS="`$GEOS_CONFIG --clibs`" python setup.py bdist_wheel
+delocate-wheel -w fixed_wheels --require-archs=intel -v dist/Shapely-1.5.2-cp27-none-macosx_10_6_intel.whl

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -60,18 +60,25 @@ if sys.platform.startswith('linux'):
     free.restype = None
 
 elif sys.platform == 'darwin':
-    if hasattr(sys, 'frozen'):
-        # .app file from py2app
-        alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
-                     '..', 'Frameworks', 'libgeos_c.dylib')]
+    # First test to see if this is a delocated wheel with a GEOS dylib.
+    geos_whl_dylib = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '.dylibs/GEOS'))
+    if os.path.exists(geos_whl_dylib):
+        _lgeos = CDLL(geos_whl_dylib)
     else:
-        alt_paths = [
-            # The Framework build from Kyng Chaos:
-            "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
-            # macports
-            '/opt/local/lib/libgeos_c.dylib',
-        ]
-    _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+        if hasattr(sys, 'frozen'):
+            # .app file from py2app
+            alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
+                         '..', 'Frameworks', 'libgeos_c.dylib')]
+        else:
+            alt_paths = [
+                # The Framework build from Kyng Chaos
+                "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
+                # macports
+                '/opt/local/lib/libgeos_c.dylib',
+            ]
+        _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+
     free = load_dll('c').free
     free.argtypes = [c_void_p]
     free.restype = None


### PR DESCRIPTION
4 lines added to shapely/geos.py will let us load a shared library included in a [binary wheel for OS X](https://github.com/MacPython/wiki/wiki/Spinning-wheels). This means a completely self-contained Shapely wheel that "just works" on a OS X system Python or python.org Python.

My plan is to use [delocate](https://github.com/matthew-brett/delocate) to copy dependencies and relink the extension modules as the SciPy project does. Currently, I'm using the Kyngchaos Framework libs because they are dual architecture (like python.org's Python). It brings the wheel size up to 1.2MB, which isn't too bad at all.

@mwtoews can you review this for me and merge? I'd like to get a binary wheel for 1.5.2 out for some user testing soon.