### PR TITLE
Improvements to handling of empty geometries

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -165,7 +165,13 @@ class JOIN_STYLE(object):
     mitre = 2
     bevel = 3
 
-EMPTY = deserialize_wkb(a2b_hex(b'010700000000000000'))
+EMPTY_LINESTRING = deserialize_wkb(a2b_hex(b'010200000000000000'))
+EMPTY_POLYGON = deserialize_wkb(a2b_hex(b'010300000000000000'))
+EMPTY_MULTIPOINT = deserialize_wkb(a2b_hex(b'010400000000000000'))
+EMPTY_MULTILINESTRING = deserialize_wkb(a2b_hex(b'010500000000000000'))
+EMPTY_MULTIPOLYGON = deserialize_wkb(a2b_hex(b'010600000000000000'))
+EMPTY_GEOMETRYCOLLECTION = deserialize_wkb(a2b_hex(b'010700000000000000'))
+EMPTY = EMPTY_GEOMETRYCOLLECTION
 
 
 class BaseGeometry(object):

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -11,7 +11,7 @@ from ctypes import c_double, cast, POINTER
 from shapely.coords import required
 from shapely.geos import lgeos, TopologicalError
 from shapely.geometry.base import (
-    BaseGeometry, geom_factory, JOIN_STYLE, geos_geom_from_py
+    BaseGeometry, geom_factory, JOIN_STYLE, geos_geom_from_py, EMPTY_LINESTRING
 )
 from shapely.geometry.proxy import CachingGeometryProxy
 from shapely.geometry.point import Point
@@ -47,6 +47,8 @@ class LineString(BaseGeometry):
         BaseGeometry.__init__(self)
         if coordinates is not None:
             self._set_coords(coordinates)
+        else:
+            self.__geom__ = EMPTY_LINESTRING
 
     @property
     def __geo_interface__(self):

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -9,7 +9,8 @@ if sys.version_info[0] < 3:
 from ctypes import c_double, c_void_p, cast, POINTER
 
 from shapely.geos import lgeos
-from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
+from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py, \
+                                  EMPTY_MULTILINESTRING
 from shapely.geometry import linestring
 from shapely.geometry.proxy import CachingGeometryProxy
 
@@ -47,7 +48,7 @@ class MultiLineString(BaseMultipartGeometry):
 
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling
-            pass
+            self.__geom__ = EMPTY_MULTILINESTRING
         else:
             self._geom, self._ndim = geos_multilinestring_from_py(lines)
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -12,7 +12,7 @@ from ctypes import ArgumentError
 from shapely.coords import required
 from shapely.geos import lgeos
 from shapely.geometry.base import (
-    BaseMultipartGeometry, exceptNull, geos_geom_from_py
+    BaseMultipartGeometry, exceptNull, geos_geom_from_py, EMPTY_MULTIPOINT
 )
 from shapely.geometry import point
 from shapely.geometry.proxy import CachingGeometryProxy
@@ -55,7 +55,7 @@ class MultiPoint(BaseMultipartGeometry):
 
         if points is None or len(points) == 0:
             # allow creation of empty multipoints, to support unpickling
-            pass
+            self.__geom__ = EMPTY_MULTIPOINT
         else:
             self._geom, self._ndim = geos_multipoint_from_py(points)
 

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -9,7 +9,8 @@ if sys.version_info[0] < 3:
 from ctypes import c_void_p, cast
 
 from shapely.geos import lgeos
-from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
+from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py, \
+                                  EMPTY_MULTIPOLYGON
 from shapely.geometry import polygon
 from shapely.geometry.proxy import CachingGeometryProxy
 
@@ -57,7 +58,7 @@ class MultiPolygon(BaseMultipartGeometry):
 
         if not polygons:
             # allow creation of empty multipolygons, to support unpickling
-            pass
+            self.__geom__ = EMPTY_MULTIPOLYGON
         elif context_type == 'polygons':
             self._geom, self._ndim = geos_multipolygon_from_polygons(polygons)
         elif context_type == 'geojson':

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -6,7 +6,8 @@ from ctypes import cast, POINTER
 
 from shapely.coords import required
 from shapely.geos import lgeos, DimensionError
-from shapely.geometry.base import BaseGeometry, geos_geom_from_py
+from shapely.geometry.base import BaseGeometry, geos_geom_from_py, \
+                                  EMPTY_MULTIPOINT
 from shapely.geometry.proxy import CachingGeometryProxy
 
 __all__ = ['Point', 'asPoint']
@@ -47,6 +48,9 @@ class Point(BaseGeometry):
         BaseGeometry.__init__(self)
         if len(args) > 0:
             self._set_coords(*args)
+        else:
+            # avoid issue with WKB and 'POINT EMPTY'
+            self.__geom__ = EMPTY_MULTIPOINT
 
     # Coordinate getters and setters
 

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -50,7 +50,7 @@ class LineStringTestCase(unittest.TestCase):
 
         # Test Non-operability of Null geometry
         l_null = LineString()
-        self.assertEqual(l_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
+        self.assertEqual(l_null.wkt, 'LINESTRING EMPTY')
         self.assertEqual(l_null.length, 0.0)
 
         # Check that we can set coordinates of a null geometry

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,5 +18,24 @@ class TwoDeeTestCase(unittest.TestCase):
         self.assertEqual(t._ndim, 2)
 
 
+GEOMETRY_TYPES = [
+    geometry.Point,
+    geometry.LineString,
+    geometry.Polygon,
+    geometry.LinearRing,
+    geometry.MultiPoint,
+    geometry.MultiLineString,
+    geometry.MultiPolygon,
+    geometry.GeometryCollection,
+]
+class RoundTripTestCase(unittest.TestCase):
+    def test_roundtrip_empty(self):
+        for GEOMETRY_TYPE in GEOMETRY_TYPES:
+            geom = GEOMETRY_TYPE()
+            data = dumps(geom)
+            result = loads(data)
+            self.assertEqual(geom.wkt, result.wkt)
+            self.assertEqual(geom, result)
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TwoDeeTestCase)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -70,7 +70,7 @@ class LineStringTestCase(unittest.TestCase):
 
         # Test Non-operability of Null geometry
         p_null = Point()
-        self.assertEqual(p_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
+        self.assertEqual(p_null.wkt, 'MULTIPOINT EMPTY')
         self.assertEqual(p_null.coords[:], [])
         self.assertEqual(p_null.area, 0.0)
 

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -103,7 +103,7 @@ class PolygonTestCase(unittest.TestCase):
 
         # Test Non-operability of Null rings
         r_null = LinearRing()
-        self.assertEqual(r_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
+        self.assertEqual(r_null.wkt, 'LINESTRING EMPTY')
         self.assertEqual(r_null.length, 0.0)
 
         # Check that we can set coordinates of a null geometry
@@ -209,6 +209,22 @@ class PolygonTestCase(unittest.TestCase):
         # Test multiple operators, boundary of a buffer
         ec = list(p.buffer(1).boundary.coords)
         self.assertIsInstance(ec, list)  # TODO: this is a poor test
+
+    def test_empty_equality(self):
+        # Test equals operator, including empty geometries
+        # see issue #338
+        
+        point1 = Point(0, 0)
+        polygon1 = Polygon(((0.0, 0.0), (0.0, 1.0), (-1.0, 1.0), (-1.0, 0.0)))
+        polygon2 = Polygon(((0.0, 0.0), (0.0, 1.0), (-1.0, 1.0), (-1.0, 0.0)))
+        polygon_empty1 = Polygon()
+        polygon_empty2 = Polygon()
+        
+        self.assertNotEqual(point1, polygon1)
+        self.assertEqual(polygon_empty1, polygon_empty2)
+        self.assertNotEqual(polygon1, polygon_empty1)
+        self.assertEqual(polygon1, polygon2)
+        self.assertNotEqual(None, polygon_empty1)
 
 
 def test_suite():


### PR DESCRIPTION
*For discussion - see #338*.

This PR moves to different representations of empty geometries in WKT/WKB, and also includes a fix for comparison of empty Polygon geometries. The tests include checking roundtrip of all geometries with the `pickle` module (which is currently broken - see #338), and tests for the empty Polygon comparison issue.