### PR TITLE
Look for geos_c.dll not geos.dll on Windows. Fixes #343.

### DIFF
--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -197,7 +197,7 @@ elif sys.platform == 'win32':
             original_path = os.environ['PATH']
             os.environ['PATH'] = "%s;%s;%s" % \
                 (egg_dlls, wininst_dlls, original_path)
-            lgeos = CDLL("geos.dll")
+            lgeos = CDLL("geos_c.dll")
         except (ImportError, WindowsError, OSError):
             raise
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -122,7 +122,7 @@ elif sys.platform == 'win32':
         original_path = os.environ['PATH']
         os.environ['PATH'] = "%s;%s;%s" % \
             (egg_dlls, wininst_dlls, original_path)
-        _lgeos = CDLL("geos.dll")
+        _lgeos = CDLL("geos_c.dll")
     except (ImportError, WindowsError, OSError):
         raise
 


### PR DESCRIPTION
This PR resolves #343 by changing the library name on Windows from `geos.dll` (the C++ library) to `geos_c.dll` (the C library, needed by ctypes).

I've tested this on a fresh install of OSGeo4W.

I normally use Shapely on Windows via conda, which makes this change in it's build also: https://github.com/conda-forge/shapely-feedstock/blob/master/recipe/geos_c.patch

@pelson Presumably this change will break the current shapely-feedstock patch.