### PR TITLE
Fix 'defualt' typo, replace with 'default'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,7 +27,7 @@ Refactoring:
 
 - Switch from ``SingleSidedBuffer()`` to ``OffsetCurve()`` for GEOS >= 3.3
   (#270).
-- Cython speedups are now enabled by defualt (#252).
+- Cython speedups are now enabled by default (#252).
 
 Packaging:
 


### PR DESCRIPTION
The spelling error was noticed while reviewing the changes in 1.6a1 as part of the Debian package update.