### PR TITLE
Add docs for minimum_rotated_rectangle

### DIFF
--- a/docs/code/minimum_rotated_rectangle.py
+++ b/docs/code/minimum_rotated_rectangle.py
@@ -1,0 +1,49 @@
+from shapely.geometry import MultiPoint, Polygon, LineString
+import matplotlib.pyplot as plt
+from descartes.patch import PolygonPatch
+
+from figures import SIZE
+
+fig = plt.figure(1, figsize=SIZE, dpi=90)
+fig.set_frameon(True)
+
+# 1
+ax = fig.add_subplot(121)
+
+mp = MultiPoint([(0, 0), (0.5, 1.5), (1, 0.5), (0.5, 0.5)])
+rect = mp.minimum_rotated_rectangle
+
+for p in mp:
+	ax.plot(p.x, p.y, 'o', color='#999999')
+patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
+ax.add_patch(patch)
+ax.set_title('a) MultiPoint')
+
+xr = [-1, 2]
+yr = [-1, 2]
+ax.set_xlim(*xr)
+ax.set_xticks(range(*xr) + [xr[-1]])
+ax.set_ylim(*yr)
+ax.set_yticks(range(*yr) + [yr[-1]])
+ax.set_aspect(1)
+
+# 2
+ax = fig.add_subplot(122)
+ls = LineString([(-0.5, 1.2), (0.5, 0), (1, 1), (1.5, 0), (1.5, 0.5)])
+rect = ls.minimum_rotated_rectangle
+
+ax.plot(*ls.xy, color='#333333', linewidth=3, alpha=0.5, zorder=2)
+patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
+ax.add_patch(patch)
+
+xr = [-1, 2]
+yr = [-1, 2]
+ax.set_xlim(*xr)
+ax.set_xticks(range(*xr) + [xr[-1]])
+ax.set_ylim(*yr)
+ax.set_yticks(range(*yr) + [yr[-1]])
+ax.set_aspect(1)
+
+ax.set_title('b) LineString')
+
+plt.show()

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1576,6 +1576,22 @@ Figure 10. Convex hull (blue) of 2 points (left) and of 6 points (right).
   >>> MultiPoint([(0, 0), (1, 1)]).envelope
   <shapely.geometry.polygon.Polygon object at 0x...>
 
+.. attribute:: object.minimum_rotated_rectangle 
+  
+  Returns the general minimum bounding rectangle that contains the object. 
+  Unlike envelope this rectangle is not constrained to be parallel to the 
+  coordinate axes. If the convex hull of the object is a degenerate (line or point) 
+  this degenerate is returned.
+
+  `New in Shapely 1.6.0`
+
+.. code-block:: pycon
+  
+  >>> Point(0, 0).minimum_rotated_rectangle
+  <shapely.geometry.point.Point object at 0x7f5cc62b1828>
+  >>> MultiPoint([(0,0),(1,1),(2,0.5)]).minimum_rotated_rectangle
+  <shapely.geometry.polygon.Polygon object at 0x7f5cc11f9dd8>
+
 .. method:: object.parallel_offset(distance, side, resolution=16, join_style=1, mitre_limit=5.0)
 
   Returns a LineString or MultiLineString geometry at a distance from the

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1576,7 +1576,7 @@ Figure 10. Convex hull (blue) of 2 points (left) and of 6 points (right).
   >>> MultiPoint([(0, 0), (1, 1)]).envelope
   <shapely.geometry.polygon.Polygon object at 0x...>
 
-.. attribute:: object.minimum_rotated_rectangle 
+.. attribute:: object.minimum_rotated_rectangle
   
   Returns the general minimum bounding rectangle that contains the object. 
   Unlike envelope this rectangle is not constrained to be parallel to the 
@@ -1588,9 +1588,14 @@ Figure 10. Convex hull (blue) of 2 points (left) and of 6 points (right).
 .. code-block:: pycon
   
   >>> Point(0, 0).minimum_rotated_rectangle
-  <shapely.geometry.point.Point object at 0x7f5cc62b1828>
+  <shapely.geometry.point.Point object at 0x...>
   >>> MultiPoint([(0,0),(1,1),(2,0.5)]).minimum_rotated_rectangle
-  <shapely.geometry.polygon.Polygon object at 0x7f5cc11f9dd8>
+  <shapely.geometry.polygon.Polygon object at 0x...>
+
+.. plot:: code/minimum_rotated_rectangle.py
+
+Figure 11. Minimum rotated rectangle for a multipoint feature (left) and a 
+linestring feature (right).
 
 .. method:: object.parallel_offset(distance, side, resolution=16, join_style=1, mitre_limit=5.0)
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1621,7 +1621,7 @@ linestring feature (right).
 
 .. plot:: code/parallel_offset.py
 
-Figure 11. Three styles of parallel offset lines on the left side of a simple
+Figure 12. Three styles of parallel offset lines on the left side of a simple
 line string (its starting point shown as a circle) and one offset on the right
 side, a multipart.
 
@@ -1629,7 +1629,7 @@ The effect of the `mitre_limit` parameter is shown below.
 
 .. plot:: code/parallel_offset_mitre.py
 
-Figure 12. Large and small mitre_limit values for left and right offsets.
+Figure 13. Large and small mitre_limit values for left and right offsets.
 
 .. method:: object.simplify(tolerance, preserve_topology=True)
 
@@ -1656,7 +1656,7 @@ Douglas-Peucker algorithm [6]_ is used.
 
 .. plot:: code/simplify.py
 
-Figure 13. Simplification of a nearly circular polygon using a tolerance of 0.2
+Figure 14. Simplification of a nearly circular polygon using a tolerance of 0.2
 (left) and 0.5 (right).
 
 .. note::
@@ -1764,7 +1764,7 @@ preserved or supported by 3D affine transformations.
 
   .. plot:: code/rotate.py
 
-  Figure 14. Rotation of a `LineString` (gray) by an angle of 90°
+  Figure 15. Rotation of a `LineString` (gray) by an angle of 90°
   counter-clockwise (blue) using different origins.
 
 .. function:: shapely.affinity.scale(geom, xfact=1.0, yfact=1.0, zfact=1.0, origin='center')
@@ -1806,7 +1806,7 @@ preserved or supported by 3D affine transformations.
 
   .. plot:: code/scale.py
 
-  Figure 15. Scaling of a gray triangle to blue result: a) by a factor of 1.5
+  Figure 16. Scaling of a gray triangle to blue result: a) by a factor of 1.5
   along x-direction, with reflection across y-axis; b) by a factor of 2 along
   x-direction with custom origin at (1, 1).
 
@@ -1838,7 +1838,7 @@ preserved or supported by 3D affine transformations.
 
   .. plot:: code/skew.py
 
-  Figure 16. Skewing of a gray "R" to blue result: a) by a shear angle of 20°
+  Figure 17. Skewing of a gray "R" to blue result: a) by a shear angle of 20°
   along the x-direction and an origin at (1, 1); b) by a shear angle of 30°
   along the y-direction, using default origin.
 


### PR DESCRIPTION
Added documentation for geometry.minimum_rotated_rectangle in the manual, as requested in issue #364. I tried adding a figure too.