### PR TITLE
Fix for equals comparison with empty polygons

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -251,6 +251,11 @@ class Polygon(BaseGeometry):
     def __eq__(self, other):
         if not isinstance(other, Polygon):
             return False
+        check_empty = (self.is_empty, other.is_empty)
+        if all(check_empty):
+            return True
+        elif any(check_empty):
+            return False
         my_coords = [
             tuple(self.exterior.coords),
             [tuple(interior.coords) for interior in self.interiors]

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -210,6 +210,21 @@ class PolygonTestCase(unittest.TestCase):
         ec = list(p.buffer(1).boundary.coords)
         self.assertIsInstance(ec, list)  # TODO: this is a poor test
 
+    def test_empty_equality(self):
+        # Test equals operator, including empty geometries
+        # see issue #338
+
+        point1 = Point(0, 0)
+        polygon1 = Polygon(((0.0, 0.0), (0.0, 1.0), (-1.0, 1.0), (-1.0, 0.0)))
+        polygon2 = Polygon(((0.0, 0.0), (0.0, 1.0), (-1.0, 1.0), (-1.0, 0.0)))
+        polygon_empty1 = Polygon()
+        polygon_empty2 = Polygon()
+
+        self.assertNotEqual(point1, polygon1)
+        self.assertEqual(polygon_empty1, polygon_empty2)
+        self.assertNotEqual(polygon1, polygon_empty1)
+        self.assertEqual(polygon1, polygon2)
+        self.assertNotEqual(None, polygon_empty1)
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(PolygonTestCase)


### PR DESCRIPTION
This PR fixes a bug triggered when comparing the equality of empty Polygons. The accompanying test illustrates the issue. The problem is that an empty polygon doesn't have any coordinates, so `self.exterior.coords` in the existing algorithm falls over.