### PR TITLE
Filter empty geometries in STRtree to avoid segfaults. Fixes #345.

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -31,6 +31,8 @@ class STRtree:
     """
 
     def __init__(self, geoms):
+        # filter empty geometries out of the input
+        geoms = [geom for geom in geoms if not geom.is_empty]
         self._n_geoms = len(geoms)
         # GEOS STRtree capacity has to be > 1
         self._tree_handle = lgeos.GEOSSTRtree_create(max(2, len(geoms)))

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -1,7 +1,7 @@
 from . import unittest
 
 from shapely.strtree import STRtree
-from shapely.geometry import Point
+from shapely.geometry import Point, Polygon
 from shapely.geos import geos_version
 
 
@@ -14,6 +14,33 @@ class STRTestCase(unittest.TestCase):
         self.assertEqual(len(results), 1)
         results = tree.query(Point(2,2).buffer(1.0))
         self.assertEqual(len(results), 3)
+
+    def test_insert_empty_geometry(self):
+        """
+        Passing nothing but empty geometries results in an empty strtree.
+        The query segfaults if the empty geometry was actually inserted.
+        """
+        empty = Polygon()
+        geoms = [empty]
+        tree = STRtree(geoms)
+        assert(tree._n_geoms == 0)
+        query = Polygon([(0,0),(1,1),(2,0),(0,0)])
+        results = tree.query(query)
+
+    def test_query_empty_geometry(self):
+        """
+        Empty geometries should be filtered out.
+        The query segfaults if the empty geometry was actually inserted.
+        """
+        empty = Polygon()
+        point = Point(1, 0.5)
+        geoms = [empty, point]
+        tree = STRtree(geoms)
+        assert(tree._n_geoms == 1)
+        query = Polygon([(0,0),(1,1),(2,0),(0,0)])
+        results = tree.query(query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0], point)
 
 
 def test_suite():


### PR DESCRIPTION
This PR fixes the issue with empty geometries and STRtree in #345.

I think I've done the right thing aiming this at the maint-1.5 branch but correct me if I've done it wrong?