### PR TITLE
Added convenience method `anchored_box()` to geo.py

### DIFF
--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -18,6 +18,33 @@ def box(minx, miny, maxx, maxy, ccw=True):
         coords = coords[::-1]
     return Polygon(coords)
 
+def anchored_box(anchor='nw',x,y,width,height,ccw=True):
+    """Return a rectangular polygon extruded from the specified anchor point.
+    The anchor point can be a corner or the centre of an edge in relation to the centre point, or the centre itself.
+    Anchor options from left to right, top to bottom are: nw,n,ne,w,c,e,sw,s,se . (Defaults to North-West)
+    """
+    if anchor =='nw':
+        return box(x,y-height,x+width,y,ccw)
+    elif anchor =='w':
+        return box(x,y-height/2.0,x+width,y+height/2.0,ccw)
+    elif anchor =='sw':
+        return box (x,y,x+width,y+height,ccw)
+    elif anchor =='n':
+        return box(x-width/2.0,y-height,x+width/2.0,y,ccw)
+    elif anchor =='c':
+        return box(x-width/2.0,y-height/2.0,x+width/2.0,y+height/2.0,ccw)
+    elif anchor == 's':
+        return box(x-width/2.0,y,x+width/2.0,y+height,ccw)
+    elif anchor == 'ne':
+        return box(x-width,y-height,x,y,ccw)
+    elif anchor == 'e':
+        return box(x-width,y-height/2.0,x,y+height/2.0,ccw)
+    elif anchor =='se':
+        return box(x-width,y,x,y+height,ccw)
+    else:
+        raise ValueError('Unknown anchor point')
+    
+
 def shape(context):
     """Returns a new, independent geometry with coordinates *copied* from the
     context.


### PR DESCRIPTION
The `anchored_box()` method provides a standard way to specify an anchor vertex for boxes, which is used in many image processing tools.  A corner, edge centre, or rectangle centroid may be specified as the anchor point.