### PR TITLE
Improvements to documentation figures

### DIFF
--- a/docs/code/buffer.py
+++ b/docs/code/buffer.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 def plot_line(ax, ob):
     x, y = ob.xy
@@ -23,13 +23,7 @@ ax.add_patch(patch1)
 
 ax.set_title('a) dilation, cap_style=3')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 #2
 ax = fig.add_subplot(122)
@@ -51,13 +45,7 @@ ax.add_patch(patch2b)
 
 ax.set_title('b) erosion, join_style=1')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/buffer.py
+++ b/docs/code/buffer.py
@@ -2,11 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY, set_limits
-
-def plot_line(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, color=GRAY, linewidth=3, solid_capstyle='round', zorder=1)
+from figures import SIZE, BLUE, GRAY, set_limits, plot_line
 
 line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 

--- a/docs/code/cascaded_union.py
+++ b/docs/code/cascaded_union.py
@@ -3,7 +3,7 @@ from shapely.geometry import Point
 from shapely.ops import cascaded_union
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 polygons = [Point(i, 0).buffer(0.7) for i in range(5)]
 
@@ -18,13 +18,7 @@ for ob in polygons:
 
 ax.set_title('a) polygons')
 
-xrange = [-2, 6]
-yrange = [-2, 2]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -2, 6, -2, 2)
 
 #2
 ax = fig.add_subplot(122)
@@ -35,13 +29,7 @@ ax.add_patch(patch2b)
 
 ax.set_title('b) union')
 
-xrange = [-2, 6]
-yrange = [-2, 2]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -2, 6, -2, 2)
 
 pyplot.show()
 

--- a/docs/code/convex_hull.py
+++ b/docs/code/convex_hull.py
@@ -3,7 +3,7 @@ from shapely.geometry import MultiPoint
 
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, set_limits
+from figures import GRAY, BLUE, SIZE, set_limits, plot_line
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 fig.set_frameon(True)
@@ -13,10 +13,9 @@ ax = fig.add_subplot(121)
 
 points2 = MultiPoint([(0, 0), (2, 2)])
 for p in points2:
-    ax.plot(p.x, p.y, 'o', color='#999999')
+    ax.plot(p.x, p.y, 'o', color=GRAY)
 hull2 = points2.convex_hull
-x, y = hull2.xy
-ax.plot(x, y, color='#6699cc', linewidth=3, alpha=0.5, zorder=2)
+plot_line(ax, hull2, color=BLUE, alpha=0.5, zorder=2)
 
 ax.set_title('a) N = 2')
 
@@ -28,9 +27,9 @@ ax = fig.add_subplot(122)
 points1 = MultiPoint([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 
 for p in points1:
-    ax.plot(p.x, p.y, 'o', color='#999999')
+    ax.plot(p.x, p.y, 'o', color=GRAY)
 hull1 = points1.convex_hull
-patch1 = PolygonPatch(hull1, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
+patch1 = PolygonPatch(hull1, facecolor=BLUE, edgecolor=BLUE, alpha=0.5, zorder=2)
 ax.add_patch(patch1)
 
 ax.set_title('b) N > 2')

--- a/docs/code/convex_hull.py
+++ b/docs/code/convex_hull.py
@@ -3,7 +3,7 @@ from shapely.geometry import MultiPoint
 
 from descartes.patch import PolygonPatch
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 fig.set_frameon(True)
@@ -20,13 +20,7 @@ ax.plot(x, y, color='#6699cc', linewidth=3, alpha=0.5, zorder=2)
 
 ax.set_title('a) N = 2')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 #2
 ax = fig.add_subplot(122)
@@ -41,13 +35,7 @@ ax.add_patch(patch1)
 
 ax.set_title('b) N > 2')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/difference.py
+++ b/docs/code/difference.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import Point
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -22,13 +22,7 @@ ax.add_patch(patchc)
 
 ax.set_title('a.difference(b)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 #2
 ax = fig.add_subplot(122)
@@ -43,13 +37,7 @@ ax.add_patch(patchc)
 
 ax.set_title('b.difference(a)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/figures.py
+++ b/docs/code/figures.py
@@ -1,4 +1,5 @@
 from math import sqrt
+from shapely import affinity
 
 GM = (sqrt(5)-1.0)/2.0
 W = 8.0
@@ -7,6 +8,54 @@ SIZE = (W, H)
 
 BLUE = '#6699cc'
 GRAY = '#999999'
+DARKGRAY = '#333333'
+YELLOW = '#ffcc33'
+GREEN = '#339933'
+RED = '#ff3333'
+BLACK = '#000000'
+
+COLOR_ISVALID = {
+    True: BLUE,
+    False: RED,
+}
+
+def plot_line(ax, ob, color=GRAY, zorder=1, linewidth=3, alpha=1):
+    x, y = ob.xy
+    ax.plot(x, y, color=color, linewidth=linewidth, solid_capstyle='round', zorder=zorder, alpha=alpha)
+
+def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
+    x, y = ob.xy
+    ax.plot(x, y, 'o', color=color, zorder=zorder, alpha=alpha)
+
+def color_isvalid(ob, valid=GRAY, invalid=RED):
+    if ob.is_valid:
+        return valid
+    else:
+        return invalid
+
+def color_issimple(ob, simple=BLUE, complex=YELLOW):
+    if ob.is_simple:
+        return simple
+    else:
+        return complex
+
+def plot_line_isvalid(ax, ob, **kwargs):
+    kwargs["color"] = color_isvalid(ob)
+    plot_line(ax, ob, **kwargs)
+
+def plot_line_issimple(ax, ob, **kwargs):
+    kwargs["color"] = color_issimple(ob)
+    plot_line(ax, ob, **kwargs)
+
+def plot_bounds(ax, ob, zorder=1, alpha=1):
+    x, y = zip(*list((p.x, p.y) for p in ob.boundary))
+    ax.plot(x, y, 'o', color=BLACK, zorder=zorder, alpha=alpha)
+
+def add_origin(ax, geom, origin):
+    x, y = xy = affinity.interpret_origin(geom, origin, 2)
+    ax.plot(x, y, 'o', color=GRAY, zorder=1)
+    ax.annotate(str(xy), xy=xy, ha='center',
+                textcoords='offset points', xytext=(0, 8))
 
 def set_limits(ax, x0, xN, y0, yN):
     ax.set_xlim(x0, xN)

--- a/docs/code/figures.py
+++ b/docs/code/figures.py
@@ -27,7 +27,7 @@ def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
     x, y = ob.xy
     ax.plot(x, y, 'o', color=color, zorder=zorder, alpha=alpha)
 
-def color_isvalid(ob, valid=GRAY, invalid=RED):
+def color_isvalid(ob, valid=BLUE, invalid=RED):
     if ob.is_valid:
         return valid
     else:

--- a/docs/code/figures.py
+++ b/docs/code/figures.py
@@ -7,3 +7,10 @@ SIZE = (W, H)
 
 BLUE = '#6699cc'
 GRAY = '#999999'
+
+def set_limits(ax, x0, xN, y0, yN):
+    ax.set_xlim(x0, xN)
+    ax.set_xticks(range(x0, xN+1))
+    ax.set_ylim(y0, yN)
+    ax.set_yticks(range(y0, yN+1))
+    ax.set_aspect("equal")

--- a/docs/code/geometrycollection.py
+++ b/docs/code/geometrycollection.py
@@ -1,6 +1,6 @@
 from matplotlib import pyplot
 from shapely.geometry import LineString
-from figures import SIZE
+from figures import SIZE, set_limits
 
 BLUE =   '#6699cc'
 YELLOW = '#ffcc33'
@@ -30,13 +30,7 @@ ax.plot(x, y, color=GREEN, alpha=0.5, linewidth=3, solid_capstyle='round', zorde
 
 ax.set_title('a) lines')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -55,13 +49,7 @@ for ob in a.intersection(b):
 
 ax.set_title('b) collection')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/geometrycollection.py
+++ b/docs/code/geometrycollection.py
@@ -1,15 +1,6 @@
 from matplotlib import pyplot
 from shapely.geometry import LineString
-from figures import SIZE, set_limits
-
-BLUE =   '#6699cc'
-YELLOW = '#ffcc33'
-GREEN =  '#339933'
-GRAY =   '#999999'
-
-def plot_coords(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, 'o', color=GRAY, zorder=1)
+from figures import BLUE, GRAY, YELLOW, GREEN, SIZE, set_limits, plot_coords
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90) #1, figsize=(10, 4), dpi=180)
 

--- a/docs/code/intersection-sym-difference.py
+++ b/docs/code/intersection-sym-difference.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import Point
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -22,13 +22,7 @@ ax.add_patch(patchc)
 
 ax.set_title('a.intersection(b)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 #2
 ax = fig.add_subplot(122)
@@ -49,13 +43,7 @@ elif c.geom_type == 'MultiPolygon':
 
 ax.set_title('a.symmetric_difference(b)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/linearring.py
+++ b/docs/code/linearring.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry.polygon import LinearRing
 
-from figures import GRAY, RED, SIZE, set_limits, plot_coords, plot_line_isvalid
+from figures import SIZE, set_limits, plot_coords, plot_line_isvalid
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/linearring.py
+++ b/docs/code/linearring.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry.polygon import LinearRing
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -30,13 +30,7 @@ plot_line(ax, ring)
 
 ax.set_title('a) valid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -47,13 +41,7 @@ plot_line(ax, ring2)
 
 ax.set_title('b) invalid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/linearring.py
+++ b/docs/code/linearring.py
@@ -1,23 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry.polygon import LinearRing
 
-from figures import SIZE, set_limits
-
-COLOR = {
-    True:  '#6699cc',
-    False: '#ff3333'
-    }
-
-def v_color(ob):
-    return COLOR[ob.is_valid]
-
-def plot_coords(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, 'o', color='#999999', zorder=1)
-
-def plot_line(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, color=v_color(ob), alpha=0.7, linewidth=3, solid_capstyle='round', zorder=2)
+from figures import GRAY, RED, SIZE, set_limits, plot_coords, plot_line_isvalid
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -26,7 +10,7 @@ ax = fig.add_subplot(121)
 ring = LinearRing([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 0.8), (0, 0)])
 
 plot_coords(ax, ring)
-plot_line(ax, ring)
+plot_line_isvalid(ax, ring, alpha=0.7)
 
 ax.set_title('a) valid')
 
@@ -37,7 +21,7 @@ ax = fig.add_subplot(122)
 ring2 = LinearRing([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)])
 
 plot_coords(ax, ring2)
-plot_line(ax, ring2)
+plot_line_isvalid(ax, ring2, alpha=0.7)
 
 ax.set_title('b) invalid')
 

--- a/docs/code/linestring.py
+++ b/docs/code/linestring.py
@@ -39,7 +39,7 @@ set_limits(ax, -1, 4, -1, 3)
 
 #2: complex line
 ax = fig.add_subplot(122)
-line2 = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (0, 1), (1, 0)])
+line2 = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (-1, 1), (1, 0)])
 
 plot_coords(ax, line2)
 plot_bounds(ax, line2)
@@ -47,7 +47,7 @@ plot_line_issimple(ax, line2, alpha=0.7)
 
 ax.set_title('b) complex')
 
-set_limits(ax, -1, 4, -1, 3)
+set_limits(ax, -2, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/linestring.py
+++ b/docs/code/linestring.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry import LineString
 
-from figures import SIZE, set_limits
+from figures import SIZE, set_limits, plot_coords, plot_bounds, plot_line_issimple
 
 COLOR = {
     True:  '#6699cc',
@@ -31,7 +31,7 @@ line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 
 plot_coords(ax, line)
 plot_bounds(ax, line)
-plot_line(ax, line)
+plot_line_issimple(ax, line, alpha=0.7)
 
 ax.set_title('a) simple')
 
@@ -43,7 +43,7 @@ line2 = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (0, 1), (1, 0)])
 
 plot_coords(ax, line2)
 plot_bounds(ax, line2)
-plot_line(ax, line2)
+plot_line_issimple(ax, line2, alpha=0.7)
 
 ax.set_title('b) complex')
 

--- a/docs/code/linestring.py
+++ b/docs/code/linestring.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry import LineString
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -35,16 +35,11 @@ plot_line(ax, line)
 
 ax.set_title('a) simple')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_ylim(*yrange)
-ax.set_yticks(list(range(*yrange)) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 #2: complex line
 ax = fig.add_subplot(122)
-line2 = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (-1, 1), (1, 0)])
+line2 = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (0, 1), (1, 0)])
 
 plot_coords(ax, line2)
 plot_bounds(ax, line2)
@@ -52,12 +47,7 @@ plot_line(ax, line2)
 
 ax.set_title('b) complex')
 
-xrange = [-2, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_ylim(*yrange)
-ax.set_yticks(list(range(*yrange)) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/minimum_rotated_rectangle.py
+++ b/docs/code/minimum_rotated_rectangle.py
@@ -2,7 +2,7 @@ from shapely.geometry import MultiPoint, Polygon, LineString
 import matplotlib.pyplot as plt
 from descartes.patch import PolygonPatch
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 fig = plt.figure(1, figsize=SIZE, dpi=90)
 fig.set_frameon(True)
@@ -19,13 +19,7 @@ patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, 
 ax.add_patch(patch)
 ax.set_title('a) MultiPoint')
 
-xr = [-1, 2]
-yr = [-1, 2]
-ax.set_xlim(*xr)
-ax.set_xticks(range(*xr) + [xr[-1]])
-ax.set_ylim(*yr)
-ax.set_yticks(range(*yr) + [yr[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 2, -1, 2)
 
 # 2
 ax = fig.add_subplot(122)
@@ -36,13 +30,7 @@ ax.plot(*ls.xy, color='#333333', linewidth=3, alpha=0.5, zorder=2)
 patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
-xr = [-1, 2]
-yr = [-1, 2]
-ax.set_xlim(*xr)
-ax.set_xticks(range(*xr) + [xr[-1]])
-ax.set_ylim(*yr)
-ax.set_yticks(range(*yr) + [yr[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 2, -1, 2)
 
 ax.set_title('b) LineString')
 

--- a/docs/code/minimum_rotated_rectangle.py
+++ b/docs/code/minimum_rotated_rectangle.py
@@ -2,7 +2,7 @@ from shapely.geometry import MultiPoint, Polygon, LineString
 import matplotlib.pyplot as plt
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, set_limits
+from figures import DARKGRAY, GRAY, BLUE, SIZE, set_limits
 
 fig = plt.figure(1, figsize=SIZE, dpi=90)
 fig.set_frameon(True)
@@ -14,8 +14,8 @@ mp = MultiPoint([(0, 0), (0.5, 1.5), (1, 0.5), (0.5, 0.5)])
 rect = mp.minimum_rotated_rectangle
 
 for p in mp:
-	ax.plot(p.x, p.y, 'o', color='#999999')
-patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
+	ax.plot(p.x, p.y, 'o', color=GRAY)
+patch = PolygonPatch(rect, facecolor=BLUE, edgecolor=BLUE, alpha=0.5, zorder=2)
 ax.add_patch(patch)
 ax.set_title('a) MultiPoint')
 
@@ -26,8 +26,8 @@ ax = fig.add_subplot(122)
 ls = LineString([(-0.5, 1.2), (0.5, 0), (1, 1), (1.5, 0), (1.5, 0.5)])
 rect = ls.minimum_rotated_rectangle
 
-ax.plot(*ls.xy, color='#333333', linewidth=3, alpha=0.5, zorder=2)
-patch = PolygonPatch(rect, facecolor='#6699cc', edgecolor='#6699cc', alpha=0.5, zorder=2)
+ax.plot(*ls.xy, color=DARKGRAY, linewidth=3, alpha=0.5, zorder=2)
+patch = PolygonPatch(rect, facecolor=BLUE, edgecolor=BLUE, alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
 set_limits(ax, -1, 2, -1, 2)

--- a/docs/code/multilinestring.py
+++ b/docs/code/multilinestring.py
@@ -1,7 +1,8 @@
 from matplotlib import pyplot
 from shapely.geometry import MultiLineString
 
-from figures import SIZE, set_limits
+from figures import SIZE, set_limits, plot_line_issimple, plot_bounds
+from figures import plot_coords as _plot_coords
 
 COLOR = {
     True:  '#6699cc',
@@ -13,17 +14,11 @@ def v_color(ob):
 
 def plot_coords(ax, ob):
     for line in ob:
-        x, y = line.xy
-        ax.plot(x, y, 'o', color='#999999', zorder=1)
-
-def plot_bounds(ax, ob):
-    x, y = zip(*list((p.x, p.y) for p in ob.boundary))
-    ax.plot(x, y, 'o', color='#000000', zorder=1)
+        _plot_coords(ax, line, zorder=1)
 
 def plot_lines(ax, ob):
     for line in ob:
-        x, y = line.xy
-        ax.plot(x, y, color=v_color(ob), alpha=0.7, linewidth=3, solid_capstyle='round', zorder=2)
+        plot_line_issimple(ax, line, alpha=0.7, zorder=2)
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/multilinestring.py
+++ b/docs/code/multilinestring.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot
 from shapely.geometry import MultiLineString
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -38,13 +38,7 @@ plot_lines(ax, mline1)
 
 ax.set_title('a) simple')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -57,13 +51,7 @@ plot_lines(ax, mline2)
 
 ax.set_title('b) complex')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/multilinestring.py
+++ b/docs/code/multilinestring.py
@@ -1,24 +1,17 @@
 from matplotlib import pyplot
 from shapely.geometry import MultiLineString
 
-from figures import SIZE, set_limits, plot_line_issimple, plot_bounds
+from figures import SIZE, set_limits, plot_line, plot_bounds, color_issimple
 from figures import plot_coords as _plot_coords
-
-COLOR = {
-    True:  '#6699cc',
-    False: '#ffcc33'
-    }
-
-def v_color(ob):
-    return COLOR[ob.is_simple]
 
 def plot_coords(ax, ob):
     for line in ob:
         _plot_coords(ax, line, zorder=1)
 
 def plot_lines(ax, ob):
+    color = color_issimple(ob)
     for line in ob:
-        plot_line_issimple(ax, line, alpha=0.7, zorder=2)
+        plot_line(ax, line, color=color, alpha=0.7, zorder=2)
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/multipolygon.py
+++ b/docs/code/multipolygon.py
@@ -2,19 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import MultiPolygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, set_limits
-
-COLOR = {
-    True:  '#6699cc',
-    False: '#ff3333'
-    }
-
-def v_color(ob):
-    return COLOR[ob.is_valid]
-
-def plot_coords(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, 'o', color='#999999', zorder=1)
+from figures import BLUE, SIZE, set_limits, plot_coords, color_isvalid
     
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -28,7 +16,7 @@ multi1 = MultiPolygon([[a, []], [b, []]])
 
 for polygon in multi1:
     plot_coords(ax, polygon.exterior)
-    patch = PolygonPatch(polygon, facecolor=v_color(multi1), edgecolor=v_color(multi1), alpha=0.5, zorder=2)
+    patch = PolygonPatch(polygon, facecolor=color_isvalid(multi1), edgecolor=color_isvalid(multi1, valid=BLUE), alpha=0.5, zorder=2)
     ax.add_patch(patch)
 
 ax.set_title('a) valid')
@@ -45,7 +33,7 @@ multi2 = MultiPolygon([[c, []], [d, []]])
 
 for polygon in multi2:
     plot_coords(ax, polygon.exterior)
-    patch = PolygonPatch(polygon, facecolor=v_color(multi2), edgecolor=v_color(multi2), alpha=0.5, zorder=2)
+    patch = PolygonPatch(polygon, facecolor=color_isvalid(multi2), edgecolor=color_isvalid(multi2, valid=BLUE), alpha=0.5, zorder=2)
     ax.add_patch(patch)
 
 ax.set_title('b) invalid')

--- a/docs/code/multipolygon.py
+++ b/docs/code/multipolygon.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import MultiPolygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -33,13 +33,7 @@ for polygon in multi1:
 
 ax.set_title('a) valid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -56,13 +50,7 @@ for polygon in multi2:
 
 ax.set_title('b) invalid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/parallel_offset.py
+++ b/docs/code/parallel_offset.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 def plot_coords(ax, x, y, color='#999999', zorder=1):
     ax.plot(x, y, 'o', color=color, zorder=zorder)
@@ -12,13 +12,6 @@ def plot_line(ax, ob, color=GRAY):
     for part in parts:
         x, y = part.xy
         ax.plot(x, y, color=color, linewidth=3, solid_capstyle='round', zorder=1)
-
-def set_limits(ax, x_range, y_range):
-    ax.set_xlim(*x_range)
-    ax.set_xticks(range(*x_range) + [x_range[-1]])
-    ax.set_ylim(*y_range)
-    ax.set_yticks(range(*y_range) + [y_range[-1]])
-    ax.set_aspect(1)
 
 line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 line_bounds = line.bounds
@@ -37,7 +30,7 @@ offset = line.parallel_offset(0.5, 'left', join_style=1)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('a) left, round')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #2
 ax = fig.add_subplot(222)
@@ -50,7 +43,7 @@ offset = line.parallel_offset(0.5, 'left', join_style=2)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('b) left, mitred')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #3
 ax = fig.add_subplot(223)
@@ -62,7 +55,7 @@ offset = line.parallel_offset(0.5, 'left', join_style=3)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('c) left, beveled')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #4
 ax = fig.add_subplot(224)
@@ -74,7 +67,7 @@ offset = line.parallel_offset(0.5, 'right', join_style=1)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('d) right, round')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 pyplot.show()
 

--- a/docs/code/parallel_offset_mitre.py
+++ b/docs/code/parallel_offset_mitre.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 def plot_coords(ax, x, y, color='#999999', zorder=1):
     ax.plot(x, y, 'o', color=color, zorder=zorder)
@@ -12,13 +12,6 @@ def plot_line(ax, ob, color=GRAY):
     for part in parts:
         x, y = part.xy
         ax.plot(x, y, color=color, linewidth=3, solid_capstyle='round', zorder=1)
-
-def set_limits(ax, x_range, y_range):
-    ax.set_xlim(*x_range)
-    ax.set_xticks(range(*x_range) + [x_range[-1]])
-    ax.set_ylim(*y_range)
-    ax.set_yticks(range(*y_range) + [y_range[-1]])
-    ax.set_aspect(1)
 
 line = LineString([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 line_bounds = line.bounds
@@ -37,7 +30,7 @@ offset = line.parallel_offset(0.5, 'left', join_style=2, mitre_limit=0.1)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('a) left, limit=0.1')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #2
 ax = fig.add_subplot(222)
@@ -50,7 +43,7 @@ offset = line.parallel_offset(0.5, 'left', join_style=2, mitre_limit=10.0)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('b) left, limit=10.0')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #3
 ax = fig.add_subplot(223)
@@ -62,7 +55,7 @@ offset = line.parallel_offset(0.5, 'right', join_style=2, mitre_limit=0.1)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('c) right, limit=0.1')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 #4
 ax = fig.add_subplot(224)
@@ -74,7 +67,7 @@ offset = line.parallel_offset(0.5, 'right', join_style=2, mitre_limit=10.0)
 plot_line(ax, offset, color=BLUE)
 
 ax.set_title('d) right, limit=10.0')
-set_limits(ax, ax_range, ay_range)
+set_limits(ax, ax_range[0], ax_range[1], ay_range[0], ay_range[1])
 
 pyplot.show()
 

--- a/docs/code/polygon.py
+++ b/docs/code/polygon.py
@@ -2,19 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import Polygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, set_limits
-
-COLOR = {
-    True:  '#6699cc',
-    False: '#ff3333'
-    }
-
-def v_color(ob):
-    return COLOR[ob.is_valid]
-
-def plot_coords(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, 'o', color='#999999', zorder=1)
+from figures import BLUE, SIZE, set_limits, plot_coords, color_isvalid
     
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -28,7 +16,7 @@ polygon = Polygon(ext, [int])
 plot_coords(ax, polygon.interiors[0])
 plot_coords(ax, polygon.exterior)
 
-patch = PolygonPatch(polygon, facecolor=v_color(polygon), edgecolor=v_color(polygon), alpha=0.5, zorder=2)
+patch = PolygonPatch(polygon, facecolor=color_isvalid(polygon), edgecolor=color_isvalid(polygon, valid=BLUE), alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
 ax.set_title('a) valid')
@@ -44,7 +32,7 @@ polygon = Polygon(ext, [int])
 plot_coords(ax, polygon.interiors[0])
 plot_coords(ax, polygon.exterior)
 
-patch = PolygonPatch(polygon, facecolor=v_color(polygon), edgecolor=v_color(polygon), alpha=0.5, zorder=2)
+patch = PolygonPatch(polygon, facecolor=color_isvalid(polygon), edgecolor=color_isvalid(polygon, valid=BLUE), alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
 ax.set_title('b) invalid')

--- a/docs/code/polygon.py
+++ b/docs/code/polygon.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import Polygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -33,13 +33,7 @@ ax.add_patch(patch)
 
 ax.set_title('a) valid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -55,13 +49,7 @@ ax.add_patch(patch)
 
 ax.set_title('b) invalid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/polygon2.py
+++ b/docs/code/polygon2.py
@@ -3,19 +3,7 @@ from matplotlib.patches import Circle
 from shapely.geometry import Polygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, set_limits
-
-COLOR = {
-    True:  '#6699cc',
-    False: '#ff3333'
-    }
-
-def v_color(ob):
-    return COLOR[ob.is_valid]
-
-def plot_coords(ax, ob):
-    x, y = ob.xy
-    ax.plot(x, y, 'o', color='#999999', zorder=1)
+from figures import BLUE, SIZE, set_limits, plot_coords, color_isvalid
     
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -29,7 +17,7 @@ polygon = Polygon(ext, [int])
 plot_coords(ax, polygon.interiors[0])
 plot_coords(ax, polygon.exterior)
 
-patch = PolygonPatch(polygon, facecolor=v_color(polygon), edgecolor=v_color(polygon), alpha=0.5, zorder=2)
+patch = PolygonPatch(polygon, facecolor=color_isvalid(polygon), edgecolor=color_isvalid(polygon, valid=BLUE), alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
 ax.set_title('c) invalid')
@@ -48,7 +36,7 @@ plot_coords(ax, polygon.interiors[0])
 plot_coords(ax, polygon.interiors[1])
 plot_coords(ax, polygon.exterior)
 
-patch = PolygonPatch(polygon, facecolor=v_color(polygon), edgecolor=v_color(polygon), alpha=0.5, zorder=2)
+patch = PolygonPatch(polygon, facecolor=color_isvalid(polygon), edgecolor=color_isvalid(polygon, valid=BLUE), alpha=0.5, zorder=2)
 ax.add_patch(patch)
 
 ax.set_title('d) invalid')

--- a/docs/code/polygon2.py
+++ b/docs/code/polygon2.py
@@ -3,7 +3,7 @@ from matplotlib.patches import Circle
 from shapely.geometry import Polygon
 from descartes.patch import PolygonPatch
 
-from figures import SIZE
+from figures import SIZE, set_limits
 
 COLOR = {
     True:  '#6699cc',
@@ -34,13 +34,7 @@ ax.add_patch(patch)
 
 ax.set_title('c) invalid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #4: invalid self-touching ring
 ax = fig.add_subplot(122)
@@ -59,13 +53,7 @@ ax.add_patch(patch)
 
 ax.set_title('d) invalid')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/rotate.py
+++ b/docs/code/rotate.py
@@ -2,20 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from shapely import affinity
 
-from figures import SIZE, BLUE, GRAY, set_limits
-
-
-def add_origin(ax, geom, origin):
-    x, y = xy = affinity.interpret_origin(geom, origin, 2)
-    ax.plot(x, y, 'o', color=GRAY, zorder=1)
-    ax.annotate(str(xy), xy=xy, ha='center',
-                textcoords='offset points', xytext=(0, 8))
-
-
-def plot_line(ax, ob, color):
-    x, y = ob.xy
-    ax.plot(x, y, color=color, alpha=0.7, linewidth=3,
-            solid_capstyle='round', zorder=2)
+from figures import SIZE, BLUE, GRAY, set_limits, plot_line, add_origin
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/rotate.py
+++ b/docs/code/rotate.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import LineString
 from shapely import affinity
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 
 def add_origin(ax, geom, origin):
@@ -21,9 +21,6 @@ fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
 line = LineString([(1, 3), (1, 1), (4, 1)])
 
-xrange = [0, 5]
-yrange = [0, 4]
-
 # 1
 ax = fig.add_subplot(121)
 
@@ -33,11 +30,7 @@ add_origin(ax, line, 'center')
 
 ax.set_title(u"90\N{DEGREE SIGN}, default origin (center)")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 # 2
 ax = fig.add_subplot(122)
@@ -48,10 +41,6 @@ add_origin(ax, line, 'centroid')
 
 ax.set_title(u"90\N{DEGREE SIGN}, origin='centroid'")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 pyplot.show()

--- a/docs/code/scale.py
+++ b/docs/code/scale.py
@@ -3,7 +3,7 @@ from shapely.geometry import Polygon
 from shapely import affinity
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 
 def add_origin(ax, geom, origin):
@@ -15,9 +15,6 @@ def add_origin(ax, geom, origin):
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
 triangle = Polygon([(1, 1), (2, 3), (3, 1)])
-
-xrange = [0, 5]
-yrange = [0, 4]
 
 # 1
 ax = fig.add_subplot(121)
@@ -34,11 +31,7 @@ add_origin(ax, triangle, 'center')
 
 ax.set_title("a) xfact=1.5, yfact=-1")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 # 2
 ax = fig.add_subplot(122)
@@ -55,10 +48,6 @@ add_origin(ax, triangle, (1, 1))
 
 ax.set_title("b) xfact=2, origin=(1, 1)")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 pyplot.show()

--- a/docs/code/scale.py
+++ b/docs/code/scale.py
@@ -3,14 +3,7 @@ from shapely.geometry import Polygon
 from shapely import affinity
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY, set_limits
-
-
-def add_origin(ax, geom, origin):
-    x, y = xy = affinity.interpret_origin(geom, origin, 2)
-    ax.plot(x, y, 'o', color=GRAY, zorder=1)
-    ax.annotate(str(xy), xy=xy, ha='center',
-                textcoords='offset points', xytext=(0, 8))
+from figures import SIZE, BLUE, GRAY, set_limits, add_origin
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/simplify.py
+++ b/docs/code/simplify.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import MultiPoint, Point
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90) #1, figsize=SIZE, dpi=90)
 
@@ -21,13 +21,7 @@ ax.add_patch(patch1b)
 
 ax.set_title('a) tolerance 0.2')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 #2
 ax = fig.add_subplot(122)
@@ -42,13 +36,7 @@ ax.add_patch(patch2b)
 
 ax.set_title('b) tolerance 0.5')
 
-xrange = [-1, 3]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 3, -1, 3)
 
 pyplot.show()
 

--- a/docs/code/skew.py
+++ b/docs/code/skew.py
@@ -3,14 +3,7 @@ from shapely.wkt import loads as load_wkt
 from shapely import affinity
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY, set_limits
-
-
-def add_origin(ax, geom, origin):
-    x, y = xy = affinity.interpret_origin(geom, origin, 2)
-    ax.plot(x, y, 'o', color=GRAY, zorder=1)
-    ax.annotate(str(xy), xy=xy, ha='center',
-                textcoords='offset points', xytext=(0, 8))
+from figures import SIZE, BLUE, GRAY, set_limits, add_origin
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 

--- a/docs/code/skew.py
+++ b/docs/code/skew.py
@@ -3,7 +3,7 @@ from shapely.wkt import loads as load_wkt
 from shapely import affinity
 from descartes.patch import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 
 def add_origin(ax, geom, origin):
@@ -29,9 +29,6 @@ POLYGON((2.218 2.204, 2.273 2.18, 2.328 2.144, 2.435 2.042, 2.541 1.895,
   2.259 3.025, 2.219 3.103, 2.163 3.167, 2.091 3.217, 2.004 3.253, 1.902 3.275,
   1.784 3.282, 1.347 3.282))''')
 
-xrange = [0, 5]
-yrange = [0, 4]
-
 # 1
 ax = fig.add_subplot(121)
 
@@ -47,11 +44,7 @@ add_origin(ax, R, (1, 1))
 
 ax.set_title("a) xs=20, origin(1, 1)")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 # 2
 ax = fig.add_subplot(122)
@@ -68,10 +61,6 @@ add_origin(ax, R, 'center')
 
 ax.set_title("b) ys=30")
 
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, 0, 5, 0, 4)
 
 pyplot.show()

--- a/docs/code/triangulate.py
+++ b/docs/code/triangulate.py
@@ -3,7 +3,7 @@ from shapely.ops import triangulate
 
 from matplotlib import pyplot
 from descartes.patch import PolygonPatch
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 points = MultiPoint([(0, 0), (1, 1), (0, 2), (2, 2), (3, 1), (1, 0)])
 triangles = triangulate(points)
@@ -19,6 +19,6 @@ for triangle in triangles:
 for point in points:
     pyplot.plot(point.x, point.y, 'o', color=GRAY)
 
-pyplot.xlim(-0.5, 3.5)
-pyplot.ylim(-0.5, 2.5)
+set_limits(ax, -1, 4, -1, 3)
+
 pyplot.show()

--- a/docs/code/union.py
+++ b/docs/code/union.py
@@ -2,7 +2,7 @@ from matplotlib import pyplot
 from shapely.geometry import Point
 from descartes import PolygonPatch
 
-from figures import SIZE, BLUE, GRAY
+from figures import SIZE, BLUE, GRAY, set_limits
 
 fig = pyplot.figure(1, figsize=SIZE, dpi=90)
 
@@ -22,13 +22,7 @@ ax.add_patch(patchc)
 
 ax.set_title('a.union(b)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 def plot_line(ax, ob, color=GRAY):
     x, y = ob.xy
@@ -49,13 +43,7 @@ elif u.geom_type is 'MultiLineString':
 
 ax.set_title('a.boundary.union(b.boundary)')
 
-xrange = [-1, 4]
-yrange = [-1, 3]
-ax.set_xlim(*xrange)
-ax.set_xticks(range(*xrange) + [xrange[-1]])
-ax.set_ylim(*yrange)
-ax.set_yticks(range(*yrange) + [yrange[-1]])
-ax.set_aspect(1)
+set_limits(ax, -1, 4, -1, 3)
 
 pyplot.show()
 


### PR DESCRIPTION
This PR adds support for Python 3.x rendering of the documentation figures (as mentioned in #337). It also removes some code duplication by moving common functions into `figures.py`. More could probably be done, but this will do for now.