### PR TITLE
Correct the description of Hausdorff distance

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -222,8 +222,9 @@ General Attributes and Methods
 .. method:: object.hausdorff_distance(other)
 
   Returns the Hausdorff distance (``float``) to the `other` geometric object.
-  The Hausdorff distance is the furthest distance from any point on the first
-  geometry to any point on the second geometry.
+  The Hausdorff distance between two geometries is the furthest distance that
+  a point on either geometry can be from the nearest point to it on the other
+  geometry.
 
   `New in Shapely 1.6.0`
 


### PR DESCRIPTION
The manual describes Hausdorff distance as follows:

>.. method:: object.hausdorff_distance(other)
>
>  Returns the Hausdorff distance (``float``) to the `other` geometric object.
>  The Hausdorff distance is the furthest distance from any point on the first
>  geometry to any point on the second geometry.
>
>  `New in Shapely 1.6.0`

Depending on how one interpreted this description, this would suggest that the following code would return either a 4 or a 1 when it fact it returns a 2 (as it should).
```
A = LineString([(0,0),(2,0)])
B = LineString([(1,0),(4,0)])
A.hausdorff_distance(B)
```
As it is, the documentation implies that Hausdorff distance can be described mathematically as either:
$\sup_{x \in A, y \in B}d(x,y)$
or at a stretch
$\sup_{x \in A}\inf_{y \in B}d(x,y)$
rather than
$\max{\sup_{x \in A}\inf_{y \in B}d(x,y),\sup_{x \in B}\inf_{y \in A}d(x,y)}$
as in the wiki article on [Hausdorff distance](https://en.wikipedia.org/wiki/Hausdorff_distance).

A more accurate description would be something like the following:

> The Hausdorff distance between two objects is the furthest distance that a
> point on either object can be from the nearest point to it on the other object.