### PR TITLE
Implemented GEOSRelatePattern as BaseGeometry.relate_pattern

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1235,6 +1235,37 @@ elements.
   >>> Point(0, 0).relate(LineString([(0, 0), (1, 1)]))
   'F0FFFF102'
 
+.. method:: object.relate_pattern(other, pattern)
+
+    Returns True if the DE-9IM string code for the relationship between the
+    geometries satisfies the pattern, otherwise False.
+
+The :meth:`relate_pattern` compares the DE-9IM code string for two geometries
+against a specified pattern. If the string matches the pattern then ``True`` is
+returned, otherwise ``False``. The pattern specified can be an exact match
+(``0``, ``1`` or ``2``), a boolean match (``T`` or ``F``), or a wildcard
+(``*``). For example, the pattern for the `within` predicate is ``T*****FF*``.
+
+.. code-block:: pycon
+
+  >> point = Point(0.5, 0.5)
+  >> square = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
+  >> square.relate_pattern(point, 'T*****FF*')
+  True
+  >> point.within(square)
+  True
+
+Note that the order or the geometries is significant, as demonstrated below.
+In this example the square contains the point, but the point does not contain
+the square.
+
+.. code-block:: pycon
+
+  >>> point.relate(square)
+  '0FFFFF212'
+  >>> square.relate(point)
+  '0F2FF1FF2'
+
 Further discussion of the DE-9IM matrix is beyond the scope of this manual. See
 [4]_ and http://pypi.python.org/pypi/de9im.
 

--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -298,11 +298,15 @@ def prototype(lgeos, geos_version):
     Dimensionally Extended 9 Intersection Model related
     '''
 
-    lgeos.GEOSRelatePattern.restype = c_char
-    lgeos.GEOSRelatePattern.argtypes = [c_void_p, c_void_p, c_char_p]
-
     lgeos.GEOSRelate.restype = allocated_c_char_p
     lgeos.GEOSRelate.argtypes = [c_void_p, c_void_p]
+
+    lgeos.GEOSRelatePattern.restype = c_byte
+    lgeos.GEOSRelatePattern.argtypes = [c_void_p, c_void_p, c_char_p]
+
+    if geos_version >= (3, 3, 0):
+        lgeos.GEOSRelatePatternMatch.restype = c_byte
+        lgeos.GEOSRelatePatternMatch.argtypes = [c_char_p, c_char_p]
 
     '''
     Prepared Geometry Binary predicates

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -672,6 +672,12 @@ class BaseGeometry(object):
         specified decimal place"""
         return self.equals_exact(other, 0.5 * 10**(-decimal))
 
+    def relate_pattern(self, other, pattern):
+        """Returns True if the DE-9IM string code for the relationship between
+        the geometries satisfies the pattern, else False"""
+        pattern = c_char_p(pattern.encode('ascii'))
+        return bool(self.impl['relate_pattern'](self, other, pattern))
+
     # Linear referencing
     # ------------------
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -468,6 +468,7 @@ class LGEOS300(LGEOSBase):
                 self.GEOSOverlaps,
                 self.GEOSEquals,
                 self.GEOSEqualsExact,
+                self.GEOSRelatePattern,
                 self.GEOSisEmpty,
                 self.GEOSisValid,
                 self.GEOSisSimple,
@@ -503,6 +504,7 @@ class LGEOS300(LGEOSBase):
         self.methods['symmetric_difference'] = self.GEOSSymDifference
         self.methods['union'] = self.GEOSUnion
         self.methods['intersection'] = self.GEOSIntersection
+        self.methods['relate_pattern'] = self.GEOSRelatePattern
         self.methods['simplify'] = self.GEOSSimplify
         self.methods['topology_preserve_simplify'] = \
             self.GEOSTopologyPreserveSimplify
@@ -553,6 +555,7 @@ class LGEOS310(LGEOSBase):
                 self.GEOSPreparedContainsProperly,
                 self.GEOSPreparedCovers,
                 self.GEOSPreparedIntersects,
+                self.GEOSRelatePattern,
                 self.GEOSisEmpty,
                 self.GEOSisValid,
                 self.GEOSisSimple,
@@ -601,6 +604,7 @@ class LGEOS310(LGEOSBase):
             self.GEOSPreparedContainsProperly
         self.methods['prepared_overlaps'] = self.GEOSPreparedOverlaps
         self.methods['prepared_covers'] = self.GEOSPreparedCovers
+        self.methods['relate_pattern'] = self.GEOSRelatePattern
         self.methods['simplify'] = self.GEOSSimplify
         self.methods['topology_preserve_simplify'] = \
             self.GEOSTopologyPreserveSimplify

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -108,6 +108,7 @@ IMPL300 = {
     'within': (BinaryPredicate, 'within'),
     'covers': (BinaryPredicate, 'covers'),
     'equals_exact': (BinaryPredicate, 'equals_exact'),
+    'relate_pattern': (BinaryPredicate, 'relate_pattern'),
 
     # First pure Python implementation
     'is_ccw': (cga.is_ccw_impl, 'is_ccw'),


### PR DESCRIPTION
This commit implements `GEOSRelatePattern` as `object.relate_pattern`, e.g.:

```
>>> g1 = Polygon([(0, 0), (0, 1), (3, 1), (3, 0), (0, 0)])
>>> g2 = Polygon([(1, -1), (1, 2), (2, 2), (2, -1), (1, -1)])
>>> g1.relate_pattern(g2, 'T********')
True
```

Needs documentation, although not too much more than is already provided for `object.relate`. http://toblerity.org/shapely/manual.html#de-9im-relationships