### PR TITLE
Fixed bug in creating LinearRing from LineString. Closes #609.

### DIFF
--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -267,7 +267,8 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         # Check whether the first set of coordinates matches the last.
         # If not, we'll have to close the ring later
         if (cp[0] != cp[sm*(m-1)] or cp[sn] != cp[sm*(m-1)+sn] or
-            (n == 3 and cp[2*sn] != cp[sm*(m-1)+2*sn])):
+            (n == 3 and cp[2*sn] != cp[sm*(m-1)+2*sn]) or
+            m == 3):
             M = m + 1
         else:
             M = m

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -136,6 +136,26 @@ class PolygonTestCase(unittest.TestCase):
                          lgeos.GEOSGeomType(ring._geom).decode('ascii'))
 
 
+    def test_linearring_from_short_closed_linestring(self):
+        # Create linearring from linestring where the coordinate sequence is
+        # too short but appears to be closed (first and last coordinates
+        # are the same)
+        coords = [(0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]
+        line = LineString(coords)
+        ring1 = LinearRing(coords)
+        ring2 = LinearRing(line)
+        assert ring1.coords[:] == ring2.coords[:]
+
+
+    def test_linearring_from_too_short_linestring(self):
+        # Creation of LinearRing request at least 3 coordinates (unclosed) or
+        # 4 coordinates (closed)
+        coords = [(0.0, 0.0), (0.0, 0.0)]
+        line = LineString(coords)
+        with self.assertRaises(ValueError):
+            LinearRing(line)
+
+
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy(self):
 


### PR DESCRIPTION
Fixed bug in creating LinearRing from LineString. Closes #609.
Only triggered when using speedups (cython) and numpy.

`LinearRing(line)` now works identically to `LinearRing(line.coords[:])`.

Maintaining 4 different versions of the same code (python/cython with/without numpy) is a pain, but I'm not sure how we can make it any better.