### PR TITLE
Fix for #524, splitting closed ring with starting point

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -257,7 +257,7 @@ def transform(func, geom):
 
 def nearest_points(g1, g2):
     """Returns the calculated nearest points in the input geometries
-    
+
     The points are returned in the same order as the input geometries.
     """
     seq = lgeos.methods['nearest_points'](g1._geom, g2._geom)
@@ -339,21 +339,21 @@ class SplitOp(object):
         union = poly.boundary.union(splitter)
 
         # some polygonized geometries may be holes, we do not want them
-        # that's why we test if the original polygon (poly) contains 
+        # that's why we test if the original polygon (poly) contains
         # an inner point of polygonized geometry (pg)
         return [pg for pg in polygonize(union) if poly.contains(pg.representative_point())]
 
     @staticmethod
     def _split_line_with_line(line, splitter):
         """Split a LineString with another (Multi)LineString or (Multi)Polygon"""
-        
+
         # if splitter is a polygon, pick it's boundary
         if splitter.type in ('Polygon', 'MultiPolygon'):
             splitter = splitter.boundary
 
         assert(isinstance(line, LineString))
         assert(isinstance(splitter, LineString) or isinstance(splitter, MultiLineString))
-        
+
         if splitter.crosses(line):
             # The lines cross --> return multilinestring from the split
             return line.difference(splitter)
@@ -364,7 +364,7 @@ class SplitOp(object):
             # The lines do not cross --> return collection with identity line
             return [line]
 
-    @staticmethod  
+    @staticmethod
     def _split_line_with_point(line, splitter):
         """Split a LineString with a Point"""
 
@@ -374,9 +374,12 @@ class SplitOp(object):
         # check if point is in the interior of the line
         if not line.relate_pattern(splitter, '0********'):
             # point not on line interior --> return collection with single identity line
-            # (REASONING: Returning a list with the input line reference and creating a 
-            # GeometryCollection at the general split function prevents unnecessary copying 
+            # (REASONING: Returning a list with the input line reference and creating a
+            # GeometryCollection at the general split function prevents unnecessary copying
             # of linestrings in multipoint splitting function)
+            return [line]
+        elif line.coords[0] == splitter.coords[0]:
+            # if line is a closed ring the previous test doesn't behave as desired
             return [line]
 
         # point is on line, get the distance from the first point on line
@@ -388,7 +391,7 @@ class SplitOp(object):
             pd = line.project(Point(p))
             if pd == distance_on_line:
                 return [
-                    LineString(coords[:i+1]), 
+                    LineString(coords[:i+1]),
                     LineString(coords[i:])
                 ]
             elif distance_on_line < pd:
@@ -414,9 +417,9 @@ class SplitOp(object):
                 # add the newly split 2 lines or the same line if not split
                 new_chunks.extend(SplitOp._split_line_with_point(chunk, pt))
             chunks = new_chunks
-        
+
         return chunks
-    
+
     @staticmethod
     def split(geom, splitter):
         """

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -7,7 +7,7 @@ from shapely.ops import cascaded_union, linemerge
 
 class TestSplitGeometry(unittest.TestCase):
 	# helper class for testing below
-	def helper(self, geom, splitter, expected_chunks):	
+	def helper(self, geom, splitter, expected_chunks):
 		s = split(geom, splitter)
 		self.assertEqual(s.type, "GeometryCollection")
 		self.assertEqual(len(s), expected_chunks)
@@ -91,10 +91,17 @@ class TestSplitLine(TestSplitGeometry):
 		splitter = MultiPoint([(1, 1), (1.5, 1.5), (1, 1)])
 		self.helper(self.ls, splitter, 3)
 
+	def test_split_closed_line_with_point(self):
+		# point at start/end of closed ring -> return equal
+		# see GH #524
+		ls = LineString([(0,0), (0, 1), (1, 1), (1, 0), (0, 0)])
+		splitter = Point(0, 0)
+		self.helper(ls, splitter, 1)
+
 	def test_split_line_with_line(self):
 		# crosses at one point --> return 2 segments
 		splitter = LineString([(0, 1), (1, 0)])
-		self.helper(self.ls, splitter, 2)	
+		self.helper(self.ls, splitter, 2)
 
 		# crosses at two points --> return 3 segments
 		splitter = LineString([(0, 1), (1, 0), (1, 2)])
@@ -117,7 +124,7 @@ class TestSplitLine(TestSplitGeometry):
 	def test_split_line_with_multiline(self):
 		# crosses at one point --> return 2 segments
 		splitter = MultiLineString([[(0, 1), (1, 0)], [(0, 0), (2, -2)]])
-		self.helper(self.ls, splitter, 2)	
+		self.helper(self.ls, splitter, 2)
 
 		# crosses at two points --> return 3 segments
 		splitter = MultiLineString([[(0, 1), (1, 0)], [(0, 2), (2, 0)]])
@@ -158,7 +165,7 @@ class TestSplitLine(TestSplitGeometry):
 		self.helper(self.ls, splitter, 4)
 
 class TestSplitMulti(TestSplitGeometry):
-	
+
 	def test_split_multiline_with_point(self):
 		# a cross-like multilinestring with a point in the middle --> return 4 line segments
 		l1 = LineString([(0, 1), (2, 1)])
@@ -166,26 +173,26 @@ class TestSplitMulti(TestSplitGeometry):
 		ml = MultiLineString([l1, l2])
 		splitter = Point((1, 1))
 		self.helper(ml, splitter, 4)
-		
+
 	def test_split_multiline_with_multipoint(self):
-		# a cross-like multilinestring with a point in middle, a point on one of the lines and a point in the exterior 
+		# a cross-like multilinestring with a point in middle, a point on one of the lines and a point in the exterior
 		# --> return 4+1 line segments
 		l1 = LineString([(0, 1), (3, 1)])
 		l2 = LineString([(1, 0), (1, 2)])
 		ml = MultiLineString([l1, l2])
 		splitter = MultiPoint([(1, 1), (2, 1), (4, 2)])
 		self.helper(ml, splitter, 5)
-				
+
 	def test_split_multipolygon_with_line(self):
 		# two polygons with a crossing line --> return 4 triangles
-		poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]) 
+		poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
 		poly2 = Polygon([(1, 1), (1, 2), (2, 2), (2, 1), (1, 1)])
 		mpoly = MultiPolygon([poly1, poly2])
 		ls = LineString([(-1, -1), (3, 3)])
 		self.helper(mpoly, ls, 4)
 
 		# two polygons away from the crossing line --> return identity
-		poly1 = Polygon([(10, 10), (10, 11), (11, 11), (11, 10), (10, 10)]) 
+		poly1 = Polygon([(10, 10), (10, 11), (11, 11), (11, 10), (10, 10)])
 		poly2 = Polygon([(-10, -10), (-10, -11), (-11, -11), (-11, -10), (-10, -10)])
 		mpoly = MultiPolygon([poly1, poly2])
 		ls = LineString([(-1, -1), (3, 3)])


### PR DESCRIPTION
This PR fixes an issue identified in #524.

Test case here: https://github.com/Toblerity/Shapely/compare/master...snorfalorpagus:fix524?expand=1#diff-5f3469e182096a44abd37c7568afc200R94

Fix here: https://github.com/Toblerity/Shapely/compare/master...snorfalorpagus:fix524?expand=1#diff-2e25b147950af44f159ee507a4dee69dR381

I'm not 100% sure why this works...