### PR TITLE
Allow tests to work with NumPy 1.4.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 setuptools
-Numpy>=1.8.0
+Numpy>=1.4.1
 Cython>=0.19
 descartes==1.0.1
 packaging

--- a/tests/test_vectorized.py
+++ b/tests/test_vectorized.py
@@ -54,18 +54,18 @@ class VectorizedContainsTestCase(unittest.TestCase):
 
     def test_y_array_order(self):
         y, x = np.mgrid[-10:10:5j, -5:15:5j]
-        y = y.copy(order='f')
+        y = y.copy('f')
         self.assertContainsResults(self.construct_torus(), x, y)
     
     def test_x_array_order(self):
         y, x = np.mgrid[-10:10:5j, -5:15:5j]
-        x = x.copy(order='f')
+        x = x.copy('f')
         self.assertContainsResults(self.construct_torus(), x, y)
     
     def test_xy_array_order(self):
         y, x = np.mgrid[-10:10:5j, -5:15:5j]
-        x = x.copy(order='f')
-        y = y.copy(order='f')
+        x = x.copy('f')
+        y = y.copy('f')
         result = self.assertContainsResults(self.construct_torus(), x, y)
         # We always return a C_CONTIGUOUS array.
         self.assertTrue(result.flags['C_CONTIGUOUS'])


### PR DESCRIPTION
I regularly use a CentOS 6 server with NumPy 1.4.1 (released 22 Apr 2010), which is [the current version](http://mirror.centos.org/centos/6/os/x86_64/Packages/). This PR drops the minimum-supported NumPy version and has a few modifications to enable py.test to pass with speedups enabled.

Here is the specific rational for the changes:
 * The `copy` keyword for `astype()` was introduced in 1.7.0 (e.g. see [ndarray.astype(t)](http://docs.scipy.org/doc/numpy-1.6.0/reference/generated/numpy.ndarray.astype.html#numpy.ndarray.astype) from Numpy 1.6.0)
 * Before 1.6.0, `copy()` only supported positional arguments, and `order='f'` would raise "TypeError: copy() takes no keyword arguments"; see [bug #2178](https://github.com/numpy/numpy/issues/2178)
 * The modification to the cdef bool result array is for "ValueError: unknown dtype code in numpy.pxd (0)", which is a fix [similar to this one on SO](http://stackoverflow.com/a/29431979/327026). The issue could be similar to [pandas #57](https://github.com/pydata/pandas/issues/57) fixed by Numpy 1.5.1.