### PR TITLE
Fix creation of 3D multipoint from array. Closes #437.

### DIFF
--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -181,7 +181,7 @@ def geos_multipoint_from_py(ob):
         subs = (c_void_p * m)()
 
         for i in range(m):
-            geom, ndims = point.geos_point_from_py(cp[n*i:n*i+2])
+            geom, ndims = point.geos_point_from_py(cp[n*i:n*i+n])
             subs[i] = cast(geom, c_void_p)
 
     except AttributeError:

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -69,6 +69,15 @@ class MultiPointTestCase(MultiGeometryTestCase):
         pas = asarray(geoma)
         assert_array_equal(pas, array([[1., 2.], [3., 4.]]))
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_has_z(self):
+        # test creation of 3D multipoint from numpy array, see issue #437
+        from numpy import array
+        a = array([[1,2,3],[4,5,6]])
+        mp = MultiPoint(a)
+        assert(mp._ndim == 3)
+        assert(mp.has_z)
+
     def test_subgeom_access(self):
         p0 = Point(1.0, 2.0)
         p1 = Point(3.0, 4.0)


### PR DESCRIPTION
This PR fixes a bug in the creation of MultiPoints from numpy arrays with 3 dimensions.

This bug has been present since at least Shapely 1.2, but this PR is only aimed at the maint-1.5 branch. I hope that's the right thing to do?