### PR TITLE
Remove some unused imports

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -6,7 +6,7 @@ import sys
 if sys.version_info[0] < 3:
     range = xrange
 
-from ctypes import c_double, cast, POINTER
+from ctypes import c_double
 
 from shapely.geos import lgeos, TopologicalError
 from shapely.geometry.base import (

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -6,7 +6,7 @@ import sys
 if sys.version_info[0] < 3:
     range = xrange
 
-from ctypes import c_double, c_void_p, cast, POINTER
+from ctypes import c_void_p, cast
 
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -6,8 +6,7 @@ import sys
 if sys.version_info[0] < 3:
     range = xrange
 
-from ctypes import byref, c_double, c_void_p, cast, POINTER
-from ctypes import ArgumentError
+from ctypes import byref, c_double, c_void_p, cast
 
 from shapely.geos import lgeos
 from shapely.geometry.base import (

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -2,7 +2,6 @@
 """
 
 from ctypes import c_double
-from ctypes import cast, POINTER
 
 from shapely.errors import DimensionError
 from shapely.geos import lgeos

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -6,8 +6,7 @@ import sys
 if sys.version_info[0] < 3:
     range = xrange
 
-from ctypes import c_double, c_void_p, cast, POINTER
-from ctypes import ArgumentError
+from ctypes import c_void_p, cast, POINTER
 import weakref
 
 from shapely.algorithms.cga import signed_area

--- a/shapely/geometry/proxy.py
+++ b/shapely/geometry/proxy.py
@@ -1,7 +1,7 @@
 """Proxy for coordinates stored outside Shapely geometries
 """
 
-from shapely.geometry.base import deserialize_wkb, EMPTY
+from shapely.geometry.base import EMPTY
 from shapely.geos import lgeos
 
 

--- a/shapely/iterops.py
+++ b/shapely/iterops.py
@@ -2,7 +2,6 @@
 Iterative forms of operations
 """
 
-from shapely.geos import PredicateError
 from shapely.topology import Delegating
 
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -13,7 +13,7 @@ from ctypes import byref, c_void_p, c_double
 from shapely.geos import lgeos
 from shapely.geometry.base import geom_factory, BaseGeometry
 from shapely.geometry import asShape, asLineString, asMultiLineString, Point, MultiPoint,\
-                             LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection
+                             LineString, MultiLineString, Polygon, GeometryCollection
 from shapely.algorithms.polylabel import polylabel
 
 __all__ = ['cascaded_union', 'linemerge', 'operator', 'polygonize',

--- a/shapely/predicates.py
+++ b/shapely/predicates.py
@@ -2,7 +2,7 @@
 Support for GEOS spatial predicates
 """
 
-from shapely.geos import PredicateError, TopologicalError
+from shapely.geos import PredicateError
 from shapely.topology import Delegating
 
 

--- a/shapely/validation.py
+++ b/shapely/validation.py
@@ -1,7 +1,5 @@
 # TODO: allow for implementations using other than GEOS
 
-import sys
-
 from shapely.geos import lgeos
 
 def explain_validity(ob):


### PR DESCRIPTION
Thank you for this incredibly useful module! `shapely` is as fun to use as it is powerful.

I was reading through the source code tonight to try to gain a deeper understanding of what's going on, and found a few unused imports in some modules. Please consider this PR to remove them.