### PR TITLE
Fix int check in GeometrySequence.__getitem__

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -5,7 +5,6 @@ import sys
 from warnings import warn
 from binascii import a2b_hex
 from ctypes import pointer, c_size_t, c_char_p, c_void_p
-import numbers
 
 from shapely.coords import CoordinateSequence
 from shapely.ftools import wraps
@@ -15,6 +14,16 @@ from shapely.impl import DefaultImplementation, delegated
 
 if sys.version_info[0] < 3:
     range = xrange
+    integer_types = (int, long)
+else:
+    integer_types = (int,)
+
+try:
+    import numpy as np
+    integer_types = integer_types + (np.integer,)
+except ImportError:
+    pass
+
 
 GEOMETRY_TYPES = [
     'Point',
@@ -825,7 +834,7 @@ class GeometrySequence(object):
     def __getitem__(self, key):
         self._update()
         m = self.__len__()
-        if isinstance(key, numbers.Integral):
+        if isinstance(key, integer_types):
             if key + m < 0 or key >= m:
                 raise IndexError("index out of range")
             if key < 0:

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -5,6 +5,7 @@ import sys
 from warnings import warn
 from binascii import a2b_hex
 from ctypes import pointer, c_size_t, c_char_p, c_void_p
+import numbers
 
 from shapely.coords import CoordinateSequence
 from shapely.ftools import wraps
@@ -824,7 +825,7 @@ class GeometrySequence(object):
     def __getitem__(self, key):
         self._update()
         m = self.__len__()
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             if key + m < 0 or key >= m:
                 raise IndexError("index out of range")
             if key < 0:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,9 +6,11 @@ from shapely import speedups
 try:
     import numpy
     numpy_version = numpy.version.version
+    integer_types = [int, numpy.int16, numpy.int32, numpy.int64]
 except ImportError:
     numpy = False
     numpy_version = 'not available'
+    integer_types = None
 
 # Show some diagnostic information; handy for Travis CI
 print('Python version: ' + sys.version.replace('\n', ' '))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,14 +3,14 @@ from shapely.libgeos import geos_version_string
 from shapely.geos import lgeos, WKTWriter
 from shapely import speedups
 
+test_int_types = [int]
 try:
     import numpy
     numpy_version = numpy.version.version
-    integer_types = [int, numpy.int16, numpy.int32, numpy.int64]
+    test_int_types.extend([int, numpy.int16, numpy.int32, numpy.int64])
 except ImportError:
     numpy = False
     numpy_version = 'not available'
-    integer_types = None
 
 # Show some diagnostic information; handy for Travis CI
 print('Python version: ' + sys.version.replace('\n', ' '))

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,0 +1,8 @@
+from . import unittest, test_int_types
+
+class MultiGeometryTestCase(unittest.TestCase):
+    def subgeom_access_test(self, cls, geoms):
+        geom = cls(geoms)
+        for t in test_int_types:
+            for i, g in enumerate(geoms):
+                self.assertEqual(geom[t(i)], geoms[i])

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy, integer_types
+from . import unittest, numpy, test_int_types
 from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
@@ -73,9 +73,8 @@ class MultiLineStringTestCase(unittest.TestCase):
 
         # TODO: is there an inverse?
 
-    @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy_subgeom_access(self):
-        for t in integer_types:
+    def test_subgeom_access(self):
+        for t in test_int_types:
             line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
             line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
             geom = MultiLineString([line0, line1])

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -73,6 +73,17 @@ class MultiLineStringTestCase(unittest.TestCase):
 
         # TODO: is there an inverse?
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_subgeom_access(self):
+        import numpy as np
+
+        line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
+        line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
+        geom = MultiLineString([line0, line1])
+
+        self.assertEqual(geom[np.int64(0)], line0)
+
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiLineStringTestCase)

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy
+from . import unittest, numpy, integer_types
 from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
@@ -75,13 +75,12 @@ class MultiLineStringTestCase(unittest.TestCase):
 
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_subgeom_access(self):
-        import numpy as np
+        for t in integer_types:
+            line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
+            line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
+            geom = MultiLineString([line0, line1])
 
-        line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
-        line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
-        geom = MultiLineString([line0, line1])
-
-        self.assertEqual(geom[np.int64(0)], line0)
+            self.assertEqual(geom[t(0)], line0)
 
 
 

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,10 +1,11 @@
 from . import unittest, numpy, test_int_types
+from .test_multi import MultiGeometryTestCase
 from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
 
 
-class MultiLineStringTestCase(unittest.TestCase):
+class MultiLineStringTestCase(MultiGeometryTestCase):
 
     def test_multilinestring(self):
 
@@ -74,13 +75,9 @@ class MultiLineStringTestCase(unittest.TestCase):
         # TODO: is there an inverse?
 
     def test_subgeom_access(self):
-        for t in test_int_types:
-            line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
-            line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
-            geom = MultiLineString([line0, line1])
-
-            self.assertEqual(geom[t(0)], line0)
-
+        line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
+        line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
+        self.subgeom_access_test(MultiLineString, [line0, line1])
 
 
 def test_suite():

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -68,6 +68,15 @@ class MultiPointTestCase(unittest.TestCase):
         pas = asarray(geoma)
         assert_array_equal(pas, array([[1., 2.], [3., 4.]]))
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_subgeom_access(self):
+        import numpy as np
+
+        p0 = Point(1.0, 2.0)
+        p1 = Point(3.0, 4.0)
+        geom = MultiPoint([p0, p1])
+
+        self.assertEqual(geom[np.int64(0)], p0)
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy
+from . import unittest, numpy, integer_types
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
 
@@ -70,13 +70,12 @@ class MultiPointTestCase(unittest.TestCase):
 
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_subgeom_access(self):
-        import numpy as np
+        for t in integer_types:
+            p0 = Point(1.0, 2.0)
+            p1 = Point(3.0, 4.0)
+            geom = MultiPoint([p0, p1])
 
-        p0 = Point(1.0, 2.0)
-        p1 = Point(3.0, 4.0)
-        geom = MultiPoint([p0, p1])
-
-        self.assertEqual(geom[np.int64(0)], p0)
+            self.assertEqual(geom[t(0)], p0)
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy, integer_types
+from . import unittest, numpy, test_int_types
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
 
@@ -68,9 +68,8 @@ class MultiPointTestCase(unittest.TestCase):
         pas = asarray(geoma)
         assert_array_equal(pas, array([[1., 2.], [3., 4.]]))
 
-    @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy_subgeom_access(self):
-        for t in integer_types:
+    def test_subgeom_access(self):
+        for t in test_int_types:
             p0 = Point(1.0, 2.0)
             p1 = Point(3.0, 4.0)
             geom = MultiPoint([p0, p1])

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,9 +1,10 @@
 from . import unittest, numpy, test_int_types
+from .test_multi import MultiGeometryTestCase
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
 
 
-class MultiPointTestCase(unittest.TestCase):
+class MultiPointTestCase(MultiGeometryTestCase):
 
     def test_multipoint(self):
 
@@ -69,12 +70,9 @@ class MultiPointTestCase(unittest.TestCase):
         assert_array_equal(pas, array([[1., 2.], [3., 4.]]))
 
     def test_subgeom_access(self):
-        for t in test_int_types:
-            p0 = Point(1.0, 2.0)
-            p1 = Point(3.0, 4.0)
-            geom = MultiPoint([p0, p1])
-
-            self.assertEqual(geom[t(0)], p0)
+        p0 = Point(1.0, 2.0)
+        p1 = Point(3.0, 4.0)
+        self.subgeom_access_test(MultiPoint, [p0, p1])
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -1,4 +1,4 @@
-from . import unittest
+from . import unittest, numpy
 from shapely.geometry import Polygon, MultiPolygon, asMultiPolygon
 from shapely.geometry.base import dump_coords
 
@@ -66,6 +66,16 @@ class MultiPolygonTestCase(unittest.TestCase):
         self.assertEqual(len(mpa.geoms[0].exterior.coords), 5)
         self.assertEqual(len(mpa.geoms[0].interiors), 1)
         self.assertEqual(len(mpa.geoms[0].interiors[0].coords), 5)
+
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_subgeom_access(self):
+        import numpy as np
+
+        poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+        poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
+        geom = MultiPolygon([poly0, poly1])
+
+        self.assertEqual(geom[np.int64(0)], poly0)
 
 
 def test_suite():

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -1,9 +1,10 @@
 from . import unittest, numpy, test_int_types
+from .test_multi import MultiGeometryTestCase
 from shapely.geometry import Polygon, MultiPolygon, asMultiPolygon
 from shapely.geometry.base import dump_coords
 
 
-class MultiPolygonTestCase(unittest.TestCase):
+class MultiPolygonTestCase(MultiGeometryTestCase):
 
     def test_multipolygon(self):
 
@@ -68,12 +69,9 @@ class MultiPolygonTestCase(unittest.TestCase):
         self.assertEqual(len(mpa.geoms[0].interiors[0].coords), 5)
 
     def test_subgeom_access(self):
-        for t in test_int_types:
-            poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
-            poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
-            geom = MultiPolygon([poly0, poly1])
-
-            self.assertEqual(geom[t(0)], poly0)
+        poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+        poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
+        self.subgeom_access_test(MultiPolygon, [poly0, poly1])
 
 
 def test_suite():

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy, integer_types
+from . import unittest, numpy, test_int_types
 from shapely.geometry import Polygon, MultiPolygon, asMultiPolygon
 from shapely.geometry.base import dump_coords
 
@@ -67,9 +67,8 @@ class MultiPolygonTestCase(unittest.TestCase):
         self.assertEqual(len(mpa.geoms[0].interiors), 1)
         self.assertEqual(len(mpa.geoms[0].interiors[0].coords), 5)
 
-    @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy_subgeom_access(self):
-        for t in integer_types:
+    def test_subgeom_access(self):
+        for t in test_int_types:
             poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
             poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
             geom = MultiPolygon([poly0, poly1])

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy
+from . import unittest, numpy, integer_types
 from shapely.geometry import Polygon, MultiPolygon, asMultiPolygon
 from shapely.geometry.base import dump_coords
 
@@ -69,13 +69,12 @@ class MultiPolygonTestCase(unittest.TestCase):
 
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_subgeom_access(self):
-        import numpy as np
+        for t in integer_types:
+            poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+            poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
+            geom = MultiPolygon([poly0, poly1])
 
-        poly0 = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
-        poly1 = Polygon([(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25)])
-        geom = MultiPolygon([poly0, poly1])
-
-        self.assertEqual(geom[np.int64(0)], poly0)
+            self.assertEqual(geom[t(0)], poly0)
 
 
 def test_suite():


### PR DESCRIPTION
Use numbers.Integral to allow for more robust integer index check.

Fixes #266 