### PR TITLE
Modify svg() and _repr_svg_() outputs

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -360,7 +360,8 @@ class BaseGeometry(object):
     def _repr_svg_(self):
         """SVG representation for iPython notebook"""
         if self.is_empty:
-            return '<svg />'
+            return '<svg xmlns="http://www.w3.org/2000/svg" ' \
+                'xmlns:xlink="http://www.w3.org/1999/xlink" />'
         else:
             # Pick an arbitrary size for the SVG canvas
             xmin, ymin, xmax, ymax = self.buffer(1).bounds
@@ -374,7 +375,9 @@ class BaseGeometry(object):
             buffered_box = "{0} {1} {2} {3}".\
                 format(xmin, ymin, xmax - xmin, ymax - ymin)
             return (
-                '<svg preserveAspectRatio="xMinYMin meet" viewBox="{0}" '
+                '<svg xmlns="http://www.w3.org/2000/svg" '
+                'xmlns:xlink="http://www.w3.org/1999/xlink" '
+                'preserveAspectRatio="xMinYMin meet" viewBox="{0}" '
                 'width="{1}" height="{2}" '
                 'transform="translate(0, {1}),scale(1, -1)">{3}</svg>'
                 ).format(buffered_box, x_size, y_size, self.svg(scale_factor))

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -353,35 +353,31 @@ class BaseGeometry(object):
         """WKB hex representation of the geometry"""
         return WKBWriter(lgeos).write_hex(self)
 
-    def svg(self, scale_factor=1.):
-        """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
+    def svg(self, scale_factor=1., **kwargs):
+        """Raises NotImplementedError"""
         raise NotImplementedError
 
     def _repr_svg_(self):
         """SVG representation for iPython notebook"""
-        #Pick an arbitrary size for the SVG canvas
-
-
-        xmin, ymin, xmax, ymax = self.buffer(1).bounds
-        x_size = min([max([100., xmax - xmin]), 300])
-        y_size = min([max([100., ymax - ymin]), 300])
-        try:
-            scale_factor = max([xmax - xmin, ymax - ymin]) / max([x_size, y_size])
-        except ZeroDivisionError:
-            scale_factor = 1
-        buffered_box = "{0} {1} {2} {3}".format(xmin, ymin, xmax - xmin, ymax - ymin)
-        return """<svg
-            preserveAspectRatio="xMinYMin meet"
-            viewBox="{0}"
-            width="{1}"
-            height="{2}"
-            transform="translate(0, {1}),scale(1, -1)">
-            {3}
-            </svg>""".format(buffered_box, x_size, y_size, self.svg(scale_factor))
+        if self.is_empty:
+            return '<svg />'
+        else:
+            # Pick an arbitrary size for the SVG canvas
+            xmin, ymin, xmax, ymax = self.buffer(1).bounds
+            x_size = min([max([100., xmax - xmin]), 300])
+            y_size = min([max([100., ymax - ymin]), 300])
+            try:
+                scale_factor = \
+                    max([xmax - xmin, ymax - ymin]) / max([x_size, y_size])
+            except ZeroDivisionError:
+                scale_factor = 1
+            buffered_box = "{0} {1} {2} {3}".\
+                format(xmin, ymin, xmax - xmin, ymax - ymin)
+            return (
+                '<svg preserveAspectRatio="xMinYMin meet" viewBox="{0}" '
+                'width="{1}" height="{2}" '
+                'transform="translate(0, {1}),scale(1, -1)">{3}</svg>'
+                ).format(buffered_box, x_size, y_size, self.svg(scale_factor))
 
     @property
     def geom_type(self):
@@ -744,13 +740,24 @@ class BaseMultipartGeometry(BaseGeometry):
 
     __hash__ = object.__hash__
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., color=None):
+        """Returns a group of SVG elements for the multipart geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG stroke-width.  Default is 1.
+        color : str, optional
+            Hex string for stroke or fill color. Default is to use "#66cc99"
+            if geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        return "\n".join([g.svg(scale_factor) for g in self])
+        if self.is_empty:
+            return '<g />'
+        if color is None:
+            color = "#66cc99" if self.is_valid else "#ff3333"
+        return '<g>' + \
+            ''.join(p.svg(scale_factor, color) for p in self) + \
+            '</g>'
 
 
 class GeometrySequence(object):

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -55,23 +55,26 @@ class LineString(BaseGeometry):
             'coordinates': tuple(self.coords)
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., stroke_color=None):
+        """Returns SVG polyline element for the LineString geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG stroke-width.  Default is 1.
+        stroke_color : str, optional
+            Hex string for stroke color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
+        if self.is_empty:
+            return '<g />'
+        if stroke_color is None:
+            stroke_color = "#66cc99" if self.is_valid else "#ff3333"
         pnt_format = " ".join(["{0},{1}".format(*c) for c in self.coords])
-        return """<polyline
-            fill="none"
-            stroke="{2}"
-            stroke-width={1}
-            points="{0}"
-            opacity=".8"
-            />""".format(
-                pnt_format,
-                2.*scale_factor, 
-                "#66cc99" if self.is_valid else "#ff3333")
+        return (
+            '<polyline fill="none" stroke="{2}" stroke-width="{1}" '
+            'points="{0}" opacity="0.8" />'
+            ).format(pnt_format, 2. * scale_factor, stroke_color)
 
     @property
     def ctypes(self):

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -61,26 +61,24 @@ class MultiLineString(BaseMultipartGeometry):
             'coordinates': tuple(tuple(c for c in g.coords) for g in self.geoms)
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., stroke_color=None):
+        """Returns a group of SVG polyline elements for the LineString geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG stroke-width.  Default is 1.
+        stroke_color : str, optional
+            Hex string for stroke color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        parts = []
-        for part in self.geoms:
-            pnt_format = " ".join(["{0},{1}".format(*c) for c in part.coords])
-            parts.append("""<polyline
-                fill="none"
-                stroke="{2}"
-                stroke-width={1}
-                points="{0}"
-                opacity=".8"
-                />""".format(
-                    pnt_format,
-                    2.*scale_factor,
-                    "#66cc99" if self.is_valid else "#ff3333"))
-        return "\n".join(parts)
+        if self.is_empty:
+            return '<g />'
+        if stroke_color is None:
+            stroke_color = "#66cc99" if self.is_valid else "#ff3333"
+        return '<g>' + \
+            ''.join(p.svg(scale_factor, stroke_color) for p in self) + \
+            '</g>'
 
 
 class MultiLineStringAdapter(CachingGeometryProxy, MultiLineString):

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -69,28 +69,24 @@ class MultiPoint(BaseMultipartGeometry):
             'coordinates': tuple([g.coords[0] for g in self.geoms])
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., fill_color=None):
+        """Returns a group of SVG circle elements for the MultiPoint geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG circle diameters.  Default is 1.
+        fill_color : str, optional
+            Hex string for fill color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        
-        parts = []
-        for part in self.geoms:
-            parts.append("""<circle
-            cx="{0.x}"
-            cy="{0.y}"
-            r="{1}"
-            stroke="#555555"
-            stroke-width="{2}"
-            fill="{3}"
-            opacity=".6"
-            />""".format(
-                part,
-                3*scale_factor,
-                1*scale_factor, "#66cc99" if self.is_valid else "#ff3333"))
-        return "\n".join(parts)
+        if self.is_empty:
+            return '<g />'
+        if fill_color is None:
+            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        return '<g>' + \
+            ''.join(p.svg(scale_factor, fill_color) for p in self) + \
+            '</g>'
 
     @property
     @exceptNull

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -80,29 +80,24 @@ class MultiPolygon(BaseMultipartGeometry):
             'coordinates': allcoords
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., fill_color=None):
+        """Returns group of SVG path elements for the MultiPolygon geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG stroke-width.  Default is 1.
+        fill_color : str, optional
+            Hex string for fill color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        parts = []
-        for part in self.geoms:
-            exterior_coords = [["{0},{1}".format(*c) for c in part.exterior.coords]]
-            interior_coords = [
-                ["{0},{1}".format(*c) for c in interior.coords]
-                for interior in part.interiors ]
-            path = " ".join([
-                "M {0} L {1} z".format(coords[0], " L ".join(coords[1:]))
-                for coords in exterior_coords + interior_coords ])
-            parts.append(
-                """<g fill-rule="evenodd" fill="{2}" stroke="#555555"
-                stroke-width="{0}" opacity="0.6">
-                <path d="{1}" /></g>""".format(
-                    2. * scale_factor,
-                    path,
-                    "#66cc99" if self.is_valid else "#ff3333"))
-        return "\n".join(parts)
+        if self.is_empty:
+            return '<g />'
+        if fill_color is None:
+            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        return '<g>' + \
+            ''.join(p.svg(scale_factor, fill_color) for p in self) + \
+            '</g>'
 
 
 class MultiPolygonAdapter(CachingGeometryProxy, MultiPolygon):

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -74,25 +74,25 @@ class Point(BaseGeometry):
             'coordinates': self.coords[0]
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., fill_color=None):
+        """Returns SVG circle element for the Point geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG circle diameter.  Default is 1.
+        fill_color : str, optional
+            Hex string for fill color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        return """<circle
-            cx="{0.x}"
-            cy="{0.y}"
-            r="{1}"
-            stroke="#555555"
-            stroke-width="{2}"
-            fill="{3}"
-            opacity=".6"
-            />""".format(
-                self,
-                3 * scale_factor,
-                1 * scale_factor,
-                "#66cc99" if self.is_valid else "#ff3333")
+        if self.is_empty:
+            return '<g />'
+        if fill_color is None:
+            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        return (
+            '<circle cx="{0.x}" cy="{0.y}" r="{1}" '
+            'stroke="#555555" stroke-width="{2}" fill="{3}" opacity="0.6" />'
+            ).format(self, 3. * scale_factor, 1. * scale_factor, fill_color)
 
     @property
     def ctypes(self):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -300,25 +300,33 @@ class Polygon(BaseGeometry):
             'coordinates': tuple(coords)
             }
 
-    def svg(self, scale_factor=1.):
+    def svg(self, scale_factor=1., fill_color=None):
+        """Returns SVG path element for the Polygon geometry.
+
+        Parameters
+        ==========
+        scale_factor : float
+            Multiplication factor for the SVG stroke-width.  Default is 1.
+        fill_color : str, optional
+            Hex string for fill color. Default is to use "#66cc99" if
+            geometry is valid, and "#ff3333" if invalid.
         """
-        SVG representation of the geometry. Scale factor is multiplied by
-        the size of the SVG symbol so it can be scaled consistently for a
-        consistent appearance based on the canvas size.
-        """
-        exterior_coords = [["{0},{1}".format(*c) for c in self.exterior.coords]]
+        if self.is_empty:
+            return '<g />'
+        if fill_color is None:
+            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        exterior_coords = [
+            ["{0},{1}".format(*c) for c in self.exterior.coords]]
         interior_coords = [
             ["{0},{1}".format(*c) for c in interior.coords]
-            for interior in self.interiors ]
+            for interior in self.interiors]
         path = " ".join([
             "M {0} L {1} z".format(coords[0], " L ".join(coords[1:]))
-            for coords in exterior_coords + interior_coords ])
-        return """
-            <g fill-rule="evenodd" fill="{2}" stroke="#555555"
-            stroke-width="{0}" opacity="0.6">
-            <path d="{1}" />
-            </g>""".format(
-                2.*scale_factor, path, "#66cc99" if self.is_valid else "#ff3333")
+            for coords in exterior_coords + interior_coords])
+        return (
+            '<path fill-rule="evenodd" fill="{2}" stroke="#555555" '
+            'stroke-width="{0}" opacity="0.6" d="{1}" />'
+            ).format(2. * scale_factor, path, fill_color)
 
 
 class PolygonAdapter(PolygonProxy, Polygon):

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -13,7 +13,6 @@ class SvgTestCase(unittest.TestCase):
     def assertSVG(self, geom, expected, **kwrds):
         """Helper function to check XML and debug SVG"""
         svg_elem = geom.svg(**kwrds)
-        self.assertEqual(svg_elem, expected)
         try:
             parse_xml_string(svg_elem)
         except:
@@ -26,7 +25,7 @@ class SvgTestCase(unittest.TestCase):
             raise AssertionError(
                 'XML is not valid for SVG doucment: ' + str(svg_doc))
         svg_output_dir = None
-        # svg_output_dir = '.'
+        # svg_output_dir = '.'  # useful for debugging SVG files
         if svg_output_dir:
             fname = geom.type
             if geom.is_empty:
@@ -39,6 +38,7 @@ class SvgTestCase(unittest.TestCase):
             svg_path = os.path.join(svg_output_dir, fname + '.svg')
             with open(svg_path, 'w') as fp:
                 fp.write(doc.toprettyxml())
+        self.assertEqual(svg_elem, expected)
 
     def test_point(self):
         # Empty
@@ -78,15 +78,15 @@ class SvgTestCase(unittest.TestCase):
         # Empty
         self.assertSVG(LineString(), '<g />')
         # Valid
-        g = LineString([(6, 7), (3, 4)])
+        g = LineString([(5, 8), (496, -6), (530, 20)])
         self.assertSVG(
             g,
             '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
-            'points="6.0,7.0 3.0,4.0" opacity="0.8" />')
+            'points="5.0,8.0 496.0,-6.0 530.0,20.0" opacity="0.8" />')
         self.assertSVG(
             g,
             '<polyline fill="none" stroke="#66cc99" stroke-width="10.0" '
-            'points="6.0,7.0 3.0,4.0" opacity="0.8" />',
+            'points="5.0,8.0 496.0,-6.0 530.0,20.0" opacity="0.8" />',
             scale_factor=5)
         # Invalid
         self.assertSVG(
@@ -159,12 +159,12 @@ class SvgTestCase(unittest.TestCase):
         # Invalid
         self.assertSVG(
             MultiPolygon([
-                Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+                Polygon([(140, 140), (120, 145), (145, 130), (140, 140)]),
                 Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
             ]),
             '<g><path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
-            'stroke-width="2.0" opacity="0.6" d="M 40.0,40.0 L 20.0,45.0 L '
-            '45.0,30.0 L 40.0,40.0 z" />'
+            'stroke-width="2.0" opacity="0.6" d="M 140.0,140.0 L '
+            '120.0,145.0 L 145.0,130.0 L 140.0,140.0 z" />'
             '<path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
             'stroke-width="2.0" opacity="0.6" d="M 0.0,40.0 L 0.0,0.0 L '
             '40.0,40.0 L 40.0,0.0 L 0.0,40.0 z" /></g>')

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,0 +1,234 @@
+# Tests SVG output and validity
+
+import xml.etree.ElementTree as ET
+
+from . import unittest
+from shapely.geometry import Point, MultiPoint, LineString, MultiLineString,\
+    Polygon, MultiPolygon
+from shapely.geometry.collection import GeometryCollection
+
+def is_valid_xml(x):
+    try:
+        ET.fromstring(x)
+        return True
+    except:
+        return False
+
+
+class SvgTestCase(unittest.TestCase):
+
+    def test_point(self):
+        # Empty
+        g = Point()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = Point(6, 7)
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<circle cx="6.0" cy="7.0" r="3.0" stroke="#555555" '
+            'stroke-width="1.0" fill="#66cc99" opacity="0.6" />')
+        s = g.svg(5)
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<circle cx="6.0" cy="7.0" r="15.0" stroke="#555555" '
+            'stroke-width="5.0" fill="#66cc99" opacity="0.6" />')
+
+    def test_multipoint(self):
+        # Empty
+        g = MultiPoint()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = MultiPoint([(6, 7), (3, 4)])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<g><circle cx="6.0" cy="7.0" r="3.0" stroke="#555555" '
+            'stroke-width="1.0" fill="#66cc99" opacity="0.6" />'
+            '<circle cx="3.0" cy="4.0" r="3.0" stroke="#555555" '
+            'stroke-width="1.0" fill="#66cc99" opacity="0.6" /></g>')
+
+    def test_linestring(self):
+        # Empty
+        g = LineString()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = LineString([(6, 7), (3, 4)])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
+            'points="6.0,7.0 3.0,4.0" opacity="0.8" />')
+        s = g.svg(5)
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<polyline fill="none" stroke="#66cc99" stroke-width="10.0" '
+            'points="6.0,7.0 3.0,4.0" opacity="0.8" />')
+        # Invalid
+        g = LineString([(0, 0), (0, 0)])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
+            'points="0.0,0.0 0.0,0.0" opacity="0.8" />')
+
+    def test_multilinestring(self):
+        # Empty
+        g = MultiLineString()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = MultiLineString([[(6, 7), (3, 4)], [(2, 8), (9, 1)]])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<g><polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
+            'points="6.0,7.0 3.0,4.0" opacity="0.8" />'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
+            'points="2.0,8.0 9.0,1.0" opacity="0.8" /></g>')
+        # Invalid
+        g = MultiLineString([[(2, 3), (2, 3)], [(2, 8), (9, 1)]])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<g><polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
+            'points="2.0,3.0 2.0,3.0" opacity="0.8" />'
+            '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
+            'points="2.0,8.0 9.0,1.0" opacity="0.8" /></g>')
+
+    def test_polygon(self):
+        # Empty
+        g = Polygon()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = Polygon([(35, 10), (45, 45), (15, 40), (10, 20), (35, 10)],
+                    [[(20, 30), (35, 35), (30, 20), (20, 30)]])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertEqual(
+            s,
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 35.0,10.0 L 45.0,45.0 L '
+            '15.0,40.0 L 10.0,20.0 L 35.0,10.0 z M 20.0,30.0 L 35.0,35.0 L '
+            '30.0,20.0 L 20.0,30.0 z" />')
+        s = g.svg(5)
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="10.0" opacity="0.6" d="M 35.0,10.0 L 45.0,45.0 L '
+            '15.0,40.0 L 10.0,20.0 L 35.0,10.0 z M 20.0,30.0 L 35.0,35.0 L '
+            '30.0,20.0 L 20.0,30.0 z" />')
+        # Invalid
+        g = Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 0.0,40.0 L 0.0,0.0 L '
+            '40.0,40.0 L 40.0,0.0 L 0.0,40.0 z" />')
+
+    def test_multipolygon(self):
+        # Empty
+        g = MultiPolygon()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = MultiPolygon([
+            Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+            Polygon(
+                [(20, 35), (10, 30), (10, 10), (30, 5), (45, 20), (20, 35)],
+                [[(30, 20), (20, 15), (20, 25), (30, 20)]])
+        ])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<g><path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 40.0,40.0 L 20.0,45.0 L '
+            '45.0,30.0 L 40.0,40.0 z" />'
+            '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 20.0,35.0 L 10.0,30.0 L '
+            '10.0,10.0 L 30.0,5.0 L 45.0,20.0 L 20.0,35.0 z M 30.0,20.0 L '
+            '20.0,15.0 L 20.0,25.0 L 30.0,20.0 z" /></g>')
+        # Invalid
+        g = MultiPolygon([
+            Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+            Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
+        ])
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<g><path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 40.0,40.0 L 20.0,45.0 L '
+            '45.0,30.0 L 40.0,40.0 z" />'
+            '<path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
+            'stroke-width="2.0" opacity="0.6" d="M 0.0,40.0 L 0.0,0.0 L '
+            '40.0,40.0 L 40.0,0.0 L 0.0,40.0 z" /></g>')
+
+    def test_collection(self):
+        # Empty
+        g = GeometryCollection()
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(s, '<g />')
+        # Valid
+        g = Point(7, 3).union(LineString([(4, 2), (8, 4)]))
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<g><circle cx="7.0" cy="3.0" r="3.0" stroke="#555555" '
+            'stroke-width="1.0" fill="#66cc99" opacity="0.6" />'
+            '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
+            'points="4.0,2.0 8.0,4.0" opacity="0.8" /></g>')
+        # Invalid
+        g = Point(7, 3).union(LineString([(4, 2), (4, 2)]))
+        s = g.svg()
+        self.assertTrue(is_valid_xml(s))
+        self.assertTrue(is_valid_xml(g._repr_svg_()))
+        self.assertEqual(
+            s,
+            '<g><circle cx="7.0" cy="3.0" r="3.0" stroke="#555555" '
+            'stroke-width="1.0" fill="#ff3333" opacity="0.6" />'
+            '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
+            'points="4.0,2.0 4.0,2.0" opacity="0.8" /></g>')
+
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(SvgTestCase)

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,118 +1,112 @@
 # Tests SVG output and validity
-
-import xml.etree.ElementTree as ET
+import os
+from xml.dom.minidom import parseString as parse_xml_string
 
 from . import unittest
 from shapely.geometry import Point, MultiPoint, LineString, MultiLineString,\
     Polygon, MultiPolygon
 from shapely.geometry.collection import GeometryCollection
 
-def is_valid_xml(x):
-    try:
-        ET.fromstring(x)
-        return True
-    except:
-        return False
-
 
 class SvgTestCase(unittest.TestCase):
 
+    def assertSVG(self, geom, expected, **kwrds):
+        """Helper function to check XML and debug SVG"""
+        svg_elem = geom.svg(**kwrds)
+        self.assertEqual(svg_elem, expected)
+        try:
+            parse_xml_string(svg_elem)
+        except:
+            raise AssertionError(
+                'XML is not valid for SVG element: ' + str(svg_elem))
+        svg_doc = geom._repr_svg_()
+        try:
+            doc = parse_xml_string(svg_doc)
+        except:
+            raise AssertionError(
+                'XML is not valid for SVG doucment: ' + str(svg_doc))
+        svg_output_dir = None
+        # svg_output_dir = '.'
+        if svg_output_dir:
+            fname = geom.type
+            if geom.is_empty:
+                fname += '_empty'
+            if not geom.is_valid:
+                fname += '_invalid'
+            if kwrds:
+                fname += '_' + \
+                    ','.join(str(k) + '=' + str(kwrds[k]) for k in kwrds)
+            svg_path = os.path.join(svg_output_dir, fname + '.svg')
+            with open(svg_path, 'w') as fp:
+                fp.write(doc.toprettyxml())
+
     def test_point(self):
         # Empty
-        g = Point()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(Point(), '<g />')
         # Valid
         g = Point(6, 7)
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<circle cx="6.0" cy="7.0" r="3.0" stroke="#555555" '
             'stroke-width="1.0" fill="#66cc99" opacity="0.6" />')
-        s = g.svg(5)
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<circle cx="6.0" cy="7.0" r="15.0" stroke="#555555" '
-            'stroke-width="5.0" fill="#66cc99" opacity="0.6" />')
+            'stroke-width="5.0" fill="#66cc99" opacity="0.6" />',
+            scale_factor=5)
 
     def test_multipoint(self):
         # Empty
-        g = MultiPoint()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(MultiPoint(), '<g />')
         # Valid
         g = MultiPoint([(6, 7), (3, 4)])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<g><circle cx="6.0" cy="7.0" r="3.0" stroke="#555555" '
             'stroke-width="1.0" fill="#66cc99" opacity="0.6" />'
             '<circle cx="3.0" cy="4.0" r="3.0" stroke="#555555" '
             'stroke-width="1.0" fill="#66cc99" opacity="0.6" /></g>')
+        self.assertSVG(
+            g,
+            '<g><circle cx="6.0" cy="7.0" r="15.0" stroke="#555555" '
+            'stroke-width="5.0" fill="#66cc99" opacity="0.6" />'
+            '<circle cx="3.0" cy="4.0" r="15.0" stroke="#555555" '
+            'stroke-width="5.0" fill="#66cc99" opacity="0.6" /></g>',
+            scale_factor=5)
 
     def test_linestring(self):
         # Empty
-        g = LineString()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(LineString(), '<g />')
         # Valid
         g = LineString([(6, 7), (3, 4)])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
             'points="6.0,7.0 3.0,4.0" opacity="0.8" />')
-        s = g.svg(5)
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<polyline fill="none" stroke="#66cc99" stroke-width="10.0" '
-            'points="6.0,7.0 3.0,4.0" opacity="0.8" />')
+            'points="6.0,7.0 3.0,4.0" opacity="0.8" />',
+            scale_factor=5)
         # Invalid
-        g = LineString([(0, 0), (0, 0)])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            LineString([(0, 0), (0, 0)]),
             '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
             'points="0.0,0.0 0.0,0.0" opacity="0.8" />')
 
     def test_multilinestring(self):
         # Empty
-        g = MultiLineString()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(MultiLineString(), '<g />')
         # Valid
-        g = MultiLineString([[(6, 7), (3, 4)], [(2, 8), (9, 1)]])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            MultiLineString([[(6, 7), (3, 4)], [(2, 8), (9, 1)]]),
             '<g><polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
             'points="6.0,7.0 3.0,4.0" opacity="0.8" />'
             '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
             'points="2.0,8.0 9.0,1.0" opacity="0.8" /></g>')
         # Invalid
-        g = MultiLineString([[(2, 3), (2, 3)], [(2, 8), (9, 1)]])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            MultiLineString([[(2, 3), (2, 3)], [(2, 8), (9, 1)]]),
             '<g><polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
             'points="2.0,3.0 2.0,3.0" opacity="0.8" />'
             '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '
@@ -120,61 +114,41 @@ class SvgTestCase(unittest.TestCase):
 
     def test_polygon(self):
         # Empty
-        g = Polygon()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(Polygon(), '<g />')
         # Valid
         g = Polygon([(35, 10), (45, 45), (15, 40), (10, 20), (35, 10)],
                     [[(20, 30), (35, 35), (30, 20), (20, 30)]])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
             'stroke-width="2.0" opacity="0.6" d="M 35.0,10.0 L 45.0,45.0 L '
             '15.0,40.0 L 10.0,20.0 L 35.0,10.0 z M 20.0,30.0 L 35.0,35.0 L '
             '30.0,20.0 L 20.0,30.0 z" />')
-        s = g.svg(5)
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            g,
             '<path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
             'stroke-width="10.0" opacity="0.6" d="M 35.0,10.0 L 45.0,45.0 L '
             '15.0,40.0 L 10.0,20.0 L 35.0,10.0 z M 20.0,30.0 L 35.0,35.0 L '
-            '30.0,20.0 L 20.0,30.0 z" />')
+            '30.0,20.0 L 20.0,30.0 z" />',
+            scale_factor=5)
         # Invalid
-        g = Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)]),
             '<path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
             'stroke-width="2.0" opacity="0.6" d="M 0.0,40.0 L 0.0,0.0 L '
             '40.0,40.0 L 40.0,0.0 L 0.0,40.0 z" />')
 
     def test_multipolygon(self):
         # Empty
-        g = MultiPolygon()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(MultiPolygon(), '<g />')
         # Valid
-        g = MultiPolygon([
-            Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
-            Polygon(
-                [(20, 35), (10, 30), (10, 10), (30, 5), (45, 20), (20, 35)],
-                [[(30, 20), (20, 15), (20, 25), (30, 20)]])
-        ])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            MultiPolygon([
+                Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+                Polygon([(20, 35), (10, 30), (10, 10), (30, 5), (45, 20),
+                         (20, 35)],
+                        [[(30, 20), (20, 15), (20, 25), (30, 20)]])
+                ]),
             '<g><path fill-rule="evenodd" fill="#66cc99" stroke="#555555" '
             'stroke-width="2.0" opacity="0.6" d="M 40.0,40.0 L 20.0,45.0 L '
             '45.0,30.0 L 40.0,40.0 z" />'
@@ -183,15 +157,11 @@ class SvgTestCase(unittest.TestCase):
             '10.0,10.0 L 30.0,5.0 L 45.0,20.0 L 20.0,35.0 z M 30.0,20.0 L '
             '20.0,15.0 L 20.0,25.0 L 30.0,20.0 z" /></g>')
         # Invalid
-        g = MultiPolygon([
-            Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
-            Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
-        ])
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            MultiPolygon([
+                Polygon([(40, 40), (20, 45), (45, 30), (40, 40)]),
+                Polygon([(0, 40), (0, 0), (40, 40), (40, 0), (0, 40)])
+            ]),
             '<g><path fill-rule="evenodd" fill="#ff3333" stroke="#555555" '
             'stroke-width="2.0" opacity="0.6" d="M 40.0,40.0 L 20.0,45.0 L '
             '45.0,30.0 L 40.0,40.0 z" />'
@@ -201,29 +171,17 @@ class SvgTestCase(unittest.TestCase):
 
     def test_collection(self):
         # Empty
-        g = GeometryCollection()
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(s, '<g />')
+        self.assertSVG(GeometryCollection(), '<g />')
         # Valid
-        g = Point(7, 3).union(LineString([(4, 2), (8, 4)]))
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            Point(7, 3).union(LineString([(4, 2), (8, 4)])),
             '<g><circle cx="7.0" cy="3.0" r="3.0" stroke="#555555" '
             'stroke-width="1.0" fill="#66cc99" opacity="0.6" />'
             '<polyline fill="none" stroke="#66cc99" stroke-width="2.0" '
             'points="4.0,2.0 8.0,4.0" opacity="0.8" /></g>')
         # Invalid
-        g = Point(7, 3).union(LineString([(4, 2), (4, 2)]))
-        s = g.svg()
-        self.assertTrue(is_valid_xml(s))
-        self.assertTrue(is_valid_xml(g._repr_svg_()))
-        self.assertEqual(
-            s,
+        self.assertSVG(
+            Point(7, 3).union(LineString([(4, 2), (4, 2)])),
             '<g><circle cx="7.0" cy="3.0" r="3.0" stroke="#555555" '
             'stroke-width="1.0" fill="#ff3333" opacity="0.6" />'
             '<polyline fill="none" stroke="#ff3333" stroke-width="2.0" '


### PR DESCRIPTION
To `.svg()`
* 1 element per geometry
* multi-part geometries are grouped in `<g>...</g>` elements
* empty geometries are `<g />`

To `._repr_svg_()`
* add the basic attributes to the the svg element (xmlns et al.) to show output in, e.g. Firefox; see http://www-archive.mozilla.org/projects/svg/faq.html#source
* empty geometries are `<svg ... />`

Also, the second parameter is either `color`, `fill_color`, or `stroke_color`, depending on the geometry type. When this is `None`, it is determined if the geometry is valid, as before. (I'm open to just calling this `color`).

Unit testing is added to ensure consistency of output, and only XML is validated (I don't know of an SVG validator).

Fixes #233.