### PR TITLE
Add __repr__ to BaseGeometry

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -237,6 +237,10 @@ class BaseGeometry(object):
     def __str__(self):
         return self.wkt
 
+    def __repr__(self):
+        name = getattr(self.__class__, '__qualname__', self.__class__.__name__)
+        return '<{} object representing {}>'.format(name, self.wkt)
+
     # To support pickling
     def __reduce__(self):
         return (self.__class__, (), self.wkb)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -13,6 +13,7 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(p.y, 2.0)
         self.assertEqual(p.coords[:], [(1.0, 2.0)])
         self.assertEqual(str(p), p.wkt)
+        self.assertEqual(repr(p), '<Point object representing %s>' % p.wkt)
         self.assertFalse(p.has_z)
         with self.assertRaises(DimensionError):
             p.z
@@ -21,6 +22,7 @@ class LineStringTestCase(unittest.TestCase):
         p = Point(1.0, 2.0, 3.0)
         self.assertEqual(p.coords[:], [(1.0, 2.0, 3.0)])
         self.assertEqual(str(p), p.wkt)
+        self.assertEqual(repr(p), '<Point object representing %s>' % p.wkt)
         self.assertTrue(p.has_z)
         self.assertEqual(p.z, 3.0)
 


### PR DESCRIPTION
This adds a nice repr to BaseGeometry.  This is useful to me because I have unit tests that compare fairly large dicts that include Point or MultiPolygon objects; when some non-geometric object differs, unittest spits out a line-by-line diff of the repr of the dicts which points out "differences" between the geometric objects due to their different memory addresses.  This silences those false differences.

Using the wkt does make for an extra-large repr in some cases, but I haven't figured out a nice way to reduce that while still making it possible to tell whether two objects are equal by looking at their reprs.  If anyone has a better idea than using the wkt, I'd be happy to implement it :)