### PR TITLE
add ops.substring test for edge case: endpoint geoms with internal coords

### DIFF
--- a/tests/test_substring.py
+++ b/tests/test_substring.py
@@ -68,7 +68,9 @@ class SubstringTestCase(unittest.TestCase):
     def test_return_substring_with_vertices(self):
         self.assertTrue(substring(self.line2, 1, 7).equals(LineString(([3, 1], [3, 6], [4, 6]))))
         self.assertTrue(substring(self.line2, 0.2, 0.9, True).equals(LineString(([3, 1.5], [3, 6], [3.75, 6]))))
-
+        self.assertTrue(substring(self.line2, 0, 0.9, True).equals(LineString(([3, 0], [3, 6], [3.75, 6]))))
+        self.assertTrue(substring(self.line2, 0.2, 1, True).equals(LineString(([3, 1.5], [3, 6], [4.5, 6]))))
+        
 
 def test_suite():
     loader = unittest.TestLoader()


### PR DESCRIPTION
Adding edge case (no pun intended...) to test that internal coordinates are preserved when cutting to either end of line.
Addressed by #658 and #659