### PR TITLE
GEOSRelate_r exceptions handled gracefully. Fix for #294.

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -414,6 +414,12 @@ def errcheck_just_free(result, func, argtuple):
     else:
         return retval
 
+def errcheck_null_exception(result, func, argtuple):
+    '''Wraps errcheck_just_free, raising a TopologicalError if result is NULL'''
+    if not result:
+        raise TopologicalError("The operation '{}' could not be performed. \
+Likely cause is invalidity of the geometry.".format(func.__name__))
+    return errcheck_just_free(result, func, argtuple)
 
 def errcheck_predicate(result, func, argtuple):
     '''Result is 2 on exception, 1 on True, 0 on False'''
@@ -457,7 +463,7 @@ class LGEOS300(LGEOSBase):
         # Deprecated
         self.GEOSGeomToWKB_buf.errcheck = errcheck_wkb
         self.GEOSGeomToWKT.errcheck = errcheck_just_free
-        self.GEOSRelate.errcheck = errcheck_just_free
+        self.GEOSRelate.errcheck = errcheck_null_exception
         for pred in (
                 self.GEOSDisjoint,
                 self.GEOSTouches,
@@ -532,7 +538,7 @@ class LGEOS310(LGEOSBase):
         # Deprecated
         self.GEOSGeomToWKB_buf.func.errcheck = errcheck_wkb
         self.GEOSGeomToWKT.func.errcheck = errcheck_just_free
-        self.GEOSRelate.func.errcheck = errcheck_just_free
+        self.GEOSRelate.func.errcheck = errcheck_null_exception
         for pred in (
                 self.GEOSDisjoint,
                 self.GEOSTouches,

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -395,7 +395,7 @@ class WKBWriter(object):
 # Errcheck functions for ctypes
 
 def errcheck_wkb(result, func, argtuple):
-    '''Returns bytes from a C pointer'''
+    """Returns bytes from a C pointer"""
     if not result:
         return None
     size_ref = argtuple[-1]
@@ -406,7 +406,7 @@ def errcheck_wkb(result, func, argtuple):
 
 
 def errcheck_just_free(result, func, argtuple):
-    '''Returns string from a C pointer'''
+    """Returns string from a C pointer"""
     retval = string_at(result)
     lgeos.GEOSFree(result)
     if sys.version_info[0] >= 3:
@@ -415,14 +415,14 @@ def errcheck_just_free(result, func, argtuple):
         return retval
 
 def errcheck_null_exception(result, func, argtuple):
-    '''Wraps errcheck_just_free, raising a TopologicalError if result is NULL'''
+    """Wraps errcheck_just_free, raising a TopologicalError if result is NULL"""
     if not result:
-        raise TopologicalError("The operation '{0}' could not be performed. \
-Likely cause is invalidity of the geometry.".format(func.__name__))
+        raise TopologicalError("The operation '{0}' could not be performed."
+            "Likely cause is invalidity of the geometry.".format(func.__name__))
     return errcheck_just_free(result, func, argtuple)
 
 def errcheck_predicate(result, func, argtuple):
-    '''Result is 2 on exception, 1 on True, 0 on False'''
+    """Result is 2 on exception, 1 on True, 0 on False"""
     if result == 2:
         raise PredicateError("Failed to evaluate %s" % repr(func))
     return result

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -417,7 +417,7 @@ def errcheck_just_free(result, func, argtuple):
 def errcheck_null_exception(result, func, argtuple):
     '''Wraps errcheck_just_free, raising a TopologicalError if result is NULL'''
     if not result:
-        raise TopologicalError("The operation '{}' could not be performed. \
+        raise TopologicalError("The operation '{0}' could not be performed. \
 Likely cause is invalidity of the geometry.".format(func.__name__))
     return errcheck_just_free(result, func, argtuple)
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,7 +1,8 @@
 from . import unittest
+import pytest
 from shapely.geometry import Point, Polygon, MultiPoint, GeometryCollection
 from shapely.wkt import loads
-
+from shapely.geos import TopologicalError
 
 class OperationsTestCase(unittest.TestCase):
 
@@ -62,9 +63,15 @@ class OperationsTestCase(unittest.TestCase):
 
         self.assertIsInstance(point.centroid, Point)
 
+    def test_relate(self):
         # Relate
-        self.assertEqual(point.relate(Point(-1, -1)), 'FF0FFF0F2')
+        self.assertEqual(Point(0, 0).relate(Point(-1, -1)), 'FF0FFF0F2')
 
+        # issue #294: should raise TopologicalError on exception
+        invalid_polygon = loads('POLYGON ((40 100, 80 100, 80 60, 40 60, 40 100), (60 60, 80 60, 80 40, 60 40, 60 60))')
+        assert(not invalid_polygon.is_valid)
+        with pytest.raises(TopologicalError):
+            invalid_polygon.relate(invalid_polygon)
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(OperationsTestCase)


### PR DESCRIPTION
This PR addresses issue #294. `GEOSRelate_r` returns a NULL pointer on exception, which isn't currently caught by Shapely resulting in a segmentation fault when an attempt is made to access the result. A wrapper has been added around the existing errcheck function, which checks for this and raises a `TopologicalError` if needed.