### PR TITLE
Cython warnings (maint branch)

### DIFF
--- a/shapely/_geos.pxi
+++ b/shapely/_geos.pxi
@@ -13,7 +13,7 @@ cdef extern from "geos_c.h":
     GEOSCoordSequence *GEOSCoordSeq_create_r(GEOSContextHandle_t, unsigned int, unsigned int) nogil
     GEOSCoordSequence *GEOSGeom_getCoordSeq_r(GEOSContextHandle_t, GEOSGeometry *) nogil
 
-    int GEOSCoordSeq_getSize_r(GEOSContextHandle_t, GEOSCoordSequence *, int *) nogil
+    int GEOSCoordSeq_getSize_r(GEOSContextHandle_t, GEOSCoordSequence *, unsigned int *) nogil
     int GEOSCoordSeq_setX_r(GEOSContextHandle_t, GEOSCoordSequence *, int, double) nogil
     int GEOSCoordSeq_setY_r(GEOSContextHandle_t, GEOSCoordSequence *, int, double) nogil
     int GEOSCoordSeq_setZ_r(GEOSContextHandle_t, GEOSCoordSequence *, int, double) nogil

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -180,7 +180,8 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
     cdef GEOSGeometry *g
     cdef GEOSCoordSequence *cs
     cdef double dx, dy, dz
-    cdef int i, n, m, M, sm, sn
+    cdef unsigned int m
+    cdef int i, n, M, sm, sn
 
     # If a LinearRing is passed in, just clone it and return
     # If a LineString is passed in, clone the coord seq and return a LinearRing
@@ -413,7 +414,7 @@ cdef GEOSCoordSequence* transform(GEOSCoordSequence* cs,
     Returns the transformed coordinate sequence
     """
     cdef GEOSContextHandle_t handle = cast_handle(lgeos.geos_handle)
-    cdef int m
+    cdef unsigned int m
     cdef GEOSCoordSequence *cs_t
     cdef double x, y, z
     cdef double x_t, y_t, z_t

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -52,7 +52,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if type(ob) == LineString:
             return <uintptr_t>GEOSGeom_clone_r(handle, g), n
         else:
-            cs = GEOSGeom_getCoordSeq_r(handle, g)
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, g)
             cs = GEOSCoordSeq_clone_r(handle, cs)
             return <uintptr_t>GEOSGeom_createLineString_r(handle, cs), n
 
@@ -93,7 +93,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Create a coordinate sequence
         if update_geom is not None:
-            cs = GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
             if n != update_ndim:
                 raise ValueError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
@@ -142,7 +142,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Create a coordinate sequence
         if update_geom is not None:
-            cs = GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
             if n != update_ndim:
                 raise ValueError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
@@ -195,7 +195,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         if type(ob) == LinearRing:
             return <uintptr_t>GEOSGeom_clone_r(handle, g), n
         else:
-            cs = GEOSGeom_getCoordSeq_r(handle, g)
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, g)
             GEOSCoordSeq_getSize_r(handle, cs, &m)
             if GEOSisClosed_r(handle, g) and m >= 4:
                 cs = GEOSCoordSeq_clone_r(handle, cs)
@@ -242,7 +242,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Create a coordinate sequence
         if update_geom is not None:
-            cs = GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
             if n != update_ndim:
                 raise ValueError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
@@ -301,7 +301,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
 
         # Create a coordinate sequence
         if update_geom is not None:
-            cs = GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
+            cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, cast_geom(update_geom))
             if n != update_ndim:
                 raise ValueError(
                 "Wrong coordinate dimensions; this geometry has dimensions: %d" \
@@ -472,7 +472,7 @@ cpdef affine_transform(geom, matrix):
     # Process coordinates from each supported geometry type
     if geom.type in ('Point', 'LineString', 'LinearRing'):
         the_geom = cast_geom(geom._geom)
-        cs = GEOSGeom_getCoordSeq_r(handle, the_geom)
+        cs = <GEOSCoordSequence*>GEOSGeom_getCoordSeq_r(handle, the_geom)
         
         # perform the transformation
         cs_t = transform(cs, ndim, a, b, c, d, e, f, g, h, i, xoff, yoff, zoff)


### PR DESCRIPTION
As https://github.com/Toblerity/Shapely/pull/276, but PR for the `maint` branch for inclusion with 1.5.9.

Original PR as follows:

This PR addresses three warnings currently being raised by the speedups module.

It implements the change from https://github.com/Toblerity/Shapely/pull/274 using `uintptr_t` instead of `unsigned long long`.

It fixes the warning below, by using the `unsigned int` type for the `m` dimension variable to `GEOSCoordSeq_getSize_r`.
```
shapely/speedups/_speedups.c:3210:58: warning: passing 'int *' to parameter of
      type 'unsigned int *' converts between pointers to integer types with
      different sign [-Wpointer-sign]
      GEOSCoordSeq_getSize_r(__pyx_v_handle, __pyx_v_cs, (&__pyx_v_m));
                                                         ^~~~~~~~~~~~
```

It also removes some of the other warnings being raised by the speedups module that look like this:
```
shapely/speedups/_speedups.c:1694:18: warning: assigning to
      'GEOSCoordSequence *' (aka 'struct GEOSCoordSeq_t *') from 'const
      GEOSCoordSequence *' (aka 'const struct GEOSCoordSeq_t *') discards
      qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
      __pyx_v_cs = GEOSGeom_getCoordSeq_r(__pyx_v_handle, __pyx_v_g);
                 ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I've done this by casting the calls to `GEOSGeom_getCoordSeq_r` to their non-const type (i.e. `GEOSCoordSequence*` instead of `const GEOSCoordSequence*`. I'm not sure if this is correct, but it makes the warnings go away.

There are still a lot of `unused function` warnings, but I think this is an issue with cython.