### PR TITLE
Changes to travis.yml and support for running without numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,73 @@ language: python
 sudo: false
 cache: pip
 
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+matrix:
+  include:
+    - python: "2.7"
+      env:
+        - SPEEDUPS=1
+        - NUMPY=1
+    - python: "2.7"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=1
+    - python: "2.7"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=0
 
-env:
-  - "TRAVIS_SPEEDUP_OPTS=--with-speedups"
-  - "TRAVIS_SPEEDUP_OPTS=--without-speedups"
+    - python: "3.3"
+      env:
+        - SPEEDUPS=1
+        - NUMPY=1
+    - python: "3.3"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=1
+
+    - python: "3.4"
+      env:
+        - SPEEDUPS=1
+        - NUMPY=1
+    - python: "3.4"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=1
+
+    - python: "3.5"
+      env:
+        - SPEEDUPS=1
+        - NUMPY=1
+    - python: "3.5"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=1
+    - python: "3.5"
+      env:
+        - SPEEDUPS=0
+        - NUMPY=0
 
 addons:
   apt:
     packages:
       - libgeos-dev
-      - python-numpy
 
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
   - pip install pip setuptools --upgrade
-  - pip install --install-option="--no-cython-compile" cython
+  # if building with speedups install cython
+  - if [ "$SPEEDUPS" == "1" ]; then pip install --install-option="--no-cython-compile" cython; fi
+  # if testing without numpy explicitly remove it
+  - if [ "$NUMPY" == "0" ]; then pip uninstall --yes numpy; fi
+  # convert SPEEDUPS to --with-speedups/--without-speedups
+  - if [ "$SPEEDUPS" == "1" ]; then SPEEDUPS_FLAG=--with-speedups; else SPEEDUPS_FLAG=--without-speedups; fi
 
 install:
   - pip install -e .[test]
   - pip install coveralls
 
-script: "py.test --cov shapely --cov-report term-missing ${TRAVIS_SPEEDUP_OPTS}"
+script:
+  - "py.test --cov shapely --cov-report term-missing ${SPEEDUPS_FLAG}"
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/setup.py
+++ b/setup.py
@@ -176,10 +176,9 @@ long_description = readme + '\n\n' + credits + '\n\n' + changes
 
 
 extra_reqs = {
-    'test': ['pytest', 'pytest-cov', 'numpy>=1.4.1', 'packaging']
+    'test': ['pytest', 'pytest-cov', 'packaging'],
+    'vectorized': ['numpy>=1.4.1'],
 }
-if os.getenv('NUMPY') == '0':
-    extra_reqs['test'].remove('numpy>=1.4.1')
 extra_reqs['all'] = list(it.chain.from_iterable(extra_reqs.values()))
 
 

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,8 @@ long_description = readme + '\n\n' + credits + '\n\n' + changes
 extra_reqs = {
     'test': ['pytest', 'pytest-cov', 'numpy>=1.4.1', 'packaging']
 }
+if os.getenv('NUMPY') == '0':
+    extra_reqs['test'].remove('numpy>=1.4.1')
 extra_reqs['all'] = list(it.chain.from_iterable(extra_reqs.values()))
 
 

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -21,6 +21,8 @@ def required(ob):
     """Return an object that meets Shapely requirements for self-owned
     C-continguous data, copying if necessary, or just return the original
     object."""
+    if not has_numpy:
+        return ob
     if hasattr(ob, '__array_interface__'):
         if ob.__array_interface__.get('strides') and not has_numpy:
             # raise an error if strided. See issue #52.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,13 @@ def pytest_runtest_setup(item):
         shapely.speedups.disable()
         assert(shapely.speedups.enabled is False)
         print("Speedups disabled for %s." % item.name)
+
+def pytest_report_header(config):
+    headers = []
+    try:
+        import numpy
+    except ImportError:
+        headers.append("numpy: not available")
+    else:
+        headers.append("numpy: {}".format(numpy.__version__))
+    return '\n'.join(headers)

--- a/tests/test_vectorized.py
+++ b/tests/test_vectorized.py
@@ -1,14 +1,20 @@
 from . import unittest, numpy
 from shapely.geometry import Point, box, MultiPolygon
-from shapely.vectorized import contains, touches
+
+requirements_ok = True
 
 try:
-    import numpy as np
+    from shapely.vectorized import contains, touches
 except ImportError:
-    pass
+    requirements_ok = False
+
+if numpy:
+    np = numpy
+else:
+    requirements_ok = False
 
 
-@unittest.skipIf(not numpy, 'numpy required')
+@unittest.skipIf(not requirements_ok, 'requirements not met (numpy and cython)')
 class VectorizedContainsTestCase(unittest.TestCase):
     def assertContainsResults(self, geom, x, y):
         result = contains(geom, x, y)
@@ -85,7 +91,7 @@ class VectorizedContainsTestCase(unittest.TestCase):
         self.assertContainsResults(self.construct_torus(), *g.exterior.xy)
 
 
-@unittest.skipIf(not numpy, 'numpy required')
+@unittest.skipIf(not requirements_ok, 'requirements not met (numpy and cython)')
 class VectorizedTouchesTestCase(unittest.TestCase):
     def test_touches(self):
         y, x = np.mgrid[-2:3:6j, -1:3:5j]


### PR DESCRIPTION
This is a WIP but could benefit from some comments.

- Tests running shapely on Travis without numpy (#431).
- Fixes a bug preventing shapely running without numpy (also #431).
- Removes support for Python 2.6 on Travis (#432).
- Expands the build matrix used by Travis to be more verbose. This gives more control over what is tested. There is now a `SPEEDUPS=0/1` and `NUMPY=0/1` variable. This could also provide an `AUTODOC=0/1` variable for use in #337.
- The test requirements for test_vectorized.py have been modified. Previously they ran if numpy was present. We distribute .c files for speedups.pyx and vectorized.pyx, in case the user doesn't have cython installed. I think it's more likely that the user doesn't have a C compiler installed, in which case the .c files aren't much use. The test now checks if the speedups module was build (as this was easy to check with `speedups.available` and only runs the tests if this is true.
- In order to prevent setuptools pulling in numpy as a dependency when it isn't desired it was necessary to add a couple of lines to `setup.py`. I don't like this very much but can't think of a better way to do it, other than a find/replace of setup.py in Travis.