### PR TITLE
Fix finding libgeos on windows in pyinstaller frozen application

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -129,7 +129,9 @@ elif sys.platform == 'win32':
         try:
             egg_dlls = os.path.abspath(
                 os.path.join(os.path.dirname(__file__), 'DLLs'))
-            if hasattr(sys, "frozen"):
+            if hasattr(sys, '_MEIPASS'):
+                wininst_dlls = sys._MEIPASS
+            elif hasattr(sys, "frozen"):
                 wininst_dlls = os.path.normpath(
                     os.path.abspath(sys.executable + '../../DLLS'))
             else:


### PR DESCRIPTION
In a PyInstaller frozen application the libraries are placed in the same directory as the main executable (`bin`). PyInstaller creates a `sys._MEIPASS` attribute to point to this directory. Without this change running an application from anywhere other than the `bin` directory results in an exception for not finding the geos library.

I previously thought fixing this would require a change to @ocefpaf's conda-based changes in #521 but it seems like `CONDA_PREFIX` isn't set in a pyinstaller frozen application.