### PR TITLE
Added GEOSClipByRect / shapely.ops.clip_by_rect

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -210,6 +210,10 @@ def prototype(lgeos, geos_version):
     lgeos.GEOSGetCentroid.restype = c_void_p
     lgeos.GEOSGetCentroid.argtypes = [c_void_p]
 
+    if geos_version >= (3, 5, 0):
+        lgeos.GEOSClipByRect.restype = c_void_p
+        lgeos.GEOSClipByRect.argtypes = [c_void_p, c_double, c_double, c_double, c_double]
+
     lgeos.GEOSPolygonize.restype = c_void_p
     lgeos.GEOSPolygonize.argtypes = [c_void_p, c_uint]
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -837,7 +837,18 @@ class LGEOS340(LGEOS330):
         self.methods['nearest_points'] = self.GEOSNearestPoints
 
 
-if geos_version >= (3, 4, 0):
+class LGEOS350(LGEOS340):
+    """Proxy for GEOS 3.5.0-CAPI-1.9.0
+    """
+    
+    def __init__(self, dll):
+        super(LGEOS350, self).__init__(dll)
+        self.methods['clip_by_rect'] = self.GEOSClipByRect
+
+
+if geos_version >= (3, 5, 0):
+    L = LGEOS350
+elif geos_version >= (3, 4, 0):
     L = LGEOS340
 elif geos_version >= (3, 3, 0):
     L = LGEOS330

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -531,3 +531,13 @@ def substring(geom, start_dist, end_dist, normalized=False):
         vertex_list = reversed(vertex_list)
 
     return LineString(vertex_list)
+
+
+def clip_by_rect(geom, xmin, ymin, xmax, ymax):
+    """
+    TODO: docstring
+    """
+    if geom.is_empty:
+        return geom
+    result = geom_factory(lgeos.methods['clip_by_rect'](geom._geom, xmin, ymin, xmax, ymax))
+    return result

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -534,8 +534,29 @@ def substring(geom, start_dist, end_dist, normalized=False):
 
 
 def clip_by_rect(geom, xmin, ymin, xmax, ymax):
-    """
-    TODO: docstring
+    """Returns the portion of a geometry within a rectangle
+
+    The geometry is clipped in a fast but possibly dirty way. The output is
+    not guaranteed to be valid. No exceptions will be raised for topological
+    errors.
+
+    Parameters
+    ----------
+    geom : geometry
+        The geometry to be clipped
+    xmin : float
+        Minimum x value of the rectangle
+    ymin : float
+        Minimum y value of the rectangle
+    xmax : float
+        Maximum x value of the rectangle
+    ymax : float
+        Maximum y value of the rectangle
+
+    Notes
+    -----
+    Requires GEOS >= 3.5.0
+    New in 1.7.
     """
     if geom.is_empty:
         return geom

--- a/tests/test_clip_by_rect.py
+++ b/tests/test_clip_by_rect.py
@@ -1,0 +1,109 @@
+"""
+Tests for GEOSClipByRect based on unit tests from libgeos.
+
+There are some expected differences due to Shapely's handling of empty
+geometries.
+"""
+
+from shapely.ops import clip_by_rect
+from shapely.wkt import loads as load_wkt, dumps as dump_wkt
+from shapely.geos import geos_version
+import pytest
+
+
+pytestmark = pytest.mark.skipif(geos_version < (3, 5, 0), reason='GEOS 3.5.0 required')
+
+
+def test_point_outside():
+    """Point outside"""
+    geom1 = load_wkt("POINT (0 0)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def test_point_inside():
+    """Point inside"""
+    geom1 = load_wkt("POINT (15 15)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "POINT (15 15)"
+
+
+def test_point_on_boundary():
+    """Point on boundary"""
+    geom1 = load_wkt("POINT (15 10)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def test_line_outside():
+    """Line outside"""
+    geom1 = load_wkt("LINESTRING (0 0, -5 5)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def test_line_inside():
+    """Line inside"""
+    geom1 = load_wkt("LINESTRING (15 15, 16 15)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "LINESTRING (15 15, 16 15)"
+
+
+def test_line_on_boundary():
+    """Line on boundary"""
+    geom1 = load_wkt("LINESTRING (10 15, 10 10, 15 10)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def test_line_splitting_rectangle():
+    """Line splitting rectangle"""
+    geom1 = load_wkt("LINESTRING (10 5, 25 20)")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "LINESTRING (15 10, 20 15)"
+
+
+@pytest.mark.xfail(reason="TODO issue to CCW")
+def test_polygon_shell_ccw_fully_on_rectangle_boundary():
+    """Polygon shell (CCW) fully on rectangle boundary"""
+    geom1 = load_wkt("POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10))")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10))"
+
+
+@pytest.mark.xfail(reason="TODO issue to CW")
+def test_polygon_shell_cc_fully_on_rectangle_boundary():
+    """Polygon shell (CW) fully on rectangle boundary"""
+    geom1 = load_wkt("POLYGON ((10 10, 10 20, 20 20, 20 10, 10 10))")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "POLYGON ((10 10, 20 10, 20 20, 10 20, 10 10))"
+
+
+def polygon_hole_ccw_fully_on_rectangle_boundary():
+    """Polygon hole (CCW) fully on rectangle boundary"""
+    geom1 = load_wkt("POLYGON ((0 0, 0 30, 30 30, 30 0, 0 0), (10 10, 20 10, 20 20, 10 20, 10 10))")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def polygon_hole_cw_fully_on_rectangle_boundary():
+    """Polygon hole (CW) fully on rectangle boundary"""
+    geom1 = load_wkt("POLYGON ((0 0, 0 30, 30 30, 30 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))")
+    geom2 = clip_by_rect(geom1, 10, 10, 20, 20)
+    assert dump_wkt(geom2, rounding_precision=0) == "GEOMETRYCOLLECTION EMPTY"
+
+
+def polygon_fully_within_rectangle():
+    """Polygon fully within rectangle"""
+    wkt = "POLYGON ((1 1, 1 30, 30 30, 30 1, 1 1), (10 10, 20 10, 20 20, 10 20, 10 10))"
+    geom1 = load_wkt(wkt)
+    geom2 = clip_by_rect(geom1, 0, 0, 40, 40)
+    assert dump_wkt(geom2, rounding_precision=0) == wkt
+
+
+def polygon_overlapping_rectangle():
+    """Polygon overlapping rectangle"""
+    wkt = "POLYGON ((0 0, 0 30, 30 30, 30 0, 0 0), (10 10, 20 10, 20 20, 10 20, 10 10))"
+    geom1 = load_wkt(wkt)
+    geom2 = clip_by_rect(geom1, 5, 5, 15, 15)
+    assert dump_wkt(geom2, rounding_precision=0) == "POLYGON ((5 5, 5 15, 10 15, 10 10, 15 10, 15 5, 5 5))"


### PR DESCRIPTION
TODO - write docstring.

@drnextgis - is there a good reference for this?
> This function from GEOS 3.5.0. Clips a geometry by a 2D box in a fast but possibly dirty way.

Closes #370.