### PR TITLE
Prevent segfault when attempting to create LineString with only one coordinate tuple.

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -211,6 +211,10 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     if m == 0:
         return None
 
+    if m < 2:
+        raise ValueError(
+            "LineStrings must have at least 2 coordinate tuples")
+
     def _coords(o):
         if isinstance(o, Point):
             return o.coords[0]
@@ -250,7 +254,10 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     if update_geom is not None:
         return None
     else:
-        return lgeos.GEOSGeom_createLineString(cs), n
+        ptr = lgeos.GEOSGeom_createLineString(cs)
+        if not ptr:
+            raise ValueError("GEOSGeom_createLineString returned a NULL pointer")
+        return ptr, n
 
 
 def update_linestring_from_py(geom, ob):

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -149,6 +149,10 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         if m == 0:
             return None
 
+        if m < 2:
+            raise ValueError(
+                "LineStrings must have at least 2 coordinate tuples")
+
         def _coords(o):
             if isinstance(o, Point):
                 return o.coords[0]
@@ -193,7 +197,10 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
     if update_geom is not None:
         return None
     else:
-        return <uintptr_t>GEOSGeom_createLineString_r(handle, cs), n
+        g = GEOSGeom_createLineString_r(handle, cs);
+        if not g:
+            raise ValueError("GEOSGeom_createLineString_r returned a NULL pointer")
+        return <uintptr_t>g, n
 
 
 def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
@@ -370,7 +377,10 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
     if update_geom is not None:
         return None
     else:
-        return <uintptr_t>GEOSGeom_createLinearRing_r(handle, cs), n
+        g = GEOSGeom_createLinearRing_r(handle, cs)
+        if not g:
+            raise ValueError("GEOSGeom_createLinearRing_r returned a NULL pointer")
+        return <uintptr_t>g, n
 
 
 def coordseq_ctypes(self):

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -1,4 +1,5 @@
 from . import unittest, numpy
+import pytest
 from shapely.geos import lgeos
 from shapely.geometry import LineString, asLineString, Point, LinearRing
 
@@ -107,6 +108,13 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(copy.coords[:], coords)
         self.assertEqual('LineString',
                          lgeos.GEOSGeomType(copy._geom).decode('ascii'))
+
+    def test_from_single_coordinate(self):
+        """Test for issue #486"""
+        coords = [[-122.185933073564, 37.3629353839073]]
+        with pytest.raises(ValueError):
+            ls = LineString(coords)
+            ls.geom_type # caused segfault before fix
 
 
     @unittest.skipIf(not numpy, 'Numpy required')


### PR DESCRIPTION
Prevent segfault when attempting to create LineString with only one coordinate tuple.

Added a specific check for inputs with len() < 2, but also added
a more generic catch for createLineString/LinearRing returning
a NULL pointer.

Closes #486. Credit to @clement-tourriere for an excellent report.