### PR TITLE
Add EmptyGeometry class

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -943,6 +943,12 @@ class HeterogeneousGeometrySequence(GeometrySequence):
         return g
 
 
+class EmptyGeometry(BaseGeometry):
+    def __init__(self):
+        """Create an empty geometry."""
+        BaseGeometry.__init__(self)
+
+
 def _test():
     """Test runner"""
     import doctest

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -1,11 +1,15 @@
 from . import unittest
-from shapely.geometry.base import BaseGeometry
+from shapely.geometry.base import BaseGeometry, EmptyGeometry
 import shapely.geometry as sgeom
 from shapely.geometry.polygon import LinearRing
 
 empty_generator = lambda: iter([])
 
 class EmptinessTestCase(unittest.TestCase):
+
+    def test_empty_class(self):
+        g = EmptyGeometry()
+        self.assertTrue(g._is_empty)
 
     def test_empty_base(self):
         g = BaseGeometry()


### PR DESCRIPTION
This provides an explicit means of creating an empty geometry object. Motivated by desire for a clear empty geometry type to use in na operations in geopandas. Thanks @sgillies for laying this out in #513, and @jorisvandenbossche for motivation in #510.

I went with `EmptyGeometry`, rather than `Empty`, thinking it made the context slightly clearer when used outside of `shapely`. I created an `__init__` mainly for the docstring, while retaining the `BaseGeometry` docstring for the class; maybe that's not necessary though?