### PR TITLE
correcting bug in interpolate (issue #653)

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -764,6 +764,7 @@ class BaseGeometry(object):
         return op(self, other)
 
     @delegated
+    @exceptNull
     def interpolate(self, distance, normalized=False):
         """Return a point at the specified distance along a linear geometry
 

--- a/tests/test_delaunay.py
+++ b/tests/test_delaunay.py
@@ -19,13 +19,13 @@ class DelaunayTriangulation(unittest.TestCase):
         polys = triangulate(self.p)
         self.assertEqual(len(polys), 2)
         for p in polys:
-            self.assert_(isinstance(p, Polygon))
+            self.assertTrue(isinstance(p, Polygon))
 
     def test_lines(self):
         polys = triangulate(self.p, edges=True)
         self.assertEqual(len(polys), 5)
         for p in polys:
-            self.assert_(isinstance(p, LineString))
+            self.assertTrue(isinstance(p, LineString))
 
     def test_point(self):
         p = Point(1,1)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -81,6 +81,21 @@ class OperationsTestCase(unittest.TestCase):
 
         distance = point.hausdorff_distance(line)
         self.assertEqual(distance, point.distance(Point(3, 4)))
-
+    
+    @unittest.skipIf(geos_version < (3, 2, 0), 'GEOS 3.2.0 required')
+    def test_interpolate(self):
+        # successful interpolation
+        test_line = LineString(((1,1),(1,2)))
+        known_point = Point(1,1.5)
+        interpolated_point = test_line.interpolate(.5, normalized=True)
+        self.assertEqual(interpolated_point, known_point)
+        
+        # Issue #653; should raise ValueError on exception
+        test_line = LineString(((0,0), (1,1), (2,1)))
+        empty_line = test_line.parallel_offset(10., side='right')
+        assert(empty_line.is_empty)
+        with pytest.raises(ValueError):
+            empty_line.interpolate(.5, normalized=True)
+        
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(OperationsTestCase)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -91,8 +91,7 @@ class OperationsTestCase(unittest.TestCase):
         self.assertEqual(interpolated_point, known_point)
         
         # Issue #653; should raise ValueError on exception
-        test_line = LineString(((0,0), (1,1), (2,1)))
-        empty_line = test_line.parallel_offset(10., side='right')
+        empty_line = loads('LINESTRING EMPTY')
         assert(empty_line.is_empty)
         with pytest.raises(ValueError):
             empty_line.interpolate(.5, normalized=True)


### PR DESCRIPTION
This PR addresses #653 by adding an `exceptNull` decorator to `interpolate`, thereby preventing segmentation faults when attempting to interpolate a `Point` along a `LINESTRING EMPTY` object and failing gracefully.

* initial commit is a simple correction of 2 test case in `tests/test_delaunay.py` which were failing

-------------

```
=============================================================== warnings summary ================================================================
tests/test_delaunay.py::DelaunayTriangulation::test_lines
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:28: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, LineString))
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:28: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, LineString))
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:28: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, LineString))
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:28: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, LineString))
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:28: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, LineString))

tests/test_delaunay.py::DelaunayTriangulation::test_polys
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:22: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, Polygon))
  /Users/jgaboardi/Shapely/tests/test_delaunay.py:22: DeprecationWarning: Please use assertTrue instead.
    self.assert_(isinstance(p, Polygon))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================== 290 passed, 2 xfailed, 7 warnings in 3.14 seconds ===============================================
```