### PR TITLE
Travis CI: Upgrade from Python 3.4 --> 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 cache:
   - pip
   - apt
@@ -18,11 +17,11 @@ matrix:
       env:
         - SPEEDUPS=0
         - NUMPY=0
-    - python: "3.4"
+    - python: "3.5"
       env:
         - SPEEDUPS=1
         - NUMPY=1
-    - python: "3.4"
+    - python: "3.5"
       env:
         - SPEEDUPS=0
         - NUMPY=1


### PR DESCRIPTION
23 days until Python 3.4 end of life.  https://docs.python.org/devguide/index.html#branchstatus

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"