### PR TITLE
fallback for darwin on load_dll('c')

### DIFF
--- a/shapely/libgeos.py
+++ b/shapely/libgeos.py
@@ -171,7 +171,7 @@ elif sys.platform == 'darwin':
                 ]
             lgeos = load_dll('geos_c', fallbacks=alt_paths)
 
-    free = load_dll('c').free
+    free = load_dll('c', fallbacks=['/usr/lib/libc.dylib']).free
     free.argtypes = [c_void_p]
     free.restype = None
 


### PR DESCRIPTION
It seems that ctypes.util.find_library doesn't always find libc on Mac OS X Yosemite.
```
Python 2.7.6 (default, Sep  9 2014, 15:04:36) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.39)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ctypes.util import find_library
>>> find_library('c')
>>>
```
```
Python 3.4.2 (v3.4.2:ab2c023a9432, Oct  5 2014, 20:42:22) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ctypes.util import find_library
>>> find_library('c')
>>
```
This patch puts the full path of the file in the fallbacks to work around this problem.