### PR TITLE
Polygon.from_bounds() accepts a tuple rather than 4 positional arguments

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -334,8 +334,19 @@ class Polygon(BaseGeometry):
             ).format(2. * scale_factor, path, fill_color)
 
     @classmethod
-    def from_bounds(cls, xmin, ymin, xmax, ymax):
-        """Construct a `Polygon()` from spatial bounds."""
+    def from_bounds(cls, bounds):
+        """Construct a ``Polygon()`` from spatial bounds.
+
+        Parameters
+        ----------
+        bounds : tuple
+            Spatial extent like ``(xmin, ymin, xmax, ymax)``.
+
+        Returns
+        -------
+        Polygon
+        """
+        xmin, ymin, xmax, ymax = bounds
         return cls([
             (xmin, ymin),
             (xmin, ymax),

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -227,7 +227,8 @@ class PolygonTestCase(unittest.TestCase):
         self.assertNotEqual(None, polygon_empty1)
 
     def test_from_bounds(self):
-        xmin, ymin, xmax, ymax = -180, -90, 180, 90
+        bounds = -180, -90, 180, 90
+        xmin, ymin, xmax, ymax = bounds
         coords = [
             (xmin, ymin),
             (xmin, ymax),
@@ -235,7 +236,7 @@ class PolygonTestCase(unittest.TestCase):
             (xmax, ymin)]
         self.assertEqual(
             Polygon(coords),
-            Polygon.from_bounds(xmin, ymin, xmax, ymax))
+            Polygon.from_bounds(bounds))
 
 
 def test_suite():


### PR DESCRIPTION
Ready for review @snorfalorpagus or @sgillies.

We pass spatial bounds around as a `(xmin, ymin, xmax, ymax)` almost everywhere across Fiona, Rasterio, and Shapely, so this class method should not be an exception.  See https://github.com/Toblerity/Shapely/pull/392#issuecomment-237355773 for background.