### PR TITLE
Compatibility with 64 bit

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -15,15 +15,15 @@ from shapely.geometry.base import geom_factory
 include "../_geos.pxi"
     
 
-cdef inline GEOSGeometry *cast_geom(unsigned long geom_addr):
+cdef inline GEOSGeometry *cast_geom(unsigned long long geom_addr):
     return <GEOSGeometry *>geom_addr
 
 
-cdef inline GEOSContextHandle_t cast_handle(unsigned long handle_addr):
+cdef inline GEOSContextHandle_t cast_handle(unsigned long long handle_addr):
     return <GEOSContextHandle_t>handle_addr
 
 
-cdef inline GEOSCoordSequence *cast_seq(unsigned long handle_addr):
+cdef inline GEOSCoordSequence *cast_seq(unsigned long long handle_addr):
     return <GEOSCoordSequence *>handle_addr
 
 


### PR DESCRIPTION
I recommend this change i.o.t. make it really compatible with 64 bit systems. 

Currently, _speedups might fail when the address for your handles becomes to large for 32-bit long. So all situations when this solution works are pure luck (which happens very often, almost always actually), but might fail under certain situations.

We observed this problem when integrating Python within a .NET-application. This led to larger pointer addresses, and thus to failing casts for 32bit long.

Remark: I cannot fully estimate the impact of this change for other operating systems / processor architectures.