### PR TITLE
Added srid keyword to wkb.dumps. Closes #592.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ New features:
 
 - Use DLLs indicated in sys._MEIPASS' to support PyInstaller frozen apps
   (#523).
+- `shapely.wkb.dumps` now accepts an `srid` integer keyword argument to write
+  WKB data including a spatial reference ID in the output data (#593)
 
 1.6.4.post1 (2018-01-24)
 ------------------------
@@ -614,4 +616,3 @@ TODO: fill gap here
 1.0 RC1 (2008-01-14)
 --------------------
 - First release candidate
-

--- a/shapely/wkb.py
+++ b/shapely/wkb.py
@@ -1,7 +1,8 @@
 """Load/dump geometries using the well-known binary (WKB) format
 """
 
-from shapely import geos
+from shapely.geos import WKBReader, WKBWriter, lgeos
+from shapely.geometry.base import geom_factory
 
 # Pickle-like convenience functions
 
@@ -9,7 +10,7 @@ def loads(data, hex=False):
     """Load a geometry from a WKB byte string, or hex-encoded string if
     ``hex=True``.
     """
-    reader = geos.WKBReader(geos.lgeos)
+    reader = WKBReader(lgeos)
     if hex:
         return reader.read_hex(data)
     else:
@@ -20,12 +21,29 @@ def load(fp, hex=False):
     data = fp.read()
     return loads(data, hex=hex)
 
-def dumps(ob, hex=False, **kw):
+def dumps(ob, hex=False, srid=None, **kw):
     """Dump a WKB representation of a geometry to a byte string, or a
     hex-encoded string if ``hex=True``.
-
-    See available keyword output settings in ``shapely.geos.WKBWriter``."""
-    writer = geos.WKBWriter(geos.lgeos, **kw)
+    
+    Parameters
+    ----------
+    ob : geometry
+        The geometry to export to well-known binary (WKB) representation
+    hex : bool
+        If true, export the WKB as a hexidecimal string. The default is to
+        return a binary string/bytes object.
+    srid : int
+        Spatial reference system ID to include in the output. The default value
+        means no SRID is included.
+    **kw : kwargs
+        See available keyword output settings in ``shapely.geos.WKBWriter``."""
+    if srid is not None:
+        # clone the object and set the SRID before dumping
+        geom = lgeos.GEOSGeom_clone(ob._geom)
+        lgeos.GEOSSetSRID(geom, srid)
+        ob = geom_factory(geom)
+        kw["include_srid"] = True
+    writer = WKBWriter(lgeos, **kw)
     if hex:
         return writer.write_hex(ob)
     else:

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -1,0 +1,51 @@
+from shapely.wkb import dumps, loads
+from shapely.geometry import Point
+import binascii
+
+
+def bin2hex(value):
+    return binascii.b2a_hex(value).upper().decode("utf-8")
+
+
+def hex2bin(value):
+    return binascii.a2b_hex(value)
+
+
+def test_dumps_srid():
+    p1 = Point(1.2, 3.4)
+    result = dumps(p1)
+    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    result = dumps(p1, srid=4326)
+    assert bin2hex(result) == "0101000020E6100000333333333333F33F3333333333330B40"
+
+
+def test_dumps_endianness():
+    p1 = Point(1.2, 3.4)
+    result = dumps(p1)
+    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    result = dumps(p1, big_endian=False)
+    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    result = dumps(p1, big_endian=True)
+    assert bin2hex(result) == "00000000013FF3333333333333400B333333333333"
+
+
+def test_dumps_hex():
+    p1 = Point(1.2, 3.4)
+    result = dumps(p1, hex=True)
+    assert result == "0101000000333333333333F33F3333333333330B40"
+    
+
+def test_loads_srid():
+    # load a geometry which includes an srid
+    geom = loads(hex2bin("0101000020E6100000333333333333F33F3333333333330B40"))
+    assert isinstance(geom, Point)
+    assert geom.coords[:] == [(1.2, 3.4)]
+    # by default srid is not exported
+    result = dumps(geom)
+    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    # include the srid in the output
+    result = dumps(geom, include_srid=True)
+    assert bin2hex(result) == "0101000020E6100000333333333333F33F3333333333330B40"
+    # replace geometry srid with another
+    result = dumps(geom, srid=27700)
+    assert bin2hex(result) == "0101000020346C0000333333333333F33F3333333333330B40"


### PR DESCRIPTION
Added the `srid` keyword argument to `wkb.dumps` to include an SRID in WKB data, as suggested in #592.

I've added some tests for WKB in `test_wkb.py` (to match `test_wkt.py`). There are already some in `test_persist.py` which I've left alone. Perhaps this could be expanded in the future, but it's not essential.

An observation is that `pickle` uses `wkb.dumps` to store data. This defaults to not exporting the SRID (even if one is present in the geometry after loading with `loads`. This means that the round-trip for a geometry with an SRID isn't perfect. However I think this is acceptable as generally we're ignoring the SRID in Shapely.