### PR TITLE
Polygon.from_bounds()

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -333,6 +333,15 @@ class Polygon(BaseGeometry):
             'stroke-width="{0}" opacity="0.6" d="{1}" />'
             ).format(2. * scale_factor, path, fill_color)
 
+    @classmethod
+    def from_bounds(cls, xmin, ymin, xmax, ymax):
+        """Construct a `Polygon()` from spatial bounds."""
+        return cls([
+            (xmin, ymin),
+            (xmin, ymax),
+            (xmax, ymax),
+            (xmax, ymin)])
+
 
 class PolygonAdapter(PolygonProxy, Polygon):
 

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -226,5 +226,17 @@ class PolygonTestCase(unittest.TestCase):
         self.assertEqual(polygon1, polygon2)
         self.assertNotEqual(None, polygon_empty1)
 
+    def test_from_bounds(self):
+        xmin, ymin, xmax, ymax = -180, -90, 180, 90
+        coords = [
+            (xmin, ymin),
+            (xmin, ymax),
+            (xmax, ymax),
+            (xmax, ymin)]
+        self.assertEqual(
+            Polygon(coords),
+            Polygon.from_bounds(xmin, ymin, xmax, ymax))
+
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(PolygonTestCase)


### PR DESCRIPTION
Ready for review.

To support patterns like:

```python
import fiona
from shapely.geometry import Polygon

with fiona.open('input.shp') as src:
    bounds = Polygon.from_bounds(*src.bounds)
```