### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ addons:
       - libgeos-dev
 
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then pip install unittest2; fi
   - pip install pip setuptools --upgrade
   # if building with speedups install cython
   - if [ "$SPEEDUPS" == "1" ]; then pip install --install-option="--no-cython-compile" cython; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ matrix:
         - SPEEDUPS=0
         - NUMPY=0
 
-    - python: "3.3"
-      env:
-        - SPEEDUPS=1
-        - NUMPY=1
-    - python: "3.3"
-      env:
-        - SPEEDUPS=0
-        - NUMPY=1
-
     - python: "3.4"
       env:
         - SPEEDUPS=1

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Requirements
 
 Shapely 1.6 requires
 
-* Python >=2.6 (including Python 3.x)
+* Python >=2.7 (including Python 3.x)
 * GEOS >=3.3 
 
 Installing Shapely 1.6

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Requirements
 
 Shapely 1.6 requires
 
-* Python >=2.7 (including Python 3.x)
+* Python 2.7, >=3.4
 * GEOS >=3.3 
 
 Installing Shapely 1.6

--- a/_vendor/packaging/markers.py
+++ b/_vendor/packaging/markers.py
@@ -149,7 +149,7 @@ def _format_marker(marker, first=True):
         else:
             return "(" + " ".join(inner) + ")"
     elif isinstance(marker, tuple):
-        return '{0} {1} "{2}"'.format(*marker)
+        return '{} {} "{}"'.format(*marker)
     else:
         return marker
 

--- a/_vendor/packaging/requirements.py
+++ b/_vendor/packaging/requirements.py
@@ -110,16 +110,16 @@ class Requirement(object):
         parts = [self.name]
 
         if self.extras:
-            parts.append("[{0}]".format(",".join(sorted(self.extras))))
+            parts.append("[{}]".format(",".join(sorted(self.extras))))
 
         if self.specifier:
             parts.append(str(self.specifier))
 
         if self.url:
-            parts.append("@ {0}".format(self.url))
+            parts.append("@ {}".format(self.url))
 
         if self.marker:
-            parts.append("; {0}".format(self.marker))
+            parts.append("; {}".format(self.marker))
 
         return "".join(parts)
 

--- a/_vendor/packaging/specifiers.py
+++ b/_vendor/packaging/specifiers.py
@@ -82,7 +82,7 @@ class _IndividualSpecifier(BaseSpecifier):
     def __init__(self, spec="", prereleases=None):
         match = self._regex.search(spec)
         if not match:
-            raise InvalidSpecifier("Invalid specifier: '{0}'".format(spec))
+            raise InvalidSpecifier("Invalid specifier: '{}'".format(spec))
 
         self._spec = (
             match.group("operator").strip(),
@@ -106,7 +106,7 @@ class _IndividualSpecifier(BaseSpecifier):
         )
 
     def __str__(self):
-        return "{0}{1}".format(*self._spec)
+        return "{}{}".format(*self._spec)
 
     def __hash__(self):
         return hash(self._spec)
@@ -134,7 +134,7 @@ class _IndividualSpecifier(BaseSpecifier):
         return self._spec != other._spec
 
     def _get_operator(self, op):
-        return getattr(self, "_compare_{0}".format(self._operators[op]))
+        return getattr(self, "_compare_{}".format(self._operators[op]))
 
     def _coerce_version(self, version):
         if not isinstance(version, (LegacyVersion, Version)):

--- a/_vendor/packaging/version.py
+++ b/_vendor/packaging/version.py
@@ -79,7 +79,7 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     def __repr__(self):
-        return "<LegacyVersion({0})>".format(repr(str(self)))
+        return "<LegacyVersion({})>".format(repr(str(self)))
 
     @property
     def public(self):
@@ -199,7 +199,7 @@ class Version(_BaseVersion):
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:
-            raise InvalidVersion("Invalid version: '{0}'".format(version))
+            raise InvalidVersion("Invalid version: '{}'".format(version))
 
         # Store the parsed out pieces of the version
         self._version = _Version(
@@ -231,14 +231,14 @@ class Version(_BaseVersion):
         )
 
     def __repr__(self):
-        return "<Version({0})>".format(repr(str(self)))
+        return "<Version({})>".format(repr(str(self)))
 
     def __str__(self):
         parts = []
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append("{}!".format(self._version.epoch))
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))
@@ -249,16 +249,16 @@ class Version(_BaseVersion):
 
         # Post-release
         if self._version.post is not None:
-            parts.append(".post{0}".format(self._version.post[1]))
+            parts.append(".post{}".format(self._version.post[1]))
 
         # Development release
         if self._version.dev is not None:
-            parts.append(".dev{0}".format(self._version.dev[1]))
+            parts.append(".dev{}".format(self._version.dev[1]))
 
         # Local version segment
         if self._version.local is not None:
             parts.append(
-                "+{0}".format(".".join(str(x) for x in self._version.local))
+                "+{}".format(".".join(str(x) for x in self._version.local))
             )
 
         return "".join(parts)
@@ -273,7 +273,7 @@ class Version(_BaseVersion):
 
         # Epoch
         if self._version.epoch != 0:
-            parts.append("{0}!".format(self._version.epoch))
+            parts.append("{}!".format(self._version.epoch))
 
         # Release segment
         parts.append(".".join(str(x) for x in self._version.release))

--- a/setup.py
+++ b/setup.py
@@ -212,9 +212,13 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering :: GIS',
     ],
     cmdclass           = {},
@@ -233,9 +237,6 @@ if sys.platform == 'win32':
             raise
     if '(AMD64)' in sys.version:
         for dll in glob.glob('DLLs_AMD64_VC9/*.dll'):
-            shutil.copy(dll, 'shapely/DLLs')
-    elif sys.version_info[0:2] == (2, 5):
-        for dll in glob.glob('DLLs_x86_VC7/*.dll'):
             shutil.copy(dll, 'shapely/DLLs')
     else:
         for dll in glob.glob('DLLs_x86_VC9/*.dll'):
@@ -275,8 +276,8 @@ if geos_version and geos_config:
 
 # Optional compilation of speedups
 # setuptools stuff from Bob Ippolito's simplejson project
-if sys.platform == 'win32' and sys.version_info > (2, 6):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
+if sys.platform == 'win32':
+    # distutils.msvc9compiler can raise an IOError when failing to
     # find the compiler
     ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
                   IOError)
@@ -306,9 +307,7 @@ def construct_build_ext(build_ext):
 
     return WrappedBuildExt
 
-if (hasattr(platform, 'python_implementation')
-        and platform.python_implementation() == 'PyPy'):
-    # python_implementation is only available since 2.6
+if (platform.python_implementation() == 'PyPy'):
     ext_modules = []
     libraries = []
 

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,6 @@ setup_args = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -157,7 +157,7 @@ def load_dll(libname, fallbacks=None):
     else:
         # No shared library was loaded. Raise OSError.
         raise OSError(
-            "Could not find library {0} or load any of its variants {1}".format(
+            "Could not find library {} or load any of its variants {}".format(
                 libname, fallbacks or []))
 
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -409,8 +409,8 @@ class BaseGeometry(object):
                 scale_factor = max([dx, dy]) / max([width, height])
             except ZeroDivisionError:
                 scale_factor = 1.
-            view_box = "{0} {1} {2} {3}".format(xmin, ymin, dx, dy)
-            transform = "matrix(1,0,0,-1,0,{0})".format(ymax + ymin)
+            view_box = "{} {} {} {}".format(xmin, ymin, dx, dy)
+            transform = "matrix(1,0,0,-1,0,{})".format(ymax + ymin)
             return svg_top + (
                 'width="{1}" height="{2}" viewBox="{0}" '
                 'preserveAspectRatio="xMinYMin meet">'

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -69,7 +69,7 @@ class LineString(BaseGeometry):
             return '<g />'
         if stroke_color is None:
             stroke_color = "#66cc99" if self.is_valid else "#ff3333"
-        pnt_format = " ".join(["{0},{1}".format(*c) for c in self.coords])
+        pnt_format = " ".join(["{},{}".format(*c) for c in self.coords])
         return (
             '<polyline fill="none" stroke="{2}" stroke-width="{1}" '
             'points="{0}" opacity="0.8" />'

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -337,12 +337,12 @@ class Polygon(BaseGeometry):
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
         exterior_coords = [
-            ["{0},{1}".format(*c) for c in self.exterior.coords]]
+            ["{},{}".format(*c) for c in self.exterior.coords]]
         interior_coords = [
-            ["{0},{1}".format(*c) for c in interior.coords]
+            ["{},{}".format(*c) for c in interior.coords]
             for interior in self.interiors]
         path = " ".join([
-            "M {0} L {1} z".format(coords[0], " L ".join(coords[1:]))
+            "M {} L {} z".format(coords[0], " L ".join(coords[1:]))
             for coords in exterior_coords + interior_coords])
         return (
             '<path fill-rule="evenodd" fill="{2}" stroke="#555555" '

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -52,7 +52,7 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
     else:
         # No shared library was loaded. Raise OSError.
         raise OSError(
-            "Could not find lib {0} or load any of its variants {1}.".format(
+            "Could not find lib {} or load any of its variants {}.".format(
                 libname, fallbacks or []))
 
 _lgeos = None
@@ -547,7 +547,7 @@ def errcheck_null_exception(result, func, argtuple):
     """
     if not result:
         raise TopologicalError(
-            "The operation '{0}' could not be performed."
+            "The operation '{}' could not be performed."
             "Likely cause is invalidity of the geometry.".format(
                 func.__name__))
     return errcheck_just_free(result, func, argtuple)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import unittest
 
 from shapely.geos import geos_version_string, lgeos, WKTWriter
 from shapely import speedups
@@ -23,8 +24,3 @@ print('Cython speedups: ' + str(speedups.available))
 if lgeos.geos_version >= (3, 3, 0):
     # Remove any WKT writer defaults to pass tests for all versions of GEOS
     WKTWriter.defaults = {}
-
-if sys.version_info[0:2] <= (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest

--- a/tests/test_delaunay.py
+++ b/tests/test_delaunay.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from shapely.geometry import Polygon, LineString, Point
 from shapely.ops import triangulate


### PR DESCRIPTION
Python 2.6 was already removed (see https://github.com/Toblerity/Shapely/issues/432 and https://github.com/Toblerity/Shapely/pull/433), this removes some redundant 2.6 code, and adds use of automatic formatters which are available since Python 2.7.

https://github.com/Toblerity/Shapely/issues/432 also mentions Python 3.3 is coming up to EOL, and since 2017-09-29 it now is EOL. So remove that too.

https://devguide.python.org/#status-of-python-branches

As a check, here's the pip installs for Shapely from PyPI for last month, showing very little use with 2.6 and 3.3:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.5            |  72.37% |        390,258 |
| 2.7            |  23.32% |        125,757 |
| 3.6            |   2.73% |         14,735 |
| 3.4            |   1.55% |          8,340 |
| 2.6            |   0.02% |            114 |
| 3.7            |   0.01% |             41 |
| 3.3            |   0.00% |             15 |
| 3.2            |   0.00% |              3 |

Source: `pypinfo --start-date -32 --end-date -5 --percent --pip --markdown Shapely pyversion`

(Great to see over 75% are already on Python 3!)