### PR TITLE
Allow creation of  multipoint from empty list

### DIFF
--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -53,7 +53,7 @@ class MultiPoint(BaseMultipartGeometry):
         """
         super(MultiPoint, self).__init__()
 
-        if not points:
+        if points is None or len(points) == 0:
             # allow creation of empty multipoints, to support unpickling
             pass
         else:

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -53,7 +53,7 @@ class MultiPoint(BaseMultipartGeometry):
         """
         super(MultiPoint, self).__init__()
 
-        if points is None:
+        if not points:
             # allow creation of empty multipoints, to support unpickling
             pass
         else:


### PR DESCRIPTION
`MultiPoint([])` should work like `MultiPolygon([])`.