### PR TITLE
Add support for reading/passing along CRS info

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -219,6 +219,22 @@ class BaseGeometry(object):
     # a reference to the so/dll proxy to preserve access during clean up
     _lgeos = lgeos
 
+    def __init__(self, *args, **kwargs):
+        # set the crs if there is one.
+        try:
+            self.crs = kwargs['crs']
+        except KeyError:
+            # it's optional
+            pass
+
+    @property
+    def crs(self):
+        return self._crs
+
+    @crs.setter
+    def crs(self, value):
+        self._crs = value
+
     def empty(self, val=EMPTY):
         # TODO: defer cleanup to the implementation. We shouldn't be
         # explicitly calling a lgeos method here.

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -20,13 +20,15 @@ class GeometryCollection(BaseMultipartGeometry):
         A sequence of Shapely geometry instances
     """
 
-    def __init__(self, geoms=None):
+    def __init__(self, geoms=None, crs=None):
         """
         Parameters
         ----------
         geoms : list
             A list of shapely geometry instances, which may be heterogenous.
-        
+        crs : dict
+            Optional dict containing coordinate reference system
+
         Example
         -------
         Create a GeometryCollection with a Point and a LineString
@@ -35,7 +37,7 @@ class GeometryCollection(BaseMultipartGeometry):
           >>> l = LineString([(52, -1), (49, 2)])
           >>> gc = GeometryCollection([p, l])
         """
-        BaseMultipartGeometry.__init__(self)
+        BaseMultipartGeometry.__init__(self, crs=crs)
         if not geoms:
             pass
         else:
@@ -46,7 +48,13 @@ class GeometryCollection(BaseMultipartGeometry):
         geometries = []
         for geom in self.geoms:
             geometries.append(geom.__geo_interface__)
-        return dict(type='GeometryCollection', geometries=geometries)
+        geom = {
+            'type': 'GeometryCollection',
+            'geometries': geometries
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     @property
     def geoms(self):

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,82 +1,238 @@
 """
 Geometry factories based on the geo interface
 """
+from shapely.geometry.point import Point, asPoint
+from shapely.geometry.linestring import LineString, asLineString
+from shapely.geometry.polygon import Polygon, asPolygon
+from shapely.geometry.multipoint import MultiPoint, asMultiPoint
+from shapely.geometry.multilinestring import MultiLineString, asMultiLineString
+from shapely.geometry.multipolygon import MultiPolygon, MultiPolygonAdapter
+from shapely.geometry.collection import GeometryCollection
 
-from .point import Point, asPoint
-from .linestring import LineString, asLineString
-from .polygon import Polygon, asPolygon
-from .multipoint import MultiPoint, asMultiPoint
-from .multilinestring import MultiLineString, asMultiLineString
-from .multipolygon import MultiPolygon, MultiPolygonAdapter
-from .collection import GeometryCollection
+
+def _get_ob_from_context(context):
+    """
+    Attempt to convert the context to an object shapely can understand.
+
+    Parameters
+    ----------
+    context: dict like
+
+    Returns
+    -------
+    tuple
+        ob, geom_type
+    """
+    if hasattr(context, "__geo_interface__"):
+        ob = context.__geo_interface__
+    else:
+        ob = context
+    try:
+        geom_type = ob.get("type").lower()
+    except AttributeError:
+        raise ValueError("Context does not provide geo interface")
+    return ob, geom_type
+
+
+def _extract_crs(ob):
+    """
+    Pull out the crs key/attribute from the object.
+
+    Parameters
+    ----------
+    ob: object
+
+    Returns
+    -------
+    object
+        Returns the thing at ob['crs'] or ob.crs or None
+
+    """
+    crs = None
+    try:
+        crs = ob['crs']
+    except (TypeError, KeyError):
+        pass
+    if crs is None and hasattr(ob, 'crs'):
+        crs = ob.crs
+    return crs
 
 
 def box(minx, miny, maxx, maxy, ccw=True):
-    """Returns a rectangular polygon with configurable normal vector"""
+    """
+    Returns a rectangular polygon with configurable normal vector
+
+    Parameters
+    ----------
+    minx: number
+    miny: number
+    maxx: number
+    maxy: number
+    ccw: bool
+        order of coordinates (counter-clock-wise)
+
+    Returns
+    -------
+    Polygon
+        Rectangular polygon with configurable normal vector
+
+    """
     coords = [(maxx, miny), (maxx, maxy), (minx, maxy), (minx, miny)]
     if not ccw:
         coords = coords[::-1]
     return Polygon(coords)
 
+
 def shape(context):
-    """Returns a new, independent geometry with coordinates *copied* from the
-    context.
     """
-    if hasattr(context, "__geo_interface__"):
-        ob = context.__geo_interface__
-    else:
-        ob = context
-    geom_type = ob.get("type").lower()
-    if geom_type == "point":
-        return Point(ob["coordinates"])
-    elif geom_type == "linestring":
-        return LineString(ob["coordinates"])
-    elif geom_type == "polygon":
-        return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
-    elif geom_type == "multipoint":
-        return MultiPoint(ob["coordinates"])
-    elif geom_type == "multilinestring":
-        return MultiLineString(ob["coordinates"])
-    elif geom_type == "multipolygon":
-        return MultiPolygon(ob["coordinates"], context_type='geojson')
-    elif geom_type == "geometrycollection":
-        geoms = [shape(g) for g in ob.get("geometries", [])]
-        return GeometryCollection(geoms)
-    else:
+     Returns a new, independent geometry with coordinates *copied* from the
+     context.
+
+
+    Parameters
+    ----------
+    context: dict like
+
+    Returns
+    -------
+    shapely object
+        Returns an appropriate shapely geometry class depending on context passed in.
+
+    Raises
+    ______
+    ValueError
+        When the context contains a 'type' that doesn't exist.
+
+    """
+    ob, geom_type = _get_ob_from_context(context)
+    try:
+        shape_obj = TYPE_TO_SHAPE_MAP[geom_type](ob)
+    except KeyError:
         raise ValueError("Unknown geometry type: %s" % geom_type)
+    shape_obj.crs = _extract_crs(ob)
+    return shape_obj
+
 
 def asShape(context):
-    """Adapts the context to a geometry interface. The coordinates remain
-    stored in the context.
     """
-    if hasattr(context, "__geo_interface__"):
-        ob = context.__geo_interface__
-    else:
-        ob = context
+    Adapts the context to a geometry interface. The coordinates remain
+    stored in the context.
 
+    Parameters
+    ----------
+    context: dict like
+
+    Returns
+    -------
+    shapely object
+        Returns an appropriate shapely geometry class depending on context passed in.
+
+    Raises
+    ______
+
+    ValueError
+        When the context contains a 'type' that doesn't exist.
+    """
+    ob, geom_type = _get_ob_from_context(context)
     try:
-        geom_type = ob.get("type").lower()
-    except AttributeError:
-        raise ValueError("Context does not provide geo interface")
-
-    if geom_type == "point":
-        return asPoint(ob["coordinates"])
-    elif geom_type == "linestring":
-        return asLineString(ob["coordinates"])
-    elif geom_type == "polygon":
-        return asPolygon(ob["coordinates"][0], ob["coordinates"][1:])
-    elif geom_type == "multipoint":
-        return asMultiPoint(ob["coordinates"])
-    elif geom_type == "multilinestring":
-        return asMultiLineString(ob["coordinates"])
-    elif geom_type == "multipolygon":
-        return MultiPolygonAdapter(ob["coordinates"], context_type='geojson')
-    elif geom_type == "geometrycollection":
-        geoms = [asShape(g) for g in ob.get("geometries", [])]
-        return GeometryCollection(geoms)
-    else:
+        shape_obj = TYPE_TO_SHAPE_ADAPTER_MAP[geom_type](ob)
+    except KeyError:
         raise ValueError("Unknown geometry type: %s" % geom_type)
+    shape_obj.crs = _extract_crs(ob)
+    return shape_obj
+
 
 def mapping(ob):
-    """Returns a GeoJSON-like mapping"""
+    """
+    Returns a GeoJSON-like mapping
+
+    Parameters
+    ----------
+    ob
+
+    Returns
+    -------
+    dict
+        a dict following the `__geo_interface__` standard.
+
+    """
     return ob.__geo_interface__
+
+
+def make_point(ob):
+    return Point(ob['coordinates'])
+
+
+def make_linestring(ob):
+    return LineString(ob['coordinates'])
+
+
+def make_polygon(ob):
+    return Polygon(ob['coordinates'][0], ob['coordinates'][1:])
+
+
+def make_multipoint(ob):
+    return MultiPoint(ob['coordinates'])
+
+
+def make_multilinestring(ob):
+    return MultiLineString(ob['coordinates'])
+
+
+def make_multipolygon(ob):
+    return MultiPolygon(ob['coordinates'], context_type='geojson')
+
+
+def make_geometrycollection(ob):
+    geoms = [shape(g) for g in ob.get("geometries", [])]
+    return GeometryCollection(geoms)
+
+
+def make_point_adapter(ob):
+    return asPoint(ob['coordinates'])
+
+
+def make_linestring_adapter(ob):
+    return asLineString(ob['coordinates'])
+
+
+def make_polygon_adapter(ob):
+    return asPolygon(ob['coordinates'][0], ob['coordinates'][1:])
+
+
+def make_multipoint_adapter(ob):
+    return asMultiPoint(ob['coordinates'])
+
+
+def make_multilinestring_adapter(ob):
+    return asMultiLineString(ob['coordinates'])
+
+
+def make_multipolygon_adapter(ob):
+    return MultiPolygonAdapter(ob['coordinates'], context_type='geojson')
+
+
+def make_geometrycollection_adapter(ob):
+    geoms = [asShape(g) for g in ob.get("geometries", [])]
+    return GeometryCollection(geoms)
+
+
+TYPE_TO_SHAPE_MAP = {
+    'point': make_point,
+    'linestring': make_linestring,
+    'polygon': make_polygon,
+    'multipoint': make_multipoint,
+    'multilinestring': make_multilinestring,
+    'multipolygon': make_multipolygon,
+    'geometrycollection': make_geometrycollection,
+}
+
+TYPE_TO_SHAPE_ADAPTER_MAP = {
+    'point': make_point_adapter,
+    'linestring': make_linestring_adapter,
+    'polygon': make_polygon_adapter,
+    'multipoint': make_multipoint_adapter,
+    'multilinestring': make_multilinestring_adapter,
+    'multipolygon': make_multipolygon_adapter,
+    'geometrycollection': make_geometrycollection_adapter,
+}

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -26,7 +26,7 @@ class LineString(BaseGeometry):
     and need not be straight. Unlike a LinearRing, a LineString is not closed.
     """
 
-    def __init__(self, coordinates=None):
+    def __init__(self, coordinates=None, crs=None):
         """
         Parameters
         ----------
@@ -34,6 +34,8 @@ class LineString(BaseGeometry):
             A sequence of (x, y [,z]) numeric coordinate pairs or triples or
             an object that provides the numpy array interface, including
             another instance of LineString.
+        crs : dict
+            Optional dict containing coordinate reference system
 
         Example
         -------
@@ -43,16 +45,19 @@ class LineString(BaseGeometry):
           >>> a.length
           2.0
         """
-        BaseGeometry.__init__(self)
+        BaseGeometry.__init__(self, crs=crs)
         if coordinates is not None:
             self._set_coords(coordinates)
 
     @property
     def __geo_interface__(self):
-        return {
+        geom = {
             'type': 'LineString',
             'coordinates': tuple(self.coords)
-            }
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     def svg(self, scale_factor=1., stroke_color=None):
         """Returns SVG polyline element for the LineString geometry.

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -28,7 +28,7 @@ class MultiLineString(BaseMultipartGeometry):
         A sequence of LineStrings
     """
 
-    def __init__(self, lines=None):
+    def __init__(self, lines=None, crs=None):
         """
         Parameters
         ----------
@@ -36,6 +36,8 @@ class MultiLineString(BaseMultipartGeometry):
             A sequence of line-like coordinate sequences or objects that
             provide the numpy array interface, including instances of
             LineString.
+        crs : dict
+            Optional dict containing coordinate reference system
 
         Example
         -------
@@ -43,7 +45,7 @@ class MultiLineString(BaseMultipartGeometry):
 
           >>> lines = MultiLineString( [[[0.0, 0.0], [1.0, 2.0]]] )
         """
-        super(MultiLineString, self).__init__()
+        super(MultiLineString, self).__init__(crs=crs)
 
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling
@@ -56,10 +58,13 @@ class MultiLineString(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
-        return {
+        geom = {
             'type': 'MultiLineString',
             'coordinates': tuple(tuple(c for c in g.coords) for g in self.geoms)
-            }
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     def svg(self, scale_factor=1., stroke_color=None):
         """Returns a group of SVG polyline elements for the LineString geometry.

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -30,7 +30,7 @@ class MultiPoint(BaseMultipartGeometry):
         A sequence of Points
     """
 
-    def __init__(self, points=None):
+    def __init__(self, points=None, crs=None):
         """
         Parameters
         ----------
@@ -38,6 +38,8 @@ class MultiPoint(BaseMultipartGeometry):
             A sequence of (x, y [,z]) numeric coordinate pairs or triples or a
             sequence of objects that implement the numpy array interface,
             including instaces of Point.
+        crs : dict
+            Optional dict containing coordinate reference system
 
         Example
         -------
@@ -49,7 +51,7 @@ class MultiPoint(BaseMultipartGeometry):
           >>> type(ob.geoms[0]) == Point
           True
         """
-        super(MultiPoint, self).__init__()
+        super(MultiPoint, self).__init__(crs=crs)
 
         if points is None or len(points) == 0:
             # allow creation of empty multipoints, to support unpickling
@@ -62,10 +64,13 @@ class MultiPoint(BaseMultipartGeometry):
 
     @property
     def __geo_interface__(self):
-        return {
+        geom = {
             'type': 'MultiPoint',
             'coordinates': tuple([g.coords[0] for g in self.geoms])
-            }
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     def svg(self, scale_factor=1., fill_color=None):
         """Returns a group of SVG circle elements for the MultiPoint geometry.

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -29,7 +29,7 @@ class MultiPolygon(BaseMultipartGeometry):
         A sequence of `Polygon` instances
     """
 
-    def __init__(self, polygons=None, context_type='polygons'):
+    def __init__(self, polygons=None, context_type='polygons', crs=None):
         """
         Parameters
         ----------
@@ -37,6 +37,8 @@ class MultiPolygon(BaseMultipartGeometry):
             A sequence of (shell, holes) tuples where shell is the sequence
             representation of a linear ring (see linearring.py) and holes is
             a sequence of such linear rings
+        crs : dict
+            Optional dict containing coordinate reference system
 
         Example
         -------
@@ -53,7 +55,7 @@ class MultiPolygon(BaseMultipartGeometry):
           >>> type(ob.geoms[0]) == Polygon
           True
         """
-        super(MultiPolygon, self).__init__()
+        super(MultiPolygon, self).__init__(crs=crs)
 
         if not polygons:
             # allow creation of empty multipolygons, to support unpickling
@@ -70,15 +72,17 @@ class MultiPolygon(BaseMultipartGeometry):
     def __geo_interface__(self):
         allcoords = []
         for geom in self.geoms:
-            coords = []
-            coords.append(tuple(geom.exterior.coords))
+            coords = [tuple(geom.exterior.coords)]
             for hole in geom.interiors:
                 coords.append(tuple(hole.coords))
             allcoords.append(tuple(coords))
-        return {
+        geom = {
             'type': 'MultiPolygon',
             'coordinates': allcoords
-            }
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     def svg(self, scale_factor=1., fill_color=None):
         """Returns group of SVG path elements for the MultiPolygon geometry.

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -34,7 +34,7 @@ class Point(BaseGeometry):
       1.0
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         """
         Parameters
         ----------
@@ -43,8 +43,11 @@ class Point(BaseGeometry):
         1) 1 parameter: this must satisfy the numpy array protocol.
         2) 2 or more parameters: x, y, z : float
             Easting, northing, and elevation.
+
+        crs : dict
+            Optional dict containing coordinate reference system
         """
-        BaseGeometry.__init__(self)
+        BaseGeometry.__init__(self, **kwargs)
         if len(args) > 0:
             self._set_coords(*args)
 
@@ -69,10 +72,13 @@ class Point(BaseGeometry):
 
     @property
     def __geo_interface__(self):
-        return {
+        geom = {
             'type': 'Point',
             'coordinates': self.coords[0]
-            }
+        }
+        if self.crs is not None:
+            geom['crs'] = self.crs
+        return geom
 
     def svg(self, scale_factor=1., fill_color=None):
         """Returns SVG circle element for the Point geometry.

--- a/shapely/geometry/proxy.py
+++ b/shapely/geometry/proxy.py
@@ -1,7 +1,7 @@
 """Proxy for coordinates stored outside Shapely geometries
 """
 
-from shapely.geometry.base import deserialize_wkb, EMPTY
+from shapely.geometry.base import EMPTY
 from shapely.geos import lgeos
 
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -27,10 +27,13 @@ class CollectionTestCase(unittest.TestCase):
         self.assertIsNotNone(child.wkt)
 
     def test_geointerface(self):
-        d = {"type": "GeometryCollection","geometries": [
-                {"type": "Point", "coordinates": (0, 3)},
-                {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
-            ]}
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        d = {"type": "GeometryCollection",
+             "geometries": [
+                 {"type": "Point", "coordinates": (0, 3)},
+                 {"type": "LineString", "coordinates": ((2, 0), (1, 0))},
+             ],
+             'crs': crs_obj}
 
         # asShape
         m = asShape(d)
@@ -39,6 +42,8 @@ class CollectionTestCase(unittest.TestCase):
         geom_types = [g.geom_type for g in m.geoms]
         self.assertIn("Point", geom_types)
         self.assertIn("LineString", geom_types)
+        self.assertEqual(m.crs, crs_obj)
+        self.assertEqual(m.__geo_interface__, d)
 
         # shape
         m = shape(d)

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -10,10 +10,12 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
     def test_multilinestring(self):
 
         # From coordinate tuples
-        geom = MultiLineString((((1.0, 2.0), (3.0, 4.0)),))
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        geom = MultiLineString((((1.0, 2.0), (3.0, 4.0)),), crs=crs_obj)
         self.assertIsInstance(geom, MultiLineString)
         self.assertEqual(len(geom.geoms), 1)
         self.assertEqual(dump_coords(geom), [[(1.0, 2.0), (3.0, 4.0)]])
+        self.assertEqual(geom.crs, crs_obj)
 
         # From lines
         a = LineString(((1.0, 2.0), (3.0, 4.0)))

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -9,12 +9,14 @@ class MultiPointTestCase(MultiGeometryTestCase):
     def test_multipoint(self):
 
         # From coordinate tuples
-        geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)), crs=crs_obj)
         self.assertEqual(len(geom.geoms), 2)
         self.assertEqual(dump_coords(geom), [[(1.0, 2.0)], [(3.0, 4.0)]])
+        self.assertEqual(geom.crs, crs_obj)
 
         # From points
-        geom = MultiPoint((Point(1.0, 2.0), Point(3.0, 4.0)))
+        geom = MultiPoint((Point(1.0, 2.0), Point(3.0, 4.0)), crs=crs_obj)
         self.assertEqual(len(geom.geoms), 2)
         self.assertEqual(dump_coords(geom), [[(1.0, 2.0)], [(3.0, 4.0)]])
 
@@ -33,7 +35,9 @@ class MultiPointTestCase(MultiGeometryTestCase):
         # Geo interface
         self.assertEqual(geom.__geo_interface__,
                          {'type': 'MultiPoint',
-                          'coordinates': ((1.0, 2.0), (3.0, 4.0))})
+                          'coordinates': ((1.0, 2.0), (3.0, 4.0)),
+                          'crs': crs_obj,
+                          })
 
         # Adapt a coordinate list to a line string
         coords = [[5.0, 6.0], [7.0, 8.0]]

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -9,9 +9,10 @@ class MultiPolygonTestCase(MultiGeometryTestCase):
     def test_multipolygon(self):
 
         # From coordinate tuples
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
         geom = MultiPolygon(
             [(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
-              [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])])
+              [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])], crs=crs_obj)
         self.assertIsInstance(geom, MultiPolygon)
         self.assertEqual(len(geom.geoms), 1)
         self.assertEqual(
@@ -19,11 +20,12 @@ class MultiPolygonTestCase(MultiGeometryTestCase):
             [[(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0),
               [(0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25),
                (0.25, 0.25)]]])
+        self.assertEqual(geom.crs, crs_obj)
 
         # Or from polygons
         p = Polygon(((0, 0), (0, 1), (1, 1), (1, 0)),
                     [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])
-        geom = MultiPolygon([p])
+        geom = MultiPolygon([p], crs=crs_obj)
         self.assertEqual(len(geom.geoms), 1)
         self.assertEqual(
             dump_coords(geom),
@@ -57,7 +59,9 @@ class MultiPolygonTestCase(MultiGeometryTestCase):
              'coordinates': [(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0),
                                (1.0, 0.0), (0.0, 0.0)),
                               ((0.25, 0.25), (0.25, 0.5), (0.5, 0.5),
-                               (0.5, 0.25), (0.25, 0.25)))]})
+                               (0.5, 0.25), (0.25, 0.25)))],
+             'crs': crs_obj
+             })
 
         # Adapter
         coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -8,7 +8,8 @@ class LineStringTestCase(unittest.TestCase):
     def test_point(self):
 
         # Test 2D points
-        p = Point(1.0, 2.0)
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        p = Point(1.0, 2.0, crs=crs_obj)
         self.assertEqual(p.x, 1.0)
         self.assertEqual(p.y, 2.0)
         self.assertEqual(p.coords[:], [(1.0, 2.0)])
@@ -16,6 +17,7 @@ class LineStringTestCase(unittest.TestCase):
         self.assertFalse(p.has_z)
         with self.assertRaises(DimensionError):
             p.z
+        self.assertEqual(p.crs, crs_obj)
 
         # Check 3D
         p = Point(1.0, 2.0, 3.0)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -15,11 +15,13 @@ class PolygonTestCase(unittest.TestCase):
         # Initialization
         # Linear rings won't usually be created by users, but by polygons
         coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
-        ring = LinearRing(coords)
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        ring = LinearRing(coords, crs=crs_obj)
         self.assertEqual(len(ring.coords), 5)
         self.assertEqual(ring.coords[0], ring.coords[4])
         self.assertEqual(ring.coords[0], ring.coords[-1])
         self.assertTrue(ring.is_ring)
+        self.assertEqual(ring.crs, crs_obj)
 
         # Coordinate modification
         ring.coords = ((0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0))
@@ -27,7 +29,9 @@ class PolygonTestCase(unittest.TestCase):
             ring.__geo_interface__,
             {'type': 'LinearRing',
              'coordinates': ((0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0),
-                             (0.0, 0.0))})
+                             (0.0, 0.0)),
+             'crs': crs_obj,
+             })
 
         # Test ring adapter
         coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
@@ -42,8 +46,10 @@ class PolygonTestCase(unittest.TestCase):
                           (0.0, 0.0)])
 
         # Construct a polygon, exterior ring only
-        polygon = Polygon(coords)
+        crs_obj = {"type": "name", "properties": {"name": "epsg:4326"}}
+        polygon = Polygon(coords, crs=crs_obj)
         self.assertEqual(len(polygon.exterior.coords), 5)
+        self.assertEqual(polygon.crs, crs_obj)
 
         # Ring Access
         self.assertIsInstance(polygon.exterior, LinearRing)
@@ -92,7 +98,8 @@ class PolygonTestCase(unittest.TestCase):
             {'type': 'Polygon',
              'coordinates': (((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (2.0, -1.0),
                              (0.0, 0.0)), ((0.25, 0.25), (0.25, 0.5),
-                             (0.5, 0.5), (0.5, 0.25), (0.25, 0.25)))})
+                             (0.5, 0.5), (0.5, 0.25), (0.25, 0.25))),
+             })
 
         # Adapter
         hole_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]


### PR DESCRIPTION
If a CRS is present on the context object when using `shape` or `asShape`, let's just read in the CRS for them.
This also adds the CRS to the `__geo_interface__` property (if present).
There were also some code style / import fixes and some other pep8 stuff done to some of the files along the way.

Comments / concerns welcome!