### PR TITLE
Build manylinux1 wheels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# The wheel-building image only depends on requirements-dev.txt. Ignore all
+# other files.
+*
+.*
+!requirements-dev.txt

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/modules.txt
 .idea/
 *.pyd
 *.pdb
+wheels/

--- a/Dockerfile.wheels
+++ b/Dockerfile.wheels
@@ -1,0 +1,23 @@
+FROM quay.io/pypa/manylinux1_x86_64
+
+ENV GEOS_VERSION 3.5.0
+
+# Install geos
+RUN mkdir -p /src \
+    && cd /src \
+    && curl -f -L -O http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 \
+    && tar jxf geos-$GEOS_VERSION.tar.bz2 \
+    && cd /src/geos-$GEOS_VERSION \
+    && ./configure \
+    && make \
+    && make install \
+    && rm -rf /src
+
+# Bake dev requirements into the Docker image for faster builds
+ADD requirements-dev.txt /tmp/requirements-dev.txt
+RUN for PYBIN in /opt/python/*/bin; do \
+        $PYBIN/pip install -r /tmp/requirements-dev.txt ; \
+    done
+
+WORKDIR /io
+CMD ["/io/build-linux-wheels.sh"]

--- a/build-linux-wheels.sh
+++ b/build-linux-wheels.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu
+
+# Checking for /.dockerenv is a hacky way to determine whether or not we're
+# already running in a Docker container. Note that this is not guaranteed to
+# exist in all versions and drivers and may need to be changed later.
+if [ ! -e /.dockerenv ]; then
+    docker build -f Dockerfile.wheels --pull -t shapely-wheelbuilder .
+    exec docker run -v `pwd`:/io shapely-wheelbuilder "$@"
+fi
+
+ORIGINAL_PATH=$PATH
+UNREPAIRED_WHEELS=/tmp/wheels
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    PATH=${PYBIN}:$ORIGINAL_PATH
+    python setup.py bdist_wheel -d ${UNREPAIRED_WHEELS}
+done
+
+# Bundle GEOS into the wheels
+for whl in ${UNREPAIRED_WHEELS}/*.whl; do
+    auditwheel repair ${whl} -w wheels
+done


### PR DESCRIPTION
This patch uses Docker and [auditwheel][] to build [manylinux1][] wheels for Python 2.6/3.3+. These wheels bundle GEOS into the wheel, similar to the OS X wheels, so Shapely can be `pip install`d on most Linuxes without GEOS or even a compiler.

All of the wheels are built with one step: `./build-linux-wheels.sh`.  This will build a Docker image based on the official manylinux images containing GEOS and will build all of the wheels and output them in `wheels/`. Note that this only builds x86_64 wheels, but it could be easily extended to building i686 wheels using the quay.io/pypa/manylinux1_i686 Docker image.

[auditwheel]: https://github.com/pypa/auditwheel
[manylinux1]: https://github.com/pypa/manylinux