### PR TITLE
Fixing bug in ops.substring

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -516,9 +516,9 @@ def substring(geom, start_dist, end_dist, normalized=False):
     
     vertex_list = [(start_point.x, start_point.y)]
     coords = list(geom.coords)
-    for i, p in enumerate(coords):
+    for i, p in coords:
         pd = geom.project(Point(p))
-        if pd < min_dist:
+        if pd <= min_dist:
             pass
         elif min_dist < pd < max_dist:
             vertex_list.append(p)

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -516,7 +516,7 @@ def substring(geom, start_dist, end_dist, normalized=False):
     
     vertex_list = [(start_point.x, start_point.y)]
     coords = list(geom.coords)
-    for i, p in coords:
+    for p in coords:
         pd = geom.project(Point(p))
         if pd <= min_dist:
             pass


### PR DESCRIPTION
If `min_dist` is equal to 0 (i.e. the first coordinate) then the loop immediately breaks.

This means that internal coordinates are skipped because only `(start_point.x, start_point.y)` and `(end_point.x, end_point.y)` are written to the new `vertex_list`.

By changing the less than to a less-than-equal sign the loop behaves as intended.