### PR TITLE
Fix pytest warning about [pytest] in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 testpaths = tests


### PR DESCRIPTION
From the changelog of [pytest v. 3.0.0](http://doc.pytest.org/en/latest/changelog.html#id21)

> [pytest] sections in setup.cfg files should now be named [tool:pytest] to avoid conflicts with other distutils commands (see #567). [pytest] sections in pytest.ini or tox.ini files are supported and unchanged.