### PR TITLE
Implemented GEOSHausdorffDistance

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -207,6 +207,23 @@ General Attributes and Methods
   >>> Point(0,0).distance(Point(1,1))
   1.4142135623730951
 
+.. method:: object.hausdorff_distance(other)
+
+  Returns the Hausdorff distance (``float``) to the `other` geometric object.
+  The Hausdorff distance is the furthest distance from any point on the first
+  geometry to any point on the second geometry.
+
+  `New in Shapely 1.6.0`
+
+.. code-block:: pycon
+
+  >>> point = Point(1, 1)
+  >>> line = LineString([(2, 0), (2, 4), (3, 4)])
+  >>> point.hausdorff_distance(line)
+  3.605551275463989
+  >>> point.distance(Point(3, 4))
+  3.605551275463989
+
 .. method:: object.representative_point()
 
   Returns a cheaply computed point that is guaranteed to be within the

--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -402,6 +402,10 @@ def prototype(lgeos, geos_version):
     lgeos.GEOSDistance.restype = c_int
     lgeos.GEOSDistance.argtypes = [c_void_p, c_void_p, c_void_p]
 
+    if geos_version >= (3, 2, 0):
+        lgeos.GEOSHausdorffDistance.restype = c_int
+        lgeos.GEOSHausdorffDistance.argtypes = [c_void_p, c_void_p, c_void_p]
+
     '''
     Reader and Writer APIs
     '''

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -424,6 +424,10 @@ class BaseGeometry(object):
         """Unitless distance to other geometry (float)"""
         return self.impl['distance'](self, other)
 
+    def hausdorff_distance(self, other):
+        """Unitless hausdorff distance to other geometry (float)"""
+        return self.impl['hausdorff_distance'](self, other)
+
     @property
     def length(self):
         """Unitless length of the geometry (float)"""

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -651,6 +651,7 @@ class LGEOS320(LGEOS311):
         self.methods['interpolate_normalized'] = \
             self.GEOSInterpolateNormalized
         self.methods['buffer_with_style'] = self.GEOSBufferWithStyle
+        self.methods['hausdorff_distance'] = self.GEOSHausdorffDistance
 
 
 class LGEOS330(LGEOS320):

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -140,6 +140,7 @@ IMPL320 = {
     'interpolate_normalized': (InterpolateOp, 'interpolate_normalized'),
     'interpolate': (InterpolateOp, 'interpolate'),
     'buffer_with_style': (UnaryTopologicalOp, 'buffer_with_style'),
+    'hausdorff_distance': (BinaryRealProperty, 'hausdorff_distance'),
     }
 
 IMPL330 = {

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,8 +1,9 @@
 from . import unittest
 import pytest
-from shapely.geometry import Point, Polygon, MultiPoint, GeometryCollection
+from shapely.geometry import Point, LineString, Polygon, MultiPoint, \
+                             GeometryCollection
 from shapely.wkt import loads
-from shapely.geos import TopologicalError
+from shapely.geos import TopologicalError, geos_version
 
 class OperationsTestCase(unittest.TestCase):
 
@@ -72,6 +73,14 @@ class OperationsTestCase(unittest.TestCase):
         assert(not invalid_polygon.is_valid)
         with pytest.raises(TopologicalError):
             invalid_polygon.relate(invalid_polygon)
+
+    @unittest.skipIf(geos_version < (3, 2, 0), 'GEOS 3.2.0 required')
+    def test_hausdorff_distance(self):
+        point = Point(1, 1)
+        line = LineString([(2, 0), (2, 4), (3, 4)])
+
+        distance = point.hausdorff_distance(line)
+        self.assertEqual(distance, point.distance(Point(3, 4)))
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(OperationsTestCase)


### PR DESCRIPTION
This PR implements GEOHausdorffDistance. In simple terms the hausdorff distance is the furthest distance between any point on one geometry to any point on another.

https://en.wikipedia.org/wiki/Hausdorff_distance

Available in GEOS 3.2.x.