### PR TITLE
Instancing geometries with an empty list returns an empty geom.

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -91,7 +91,9 @@ class LineString(BaseGeometry):
     # Coordinate access
     def _set_coords(self, coordinates):
         self.empty()
-        self._geom, self._ndim = geos_linestring_from_py(coordinates)
+        ret = geos_linestring_from_py(coordinates)
+        if ret is not None:
+            self._geom, self._ndim = ret
 
     coords = property(BaseGeometry._get_coords, _set_coords)
 
@@ -253,9 +255,8 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
             ob = list(ob)
             m = len(ob)
 
-        if m < 2:
-            raise ValueError(
-                "LineStrings must have at least 2 coordinate tuples")
+        if m == 0:
+            return None
 
         def _coords(o):
             if isinstance(o, Point):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -65,7 +65,9 @@ class LinearRing(LineString):
 
     def _set_coords(self, coordinates):
         self.empty()
-        self._geom, self._ndim = geos_linearring_from_py(coordinates)
+        ret = geos_linearring_from_py(coordinates)
+        if ret is not None:
+            self._geom, self._ndim = ret
 
     coords = property(_get_coords, _set_coords)
 
@@ -226,7 +228,11 @@ class Polygon(BaseGeometry):
         BaseGeometry.__init__(self)
 
         if shell is not None:
-            self._geom, self._ndim = geos_polygon_from_py(shell, holes)
+            ret = geos_polygon_from_py(shell, holes)
+            if ret is not None:
+                self._geom, self._ndim = ret
+            else:
+                self.empty()
 
     @property
     def exterior(self):
@@ -456,6 +462,9 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
             ob = list(ob)
             m = len(ob)
 
+        if m == 0:
+            return None
+
         n = len(ob[0])
         if m < 3:
             raise ValueError(
@@ -514,7 +523,10 @@ def geos_polygon_from_py(shell, holes=None):
         return geos_geom_from_py(shell)
 
     if shell is not None:
-        geos_shell, ndim = geos_linearring_from_py(shell)
+        ret = geos_linearring_from_py(shell)
+        if ret is None:
+            return None
+        geos_shell, ndim = ret
         if holes is not None and len(holes) > 0:
             ob = holes
             L = len(ob)

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -123,9 +123,9 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         except TypeError:  # Iterators, e.g. Python 3 zip
             ob = list(ob)
             m = len(ob)
-        if m < 2:
-            raise ValueError(
-                "LineStrings must have at least 2 coordinate tuples")
+
+        if m == 0:
+            return None
 
         def _coords(o):
             if isinstance(o, Point):
@@ -287,6 +287,10 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         except TypeError:  # Iterators, e.g. Python 3 zip
             ob = list(ob)
             m = len(ob)
+
+        if m == 0:
+            return None
+
         n = len(ob[0])
         if m < 3:
             raise ValueError(

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -3,6 +3,7 @@ from shapely.geometry.base import BaseGeometry
 import shapely.geometry as sgeom
 from shapely.geometry.polygon import LinearRing
 
+empty_generator = lambda: iter([])
 
 class EmptinessTestCase(unittest.TestCase):
 
@@ -32,18 +33,27 @@ class EmptinessTestCase(unittest.TestCase):
 
     def test_empty_linestring(self):
         self.assertTrue(sgeom.LineString().is_empty)
+        self.assertTrue(sgeom.LineString(None).is_empty)
+        self.assertTrue(sgeom.LineString([]).is_empty)
+        self.assertTrue(sgeom.LineString(empty_generator()).is_empty)
 
     def test_empty_multilinestring(self):
         self.assertTrue(sgeom.MultiLineString([]).is_empty)
 
     def test_empty_polygon(self):
         self.assertTrue(sgeom.Polygon().is_empty)
+        self.assertTrue(sgeom.Polygon(None).is_empty)
+        self.assertTrue(sgeom.Polygon([]).is_empty)
+        self.assertTrue(sgeom.Polygon(empty_generator()).is_empty)
 
     def test_empty_multipolygon(self):
         self.assertTrue(sgeom.MultiPolygon([]).is_empty)
 
     def test_empty_linear_ring(self):
         self.assertTrue(LinearRing().is_empty)
+        self.assertTrue(LinearRing(None).is_empty)
+        self.assertTrue(LinearRing([]).is_empty)
+        self.assertTrue(LinearRing(empty_generator()).is_empty)
 
 
 def test_suite():


### PR DESCRIPTION
This PR enables the creation of empty geometries, by passing a zero-length list (or other iterable), e.g:

```line = LineString([])```

Fixes #397.