### PR TITLE
Make geometries unhashable

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -270,7 +270,7 @@ class BaseGeometry(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    __hash__ = object.__hash__
+    __hash__ = None
 
     # Array and ctypes interfaces
     # ---------------------------
@@ -773,7 +773,7 @@ class BaseMultipartGeometry(BaseGeometry):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    __hash__ = object.__hash__
+    __hash__ = None
 
     def svg(self, scale_factor=1., color=None):
         """Returns a group of SVG elements for the multipart geometry.

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -264,7 +264,7 @@ class Polygon(BaseGeometry):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    __hash__ = object.__hash__
+    __hash__ = None
 
     @property
     def ctypes(self):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -3,19 +3,35 @@ from shapely.geometry import Point, MultiPoint, Polygon, GeometryCollection
 
 def test_point():
     g = Point(0, 0)
-    assert hash(g)
+    try:
+        assert hash(g)
+        return False
+    except TypeError:
+        return True
 
 
 def test_multipoint():
     g = MultiPoint([(0, 0)])
-    assert hash(g)
+    try:
+        assert hash(g)
+        return False
+    except TypeError:
+        return True
 
 
 def test_polygon():
     g = Point(0, 0).buffer(1.0)
-    assert hash(g)
+    try:
+        assert hash(g)
+        return False
+    except TypeError:
+        return True
 
 
 def test_collection():
     g = GeometryCollection([Point(0, 0)])
-    assert hash(g)
+    try:
+        assert hash(g)
+        return False
+    except TypeError:
+        return True


### PR DESCRIPTION
Shapely's geometries are mutable, but we're providing a hash function. These two features are inconsistent. Rather than remove mutability (for now) we'll remove the hashability.

See #209