### PR TITLE
Load dynamic library using two alternative methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,12 +44,13 @@ system library path, and install Shapely from the Python package index.
 
     $ pip install shapely
 
-If you've installed GEOS to a non-standard location, you can use the
-geos-config program to find compiler and linker options.
+If you've installed GEOS to a non-standard location, the geos-config program
+will be used to get compiler and linker options. If it is not on the PATH,
+it can be specified with a GEOS_CONFIG environment variable, e.g.:
 
 .. code-block:: console
 
-    $ CFLAGS=`geos-config --cflags` LDFLAGS=`geos-config --clibs` pip install shapely
+    $ GEOS_CONFIG=/path/to/geos-config pip install shapely
 
 If your system's GEOS version is < 3.3.0 you cannot use Shapely 1.3+ and must
 stick to 1.2.x as shown below.

--- a/shapely/libgeos.py
+++ b/shapely/libgeos.py
@@ -1,17 +1,128 @@
 """
-Proxies for the GEOS shared library, versions, and configure options
-TODO: find a flexible way to load a dynamic library from a specified path
+Minimal proxy to a GEOS C dynamic library, which is system dependant
+
+Two environment variables influence this module: GEOS_LIBRARY_PATH and/or
+GEOS_CONFIG.
+
+If GEOS_LIBRARY_PATH is set to a path to a GEOS C shared library, this is
+used. Otherwise GEOS_CONFIG can be set to a path to `geos-config`. If
+`geos-config` is already on the PATH environment variable, then it will
+be used to help better guess the name for the GEOS C dynamic library.
 """
 
-__all__ = [
-    'lgeos', 'geos_version_string', 'geos_version', 'geos_capi_version'
-]
 import os
+import logging
 import re
+import subprocess
 import sys
 from ctypes import CDLL, cdll, c_void_p, c_char_p
 from ctypes.util import find_library
 
+logging.basicConfig()
+log = logging.getLogger(__name__)
+if 'all' in sys.warnoptions:
+    log.level = logging.DEBUG
+
+
+# The main point of this module is to load a dynamic library to this variable
+lgeos = None
+
+# First try: use GEOS_LIBRARY_PATH environment variable
+if 'GEOS_LIBRARY_PATH' in os.environ:
+    geos_library_path = os.environ['GEOS_LIBRARY_PATH']
+    try:
+        lgeos = CDLL(geos_library_path)
+    except:
+        log.warn('cannot open shared object from GEOS_LIBRARY_PATH: %s',
+                 geos_library_path)
+    if lgeos:
+        if hasattr(lgeos, 'GEOSversion'):
+            log.debug('found GEOS C library using GEOS_LIBRARY_PATH')
+        else:
+            raise OSError(
+                'shared object GEOS_LIBRARY_PATH is not a GEOS C library: '
+                + str(geos_library_path))
+
+# Second try: use GEOS_CONFIG environment variable
+if 'GEOS_CONFIG' in os.environ:
+    geos_config = os.environ['GEOS_CONFIG']
+    log.debug('geos_config: %s', geos_config)
+else:
+    geos_config = 'geos-config'
+
+
+def get_geos_config(option):
+    '''Get configuration option from the `geos-config` development utility
+
+    Path to utility is set with a module-level `geos_config` variable, which
+    can be changed or unset.
+    '''
+    geos_config = globals().get('geos_config')
+    if not geos_config or not isinstance(geos_config, str):
+        raise OSError('Path to geos-config is not set')
+    try:
+        stdout, stderr = subprocess.Popen(
+            [geos_config, option],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+    except OSError as ex:
+        # e.g., [Errno 2] No such file or directory
+        raise OSError(
+            'Could not find geos-config %r: %s' % (geos_config, ex))
+    if stderr and not stdout:
+        raise ValueError(stderr.strip())
+    if sys.version_info[0] >= 3:
+        result = stdout.decode('ascii').strip()
+    else:
+        result = stdout.strip()
+    log.debug('%s %s: %r', geos_config, option, result)
+    return result
+
+# Now try and use the utility to load from `geos-config --clibs` with
+# some magic smoke to guess the other parts of the library name
+try:
+    clibs = get_geos_config('--clibs')
+except OSError:
+    geos_config = None
+if not lgeos and geos_config:
+    base = ''
+    name = 'geos_c'
+    for item in clibs.split():
+        if item.startswith("-L"):
+            base = item[2:]
+        elif item.startswith("-l"):
+            name = item[2:]
+    # Now guess the actual library name using a list of possible formats
+    if sys.platform == 'win32':
+        # Unlikely, since geos-config is a shell script, but you never know...
+        fmts = ['{name}.dll']
+    elif sys.platform == 'darwin':
+        fmts = ['lib{name}.dylib', '{name}.dylib', '{name}.framework/{name}']
+    elif os.name == 'posix':
+        fmts = ['lib{name}.so', 'lib{name}.so.1']
+    guesses = []
+    for fmt in fmts:
+        lib_name = fmt.format(name=name)
+        geos_library_path = os.path.join(base, lib_name)
+        try:
+            lgeos = CDLL(geos_library_path)
+            break
+        except:
+            guesses.append(geos_library_path)
+    if lgeos:
+        if hasattr(lgeos, 'GEOSversion'):
+            log.debug('found GEOS C library using geos-config')
+        else:
+            raise OSError(
+                'shared object found by geos-config is not a GEOS C library: '
+                + str(geos_library_path))
+    else:
+        log.warn("cannot open shared object from '%s --clibs': %r",
+                 geos_config, clibs)
+        log.warn("there were %d guess(es) for this path:\n\t%s",
+                 len(guesses), '\n\t'.join(guesses))
+
+
+# Platform-specific attempts, and build `free` object
 
 def load_dll(libname, fallbacks=[]):
     '''Load GEOS dynamic library'''
@@ -31,50 +142,51 @@ def load_dll(libname, fallbacks=[]):
         "Could not find library %s or load any of its variants %s" % (
             libname, fallbacks))
 
-
-# Load dynamic library into a 'lgeos' object, which is system dependant
-
 if sys.platform.startswith('linux'):
-    lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
+    if not lgeos:
+        lgeos = load_dll('geos_c',
+                         fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
     free = load_dll('c').free
     free.argtypes = [c_void_p]
     free.restype = None
 
 elif sys.platform == 'darwin':
-    # First test to see if this is a delocated wheel with a GEOS dylib.
-    geos_whl_dylib = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '.dylibs/libgeos_c.1.dylib'))
-    if os.path.exists(geos_whl_dylib):
-        lgeos = CDLL(geos_whl_dylib)
-    else:
-        if hasattr(sys, 'frozen'):
-            # .app file from py2app
-            alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
-                         '..', 'Frameworks', 'libgeos_c.dylib')]
+    if not lgeos:
+        # First test to see if this is a delocated wheel with a GEOS dylib.
+        geos_whl_dylib = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '.dylibs/libgeos_c.1.dylib'))
+        if os.path.exists(geos_whl_dylib):
+            lgeos = CDLL(geos_whl_dylib)
         else:
-            alt_paths = [
-                # The Framework build from Kyng Chaos
-                "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
-                # macports
-                '/opt/local/lib/libgeos_c.dylib',
-            ]
-        lgeos = load_dll('geos_c', fallbacks=alt_paths)
+            if hasattr(sys, 'frozen'):
+                # .app file from py2app
+                alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
+                             '..', 'Frameworks', 'libgeos_c.dylib')]
+            else:
+                alt_paths = [
+                    # The Framework build from Kyng Chaos
+                    "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
+                    # macports
+                    '/opt/local/lib/libgeos_c.dylib',
+                ]
+            lgeos = load_dll('geos_c', fallbacks=alt_paths)
 
     free = load_dll('c').free
     free.argtypes = [c_void_p]
     free.restype = None
 
 elif sys.platform == 'win32':
-    try:
-        egg_dlls = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                   "DLLs"))
-        wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
-        original_path = os.environ['PATH']
-        os.environ['PATH'] = "%s;%s;%s" % \
-            (egg_dlls, wininst_dlls, original_path)
-        lgeos = CDLL("geos.dll")
-    except (ImportError, WindowsError, OSError):
-        raise
+    if not lgeos:
+        try:
+            egg_dlls = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "DLLs"))
+            wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
+            original_path = os.environ['PATH']
+            os.environ['PATH'] = "%s;%s;%s" % \
+                (egg_dlls, wininst_dlls, original_path)
+            lgeos = CDLL("geos.dll")
+        except (ImportError, WindowsError, OSError):
+            raise
 
     def free(m):
         try:
@@ -85,12 +197,17 @@ elif sys.platform == 'win32':
             pass
 
 elif sys.platform == 'sunos5':
-    lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
+    if not lgeos:
+        lgeos = load_dll('geos_c',
+                         fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
     free = CDLL('libc.so.1').free
     free.argtypes = [c_void_p]
     free.restype = None
+
 else:  # other *nix systems
-    lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
+    if not lgeos:
+        lgeos = load_dll('geos_c',
+                         fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
     free = load_dll('c', fallbacks=['libc.so.6']).free
     free.argtypes = [c_void_p]
     free.restype = None


### PR DESCRIPTION
The first method is borrowed from #240 / GeoDjango, which is to use an
environment variable GEOS_LIBRARY_PATH to point directly to a dynamic library.
If this seems like a hack, it can be removed. However, it could be useful
for folks that don't have GEOS_CONFIG, such as Windows, and want to use a
different DLL file.

The second method is to use geos-config from the PATH, or can be explicity set
using a GEOS_CONFIG flag. It attempts a few paths to libraries from the output
from `geos-config --clibs`. If used in combination with GEOS_LIBRARY_PATH,
the two library versions are checked by setup.py.

After these attempts, the old code is still in place (with very minor changes).

An unused `free` object is still a TODO.

This is a continuation of #239.
