### PR TITLE
Fixed bug in unpickling of LinearRing. Closes #547.

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -71,6 +71,15 @@ class LinearRing(LineString):
 
     coords = property(_get_coords, _set_coords)
 
+    def __setstate__(self, state):
+        """WKB doesn't differentiate between LineString and LinearRing so we
+        need to move the coordinate sequence into the correct geometry type"""
+        super(LinearRing, self).__setstate__(state)
+        cs = lgeos.GEOSGeom_getCoordSeq(self.__geom__)
+        cs_clone = lgeos.GEOSCoordSeq_clone(cs)
+        lgeos.GEOSGeom_destroy(self.__geom__)
+        self.__geom__ = lgeos.GEOSGeom_createLinearRing(cs_clone)
+
     @property
     def is_ccw(self):
         """True is the ring is oriented counter clock-wise"""


### PR DESCRIPTION
This PR fixes the issue identified in #547.

Geometries are pickled using the WKB format, which does not differentiate between LINESTRING and LINEARRING objects. When a LinearRing is pickled/unpickled the result is a Shapely LinearRing with a GEOS LineString inside, which can lead to issues later. This change works around the problem by copying the coordinate sequence of the geometry after it's read from WKB into the correct geometry type. It's slightly frustrating that we have to clone the sequence, but it's required due to GEOS's ownership model.