### PR TITLE
Remove keyword argument from BaseGeometry.wkt property.

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -362,9 +362,9 @@ class BaseGeometry(object):
         return geom_to_wkt(self)
 
     @property
-    def wkt(self, **kw):
+    def wkt(self):
         """WKT representation of the geometry"""
-        return WKTWriter(lgeos, **kw).write(self)
+        return WKTWriter(lgeos).write(self)
 
     @property
     def wkb(self):


### PR DESCRIPTION
Issue identified by @ShigeruNakagaki. Closes #581.