### PR TITLE
the os package has no __file__ attribute when frozen using cx_freeze.

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -131,7 +131,7 @@ elif sys.platform == 'win32':
     try:
         egg_dlls = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                    "DLLs"))
-        wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
+        wininst_dlls = os.path.normpath(os.path.abspath(sys.executable+'../../DLLS'))
         original_path = os.environ['PATH']
         os.environ['PATH'] = "%s;%s;%s" % \
             (egg_dlls, wininst_dlls, original_path)


### PR DESCRIPTION
When you try to freeze shapely, an exception is thrown because this particular piece of code doesnt' work when frozen.  I've tested this on a windows machine in both the frozen and unfrozen versions, and it seems to work.