### PR TITLE
Fix user manual (geometry.Polygon)

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -442,7 +442,7 @@ constructor parameter.
 Polygons
 --------
 
-.. class:: Polygon(exterior [,interiors=None])
+.. class:: Polygon(shell [,holes=None])
 
   The `Polygon` constructor takes two positional parameters. The first is an
   ordered sequence of ``(x, y[, z])`` point tuples and is treated exactly as in


### PR DESCRIPTION
Connected to #526 and #500
Here I fix the wrong definition of the Polygon constructor in the user manual.

Also, the documentation about the "Attributes" (https://github.com/Toblerity/Shapely/blob/master/shapely/geometry/polygon.py#L196) seems to me a bit unclear and redundant with the user manual. However I don't know the policy of this repo about documentation.