### PR TITLE
Raise PicklingError when attempting to pickle a prepared geometry.

### DIFF
--- a/shapely/prepared.py
+++ b/shapely/prepared.py
@@ -4,6 +4,7 @@ Support for GEOS prepared geometry operations.
 
 from shapely.geos import lgeos
 from shapely.impl import DefaultImplementation, delegated
+from pickle import PicklingError
 
 
 class PreparedGeometry(object):
@@ -82,6 +83,9 @@ class PreparedGeometry(object):
     def within(self, other):
         """Returns True if geometry is within the other, else False"""
         return bool(self.impl['prepared_within'](self, other))
+
+    def __reduce__(self):
+        raise PicklingError("Prepared geometries cannot be pickled.")
 
 def prep(ob):
     """Creates and returns a prepared geometric object."""


### PR DESCRIPTION
It's not possible to pickle a prepared geometry. It doesn't look like there is any way to get the original representation of the geometry from the prepared one from GEOS, so I think it's better to explicitly forbid pickling. The following code demonstrates the issue, causing a segmentation fault when the unpickled instance tries to access the GEOS geometry that has been destroyed.

```
from shapely.geometry import Point
from shapely.prepared import prep
import pickle
p1 = Point(1,2)
p2 = prep(p1)
data = pickle.dumps(p2)
del(p2)
p3 = pickle.loads(data)
p3.intersects(p1)  # segmentation fault
```

(Why you'd want to pickle a prepared geometry I don't know, but better safe than sorry?)