### PR TITLE
shape() method can parse empty geojson

### DIFF
--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -32,7 +32,10 @@ def shape(context):
     elif geom_type == "linestring":
         return LineString(ob["coordinates"])
     elif geom_type == "polygon":
-        return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
+        try:
+            return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
+        except IndexError:
+            return Polygon()
     elif geom_type == "multipoint":
         return MultiPoint(ob["coordinates"])
     elif geom_type == "multilinestring":

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -32,10 +32,10 @@ def shape(context):
     elif geom_type == "linestring":
         return LineString(ob["coordinates"])
     elif geom_type == "polygon":
-        try:
-            return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
-        except IndexError:
+        if not ob["coordinates"]:
             return Polygon()
+        else:
+            return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
     elif geom_type == "multipoint":
         return MultiPoint(ob["coordinates"])
     elif geom_type == "multilinestring":

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -8,7 +8,7 @@ class MappingTestCase(unittest.TestCase):
         self.assertEqual(m['type'], 'Point')
         self.assertEqual(m['coordinates'], (0.0, 0.0))
         
-    def test_empty_polygon():
+    def test_empty_polygon(self):
         """Empty polygons will round trip without error"""
         self.assertIsNotNone(mapping(Polygon()))
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,6 +1,5 @@
 from . import unittest
-from shapely.geometry import Point, mapping
-
+from shapely.geometry import Point, mapping, Polygon
 
 class MappingTestCase(unittest.TestCase):
     def test_point(self):


### PR DESCRIPTION
In the current code, if you try to save and parse an empty polygon, the shape() method will result in an IndexError.

```python
from shapely.geometry import Polygon, shape, mapping
shape(mapping(Polygon()))

Traceback (most recent call last):
  File "...", line 2910, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-305ea9043881>", line 1, in <module>
    shape(mapping(Polygon()))
  File ".../python3.5/site-packages/shapely/geometry/geo.py", line 35, in shape
    return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
IndexError: tuple index out of range 
```

This pull request aim to resolve this issue with a simple Try/Except