### PR TITLE
construct LineString but ~LinearRing from Points

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -446,7 +446,7 @@ instance, thereby making a copy.
   >>> LinearRing(ring)
   <shapely.geometry.polygon.LinearRing object at 0x...>
 
-As with `LineString`, a sequence of `Point` instances is not a valid
+Unlike for `LineString`, a sequence of `Point` instances is not a valid
 constructor parameter.
 
 .. _polygons:


### PR DESCRIPTION
```python
 data = [Point(0, 0), (1, 0), (2, 1)]
 LineString(data)
```
works but
```python
LinearRing(data)
```
raises
> TypeError: object of type 'Point' has no len()