### PR TITLE
add missing import

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2329,6 +2329,7 @@ All of Shapely's geometry types are supported by these functions.
 
 .. code-block:: pycon
 
+  >> from shapely.wkt import dumps, loads
   >> wkt = dumps(Point(0, 0))
   >>> print wkt
   POINT (0.0000000000000000 0.0000000000000000)


### PR DESCRIPTION
wkt dumps/loads example was missing the import

(made a pull request on my fork instead of this earlier on accident...)