### PR TITLE
Add ImplementationError

### DIFF
--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -21,6 +21,13 @@ from shapely.predicates import BinaryPredicate, UnaryPredicate
 from shapely.topology import BinaryRealProperty, BinaryTopologicalOp
 from shapely.topology import UnaryRealProperty, UnaryTopologicalOp
 
+
+class ImplementationError(
+        AttributeError, KeyError, NotImplementedError):
+    """To be raised when the implementation does not support the 
+    requested method."""
+
+
 def delegated(func):
     """A delegated method raises AttributeError in the absence of backend
     support."""
@@ -29,11 +36,13 @@ def delegated(func):
         try:
             return func(*args, **kwargs)
         except KeyError:
-            raise AttributeError("Method %r is not supported by %r" %
-                                 (func.__name__, args[0].impl))
+            raise ImplementationError(
+                "Method '%s' not provided by "
+                "implementation '%s'" % (func.__name__, args[0].impl))
     return wrapper
 
 # Map geometry methods to their GEOS delegates
+
 
 class BaseImpl(object):
     def __init__(self, values):
@@ -41,7 +50,13 @@ class BaseImpl(object):
     def update(self, values):
         self.map.update(values)
     def __getitem__(self, key):
-        return self.map[key]
+        try:
+            return self.map[key]
+        except KeyError:
+            raise ImplementationError(
+                "Method '%s' not provided by "
+                "implementation '%s'" % (key, self.map))
+
     def __contains__(self, key):
         return key in self.map
 

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -24,8 +24,8 @@ from shapely.topology import UnaryRealProperty, UnaryTopologicalOp
 
 class ImplementationError(
         AttributeError, KeyError, NotImplementedError):
-    """To be raised when the implementation does not support the 
-    requested method."""
+    """To be raised when the registered implementation does not
+    support the requested method."""
 
 
 def delegated(func):
@@ -37,7 +37,7 @@ def delegated(func):
             return func(*args, **kwargs)
         except KeyError:
             raise ImplementationError(
-                "Method '%s' not provided by "
+                "Method '%s' not provided by registered "
                 "implementation '%s'" % (func.__name__, args[0].impl))
     return wrapper
 
@@ -45,25 +45,33 @@ def delegated(func):
 
 
 class BaseImpl(object):
+    """Base class for registrable implementations."""
+
     def __init__(self, values):
         self.map = dict(values)
+
     def update(self, values):
         self.map.update(values)
+
     def __getitem__(self, key):
         try:
             return self.map[key]
         except KeyError:
             raise ImplementationError(
-                "Method '%s' not provided by "
+                "Method '%s' not provided by registered "
                 "implementation '%s'" % (key, self.map))
 
     def __contains__(self, key):
         return key in self.map
 
+
 class GEOSImpl(BaseImpl):
+    """GEOS implementation"""
+
     def __repr__(self):
         return '<GEOSImpl object: GEOS C API version %s>' % (
             lgeos.geos_capi_version,)
+
 
 IMPL300 = {
     'area': (UnaryRealProperty, 'area'),
@@ -129,6 +137,7 @@ IMPL320 = {
 
 IMPL330 = {
     'is_closed': (UnaryPredicate, 'is_closed')}
+
 
 def impl_items(defs):
     return [(k, v[0](v[1])) for k, v in list(defs.items())]

--- a/tests/test_default_impl.py
+++ b/tests/test_default_impl.py
@@ -1,0 +1,24 @@
+import pytest
+
+from shapely.geometry import Point
+from shapely.impl import delegated, ImplementationError
+
+
+def test_error():
+    with pytest.raises(ImplementationError):
+        Point(0, 0).impl['bogus']()
+    with pytest.raises(NotImplementedError):
+        Point(0, 0).impl['bogus']()
+    with pytest.raises(KeyError):
+        Point(0, 0).impl['bogus']()
+
+
+def test_delegated():
+    class Poynt(Point):
+        @delegated
+        def bogus(self):
+            return self.impl['bogus']()
+    with pytest.raises(ImplementationError):
+        Poynt(0, 0).bogus()
+    with pytest.raises(AttributeError):
+        Poynt(0, 0).bogus()


### PR DESCRIPTION
Add an ImplementationError, akin to but slightly different from NotImplementedError. It also derives from KeyError and AttributeError for backwards compatibility with code that catches those errors for this particular case.    

This one would close #216.