### PR TITLE
Enable Cython speedups by default (if available)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
   - "TRAVIS_SPEEDUP_OPTS=--with-speedups"
-  - "TRAVIS_SPEEDUP_OPTS="
+  - "TRAVIS_SPEEDUP_OPTS=--without-speedups"
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ppa

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2338,13 +2338,12 @@ involves some overhead that might slow down your code.
 .. versionadded:: 1.2.10
 
 The :mod:`shapely.speedups` module contains performance enhancements written in
-C. They are automaticaly installed when Python has access to a compiler and
-GEOS development headers during installation.
+C. They are automatically installed when Python has access to a compiler and
+GEOS development headers during installation. 
 
 You can check if the speedups are installed with the :attr:`available`
-attribute. The constructor speedups are disabled by default. To enable the
-speedups call :func:`enable`. You can revert to the default implementation with
-:func:`disable`.
+attribute. To enable the speedups call :func:`enable`. You can revert to the
+default implementation with :func:`disable`.
 
 .. code-block:: pycon
 
@@ -2353,6 +2352,16 @@ speedups call :func:`enable`. You can revert to the default implementation with
   True
   >>> speedups.enable()
 
+.. versionadded:: 1.6.0
+
+Speedups are now enabled by default if they are available. You can check if
+speedups are enabled with the :attr:`enabled` attribute.
+
+.. code-block:: pycon
+
+  >>> from shapely import speedups
+  >>> speedups.enabled
+  True
 
 Conclusion
 ==========

--- a/shapely/geometry/__init__.py
+++ b/shapely/geometry/__init__.py
@@ -18,3 +18,6 @@ __all__ = [
     'GeometryCollection', 'mapping', 'LinearRing', 'asLinearRing',
     'CAP_STYLE', 'JOIN_STYLE',
 ]
+
+# This needs to be called here to avoid circular references
+import shapely.speedups

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -659,5 +659,3 @@ def cleanup(proxy):
     del proxy
 
 atexit.register(cleanup, lgeos)
-
-import shapely.speedups

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -659,3 +659,5 @@ def cleanup(proxy):
     del proxy
 
 atexit.register(cleanup, lgeos)
+
+import shapely.speedups

--- a/shapely/speedups/__init__.py
+++ b/shapely/speedups/__init__.py
@@ -58,5 +58,5 @@ def disable():
     coords.CoordinateSequence.__iter__ = _orig['CoordinateSequence.__iter__']
     linestring.geos_linestring_from_py = _orig['geos_linestring_from_py']
     polygon.geos_linearring_from_py = _orig['geos_linearring_from_py']
-    affinity.affine_transform = _orig['affine_transform']
+    shapely.affinity.affine_transform = _orig['affine_transform']
     _orig.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 def pytest_addoption(parser):
     parser.addoption("--with-speedups", action="store_true", default=False,
         help="Run tests with speedups.")
+    parser.addoption("--without-speedups", action="store_true", default=False,
+        help="Run tests without speedups.")
 
 def pytest_runtest_setup(item):
     if item.config.getoption("--with-speedups"):
@@ -13,4 +15,10 @@ def pytest_runtest_setup(item):
             print("Speedups have been demanded but are unavailable")
             sys.exit(1)
         shapely.speedups.enable()
+        assert(shapely.speedups.enabled is True)
         print("Speedups enabled for %s." % item.name)
+    elif item.config.getoption("--without-speedups"):
+        import shapely.speedups
+        shapely.speedups.disable()
+        assert(shapely.speedups.enabled is False)
+        print("Speedups disabled for %s." % item.name)


### PR DESCRIPTION
This PR addresses the issue(s) raised in https://github.com/Toblerity/Shapely/issues/251

* Fixed a minor bug in `shapely.speedups.disable`
* Enable Cython speedups by default, if available

For instance:
```
>>> import shapely.speedups
>>> shapely.speedups.enabled
True
```

Tests should be called --with-speedups or --without-speedups - this has been amended in `.travis.yml`.

The manual has been updated to reflect the changes.

I've assumed this would be included in 1.6, rather than 1.5.x, although I'm not sure now. Certainly the first commit should be cherry picked into the 1.5 branch. I feel this is worth some good testing, as if it is broken it would break everything.