### PR TITLE
Updating for pyinstaller paths

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -68,9 +68,13 @@ elif sys.platform == 'darwin':
         _lgeos = CDLL(geos_whl_dylib)
     else:
         if hasattr(sys, 'frozen'):
-            # .app file from py2app
-            alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
-                         '..', 'Frameworks', 'libgeos_c.dylib')]
+            try:
+                # .app file from py2app
+                alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
+                            '..', 'Frameworks', 'libgeos_c.dylib')]
+            except KeyError:
+                # binary from pyinstaller
+                alt_paths = [os.path.join(sys.executable, 'libgeos_c.dylib')]
         else:
             alt_paths = [
                 # The Framework build from Kyng Chaos


### PR DESCRIPTION
We're using pyinstaller to generate binaries, but the binaries generated on Darwin have a different directory structure than py2app.  This proposed change would simply add support for pyinstaller-generated binaries to be able to locate the GEOS dylib.

Happy to discuss, and thanks for the awesome library!