### PR TITLE
Don't double-free in STRtree's __del__ if it is called multiple times.

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -38,7 +38,9 @@ class STRtree:
             lgeos.GEOSSTRtree_insert(self._tree_handle, geom._geom, ctypes.py_object(geom))
 
     def __del__(self):
-        lgeos.GEOSSTRtree_destroy(self._tree_handle)
+        if self._tree_handle is not None:
+            lgeos.GEOSSTRtree_destroy(self._tree_handle)
+            self._tree_handle = None
 
     def query(self, geom):
         if self._n_geoms == 0:


### PR DESCRIPTION
There are some circumstances in which CPython can call `__del__` on an object twice. For me, that was happening when running a script under [`python-flamegraph`](https://github.com/evanhempel/python-flamegraph). This is because it runs a separate thread which is walking the stack, causing it to keep a reference to the `STRtree` object and attempt to delete it twice.