### PR TITLE
Bug checking number of coordinates in "holes"?

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -498,7 +498,7 @@ def geos_polygon_from_py(shell, holes=None):
             L = len(ob)
             exemplar = ob[0]
             try:
-                N = len(exemplar[0])
+                N = len(exemplar)
             except TypeError:
                 N = exemplar._ndim
             if not L >= 1:


### PR DESCRIPTION
I think this is a bug -- exemplar is already the first set of coordinates from line 499, so you want it's length, not the length of it's first item (which will return length of an x coordinate, which fails).