### PR TITLE
On later attempt to build_ext, remove previously added cython_build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,9 @@ except BuildFailed as ex:
     print("Failure information, if any, is above.")
     print("I'm retrying the build without the C extension now.")
 
+    if 'build_ext' in cmd_classes:
+        del cmd_classes['build_ext']
+
     setup(**setup_args)
 
     print(BUILD_EXT_WARNING)


### PR DESCRIPTION
When Cythonizing fails, setup.py throws an exception since the wrong `build_ext` is used. See the following:
```
$ python setup.py build_ext --inplace
Updating C extension with Cython.
running build_ext
...
command 'gcc' failed with exit status 1
Warning: The C extension could not be compiled, speedups are not enabled.
Failure information, if any, is above.
I'm retrying the build without the C extension now.
running build_ext
Traceback (most recent call last):
  File "setup.py", line 298, in <module>
    setup(**setup_args)
  File "/usr/lib64/python2.6/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib64/python2.6/distutils/dist.py", line 975, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command
    cmd_obj.run()
  File "setup.py", line 208, in run
    build_ext.run(self)
  File "/amp/gw/sw/lib/python/site-packages/Cython-0.21.2-py2.6-linux-x86_64.egg/Cython/Distutils/build_ext.py", line 160, in run
    if self.cython_gdb or [1 for ext in self.extensions
TypeError: 'NoneType' object is not iterable
```

This PR removes the previously added `cython_build_ext` (on L269) to `cmd_classes['build_ext']`, so it can build without Cython, ending with a "Plain-Python installation succeeded" message.