### PR TITLE
Fix bad assert in test_numpy in test_linestring.py

### DIFF
--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -157,7 +157,7 @@ class LineStringTestCase(unittest.TestCase):
         # Test array interface of empty linestring
         le = LineString()
         a = asarray(le)
-        assert(a.shape[0], 0)
+        self.assertEqual(a.shape[0], 0)
 
 
 def test_suite():

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -60,17 +60,17 @@ class LineStringTestCase(unittest.TestCase):
     def test_equals_argument_order(self):
         """
         Test equals predicate functions correctly regardless of the order
-        of the inputs. See issue #317. 
+        of the inputs. See issue #317.
         """
         coords = ((0, 0), (1, 0), (1, 1), (0, 0))
         ls = LineString(coords)
         lr = LinearRing(coords)
-        
+
         self.assertFalse(ls.__eq__(lr))  # previously incorrectly returned True
         self.assertFalse(lr.__eq__(ls))
         self.assertFalse(ls == lr)
         self.assertFalse(lr == ls)
-        
+
         ls_clone = LineString(coords)
         lr_clone = LinearRing(coords)
 


### PR DESCRIPTION
Misuse of `assert` like a function resulted in a warning from pytest, this fixes it and also removes trailing whitespace from the file.