### PR TITLE
Use OffsetCurve instead of SingleSidedBuffer in GEOS >= 3.3

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -129,8 +129,16 @@ def prototype(lgeos, geos_version):
         lgeos.GEOSBufferWithStyle.restype = c_void_p
         lgeos.GEOSBufferWithStyle.argtypes = [c_void_p, c_double, c_int, c_int, c_int, c_double]
 
-        lgeos.GEOSSingleSidedBuffer.restype = c_void_p
-        lgeos.GEOSSingleSidedBuffer.argtypes = [c_void_p, c_double, c_int, c_int, c_double, c_int]
+        if geos_version >= (3, 3, 0):
+
+            lgeos.GEOSOffsetCurve.restype = c_void_p
+            lgeos.GEOSOffsetCurve.argtypes = [c_void_p, c_double, c_int, c_int, c_double]
+        
+        else:
+
+            # deprecated in GEOS 3.3.0 in favour of GEOSOffsetCurve
+            lgeos.GEOSSingleSidedBuffer.restype = c_void_p
+            lgeos.GEOSSingleSidedBuffer.argtypes = [c_void_p, c_double, c_int, c_int, c_double, c_int]
 
     '''
     Geometry constructors

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -110,13 +110,13 @@ class LineString(BaseGeometry):
         return self.coords.xy
 
     def parallel_offset(
-            self, distance, side='left',
+            self, distance, side='right',
             resolution=16, join_style=JOIN_STYLE.round, mitre_limit=5.0):
 
         """Returns a LineString or MultiLineString geometry at a distance from
         the object on its right or its left side.
 
-        The side parameter may be 'left' or 'right' (default is 'left'). The
+        The side parameter may be 'left' or 'right' (default is 'right'). The
         resolution of the buffer around each vertex of the object increases by
         increasing the resolution keyword parameter or third positional
         parameter. If the distance parameter is negative the side is inverted,

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -110,16 +110,18 @@ class LineString(BaseGeometry):
         return self.coords.xy
 
     def parallel_offset(
-            self, distance, side,
+            self, distance, side='left',
             resolution=16, join_style=JOIN_STYLE.round, mitre_limit=5.0):
 
         """Returns a LineString or MultiLineString geometry at a distance from
         the object on its right or its left side.
 
-        Distance must be a positive float value. The side parameter may be
-        'left' or 'right'. The resolution of the buffer around each vertex of
-        the object increases by increasing the resolution keyword parameter or
-        third positional parameter.
+        The side parameter may be 'left' or 'right' (default is 'left'). The
+        resolution of the buffer around each vertex of the object increases by
+        increasing the resolution keyword parameter or third positional
+        parameter. If the distance parameter is negative the side is inverted,
+        e.g. distance=5.0, side='left' is the same as distance=-5.0,
+        side='right'.
 
         The join style is for outside corners between line segments. Accepted
         values are JOIN_STYLE.round (1), JOIN_STYLE.mitre (2), and
@@ -136,8 +138,7 @@ class LineString(BaseGeometry):
                 'Cannot compute offset from zero-length line segment')
         try:
             return geom_factory(self.impl['parallel_offset'](
-                self, distance, resolution, join_style, mitre_limit,
-                bool(side == 'left')))
+                self, distance, resolution, join_style, mitre_limit, side))
         except OSError:
             raise TopologicalError()
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -625,8 +625,8 @@ class LGEOS320(LGEOS311):
     def __init__(self, dll):
         super(LGEOS320, self).__init__(dll)
 
-        if geos_version == (3, 2, 0):
-            def parallel_offset(geom, distance, side, resolution=16, join_style=1, mitre_limit=5.0):
+        if geos_version >= (3, 2, 0):
+            def parallel_offset(geom, distance, resolution=16, join_style=1, mitre_limit=5.0, side='right'):
                 side = side == 'left'
                 if distance < 0:
                     distance = abs(distance)

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -1,0 +1,30 @@
+from . import unittest
+from shapely.geos import geos_version
+from shapely.geometry import LineString, LinearRing
+from shapely.wkt import loads
+
+class OperationsTestCase(unittest.TestCase):
+    @unittest.skipIf(geos_version < (3, 2, 0), 'GEOS 3.2.0 required')
+    def test_parallel_offset_linestring(self):
+        line1 = LineString([(0, 0), (10, 0)])
+        left = line1.parallel_offset(5, 'left')
+        self.assertEqual(left, LineString([(0, 5), (10, 5)]))
+        right = line1.parallel_offset(5, 'right')
+        self.assertEqual(right, LineString([(10, -5), (0, -5)]))
+        right = line1.parallel_offset(-5, 'left')
+        self.assertEqual(right, LineString([(10, -5), (0, -5)]))
+        left = line1.parallel_offset(-5, 'right')
+        self.assertEqual(left, LineString([(0, 5), (10, 5)]))
+
+        line2 = LineString([(0, 0), (5, 0), (5, -5)])
+        self.assertEqual(line2.parallel_offset(2, 'left', resolution=1),
+                         LineString([(0, 2), (5, 2), (7, 0), (7, -5)]))
+        self.assertEqual(line2.parallel_offset(2, 'left', join_style=2,
+                         resolution=1),
+                         LineString([(0, 2), (7, 2), (7, -5)]))
+
+    @unittest.skipIf(geos_version < (3, 2, 0), 'GEOS 3.2.0 required')
+    def test_parallel_offset_linear_ring(self):
+        lr1 = LinearRing([(0, 0), (5, 0), (5, 5), (0, 5), (0, 0)])
+        self.assertEqual(lr1.parallel_offset(2, 'left', resolution=1),
+                         LineString([(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)]))

--- a/tests/test_parallel_offset.py
+++ b/tests/test_parallel_offset.py
@@ -16,6 +16,9 @@ class OperationsTestCase(unittest.TestCase):
         left = line1.parallel_offset(-5, 'right')
         self.assertEqual(left, LineString([(0, 5), (10, 5)]))
 
+        # by default, parallel_offset is right-handed
+        self.assertEqual(line1.parallel_offset(5), right)
+
         line2 = LineString([(0, 0), (5, 0), (5, -5)])
         self.assertEqual(line2.parallel_offset(2, 'left', resolution=1),
                          LineString([(0, 2), (5, 2), (7, 0), (7, -5)]))


### PR DESCRIPTION
This PR switches to using `GEOSOffsetCurve` instead of `GEOSSingleSidedBuffer` which was deprecated in GEOS 3.3.0. Existing code shouldn't notice any change, although the requirement that the `distance` parameter be positive has been removed; instead, if the distance is negative the `side` parameter is inverted. The `side` parameter is now optional, as it can be defined implicitly by the polarity of `distance`. This is all handled in `geos.py` to keep version specific details outside of `linestring.py`.

https://github.com/libgeos/libgeos/blob/aa57155d18f8cbb33b5090c5ea4bae349abf4db2/capi/geos_ts_c.cpp#L1800