### PR TITLE
PyInstaller's OS X-specific bug fix

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -86,6 +86,8 @@ elif sys.platform == 'darwin':
                 # binary from pyinstaller
                 alt_paths = [
                     os.path.join(sys.executable, 'libgeos_c.dylib')]
+                if hasattr(sys, '_MEIPASS'):
+                    alt_paths.append(os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))
         else:
             alt_paths = [
                 # The Framework build from Kyng Chaos


### PR DESCRIPTION
PyInstaller's OSX-specific bug fix that add an additional fallback path to geos_c library using _MEIPASS related to https://github.com/HDFGroup/hdf-compass/issues/79