### PR TITLE
Fixing doc typo in matrix math for affine_transform().

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1766,12 +1766,20 @@ preserved or supported by 3D affine transformations.
   which represents the augmented matrix:
 
   .. math::
-    \begin{bmatrix} x' & y' & 1 \end{bmatrix} =
-    \begin{bmatrix} x  & y  & 1 \end{bmatrix}
+    \begin{bmatrix}
+      x' \\
+      y' \\
+      1
+    \end{bmatrix} =
     \begin{bmatrix}
       a & b & x_\mathrm{off} \\
       d & e & y_\mathrm{off} \\
       0 & 0 & 1
+    \end{bmatrix}
+    \begin{bmatrix}
+      x \\
+      y \\
+      1
     \end{bmatrix}
 
   or the equations for the transformed coordinates:
@@ -1787,13 +1795,23 @@ preserved or supported by 3D affine transformations.
   which represents the augmented matrix:
 
   .. math::
-    \begin{bmatrix} x' & y' & z' & 1 \end{bmatrix} =
-    \begin{bmatrix} x  & y  & z  & 1 \end{bmatrix}
+    \begin{bmatrix}
+      x' \\
+      y' \\
+      z' \\
+      1
+    \end{bmatrix} =
     \begin{bmatrix}
       a & b & c & x_\mathrm{off} \\
       d & e & f & y_\mathrm{off} \\
       g & h & i & z_\mathrm{off} \\
       0 & 0 & 0 & 1
+    \end{bmatrix}
+    \begin{bmatrix}
+      x \\
+      y \\
+      z \\
+      1
     \end{bmatrix}
 
   or the equations for the transformed coordinates:

--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -17,9 +17,9 @@ def affine_transform(geom, matrix):
 
     which represents the augmented matrix::
 
-                            / a  b xoff \ 
-        [x' y' 1] = [x y 1] | d  e yoff |
-                            \ 0  0   1  /
+        / x' \   / a  b xoff \ / x \
+        | y' | = | d  e yoff | | y |
+        \ 1  /   \ 0  0   1  / \ 1 /
 
     or the equations for the transformed coordinates::
 
@@ -32,10 +32,10 @@ def affine_transform(geom, matrix):
 
     which represents the augmented matrix::
 
-                                 / a  b  c xoff \ 
-        [x' y' z' 1] = [x y z 1] | d  e  f yoff |
-                                 | g  h  i zoff |
-                                 \ 0  0  0   1  /
+        / x' \   / a  b  c xoff \ / x \
+        | y' | = | d  e  f yoff | | y |
+        | z' |   | g  h  i zoff | | z |
+        \ 1  /   \ 0  0  0   1  / \ 1 /
 
     or the equations for the transformed coordinates::
 


### PR DESCRIPTION
In the documentation for `affine_transform()`, the matrix multiplication math don't match the rest of the equations in the docs and also don't match the implementation:
https://github.com/Toblerity/Shapely/blob/5d18af283e485a427d121e05fbf8e9968db4a569/shapely/speedups/_speedups.pyx#L480-L482

This PR updates the matrix equations in the documentation and code comments to be consistent with the other docs and existing code implementation.