### PR TITLE
Add a runtime Python version check in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,11 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
 
 from _vendor.packaging.version import Version
 
+# Ensure minimum version of Python is running
+py_version = sys.version_info[0:2]
+if not (py_version == (2, 7) or py_version >= (3, 4)):
+    raise RuntimeError('Shapely requires Python 2.7, >=3.4')
+
 # Get geos_version from GEOS dynamic library, which depends on
 # GEOS_LIBRARY_PATH and/or GEOS_CONFIG environment variables
 from shapely._buildcfg import geos_version_string, geos_version, \


### PR DESCRIPTION
While (accidentally) attempting to build Shapely on an old computer with Python 2.6, I found an incomprehensible error:
```
Traceback (most recent call last):
  File "setup.py", line 167, in <module>
    fp.write(str(shapely_version))
  File "/home/mtoews/src/Shapely/_vendor/packaging/version.py", line 252, in __str__
    parts.append(".post{}".format(self._version.post[1]))
ValueError: zero length field name in format
```
This PR provides a clearer message:
> RuntimeError: Shapely requires Python 2.7, >=3.4