### PR TITLE
Build docs on Read the Docs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,5 @@ dependencies:
 - python>=3.5
 - cython
 - geos>=3.3
+- matplotlib
 - numpy>=1.9

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - python>=3.5
 - cython
+- descartes
 - geos>=3.3
 - matplotlib
 - numpy>=1.9

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: _shapely
+channels:
+- defaults
+- conda-forge
+dependencies:
+- python>=3.5
+- cython
+- geos>=3.3
+- numpy>=1.9

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+python:
+  version: 3
+  pip_install: true
+conda:
+  file: environment.yml


### PR DESCRIPTION
In the same spirit as https://github.com/Toblerity/Fiona/pull/466 and encouraged by the discussion on https://github.com/Toblerity/Fiona/issues/258, I made a similar pull request to build Shapely docs on Read the Docs. You can see the result here:

http://juanlu001-shapely.readthedocs.io/en/latest/

Closes #337.