### PR TITLE
Add minimum_rotated_rectangle function.

### DIFF
--- a/tests/test_minimum_rotated_rectangle.py
+++ b/tests/test_minimum_rotated_rectangle.py
@@ -1,0 +1,33 @@
+from . import unittest
+from shapely import geometry
+
+class MinimumRotatedRectangleTestCase(unittest.TestCase):
+    
+    def test_minimum_rectangle(self):
+        poly = geometry.Polygon([(0,1), (1, 2), (2, 1), (1, 0), (0, 1)])
+        rect = poly.minimum_rotated_rectangle
+        self.assertIsInstance(rect, geometry.Polygon)
+        self.assertEqual(rect.area - poly.area < 0.1, True)
+        self.assertEqual(len(rect.exterior.coords), 5)
+        
+        ls = geometry.LineString([(0,1), (1, 2), (2, 1), (1, 0)])
+        rect = ls.minimum_rotated_rectangle
+        self.assertIsInstance(rect, geometry.Polygon)
+        self.assertIsInstance(rect, geometry.Polygon)
+        self.assertEqual(rect.area - ls.convex_hull.area < 0.1, True)
+        self.assertEqual(len(rect.exterior.coords), 5)
+
+    def test_digenerate(self):
+        rect = geometry.Point((0,1)).minimum_rotated_rectangle
+        self.assertIsInstance(rect, geometry.Point)
+        self.assertEqual(len(rect.coords), 1)
+        self.assertEqual(rect.coords[0], (0,1))
+
+        rect = geometry.LineString([(0,0),(2,2)]).minimum_rotated_rectangle
+        self.assertIsInstance(rect, geometry.LineString)
+        self.assertEqual(len(rect.coords), 2)
+        self.assertEqual(rect.coords[0], (0,0))
+        self.assertEqual(rect.coords[1], (2,2))
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(MinimumRotatedRectangleTestCase)


### PR DESCRIPTION
I tried adding the functionality requested in #354  to enhance the base geometry object. 
This function enables the computation of a minimum bounding rectangle that is not constrained to be parallel to the axes but can be rotated.
The solution is based on the algorithm proposed in this [link](http://gis.stackexchange.com/questions/22895/how-to-find-the-minimum-area-rectangle-for-given-points/22934#22934) that was provided by @snorfalorpagus