### PR TITLE
Replace cascaded with unary union in docs and more

### DIFF
--- a/docs/code/unary_union.py
+++ b/docs/code/unary_union.py
@@ -1,6 +1,6 @@
 from matplotlib import pyplot
 from shapely.geometry import Point
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 from descartes import PolygonPatch
 
 from figures import SIZE, BLUE, GRAY, set_limits
@@ -23,7 +23,7 @@ set_limits(ax, -2, 6, -2, 2)
 #2
 ax = fig.add_subplot(122)
 
-u = cascaded_union(polygons)
+u = unary_union(polygons)
 patch2b = PolygonPatch(u, fc=BLUE, ec=BLUE, alpha=0.5, zorder=2)
 ax.add_patch(patch2b)
 
@@ -32,4 +32,3 @@ ax.set_title('b) union')
 set_limits(ax, -2, 6, -2, 2)
 
 pyplot.show()
-

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2089,17 +2089,20 @@ using functions in the :mod:`shapely.ops` module.
      <shapely.geometry.linestring.LineString object at 0x...>,
      <shapely.geometry.linestring.LineString object at 0x...>]
 
-Cascading Unions
+Efficient Unions
 ----------------
 
 The :func:`~shapely.ops.unary_union` function in `shapely.ops` is more
 efficient than accumulating with :meth:`union`.
 
-.. plot:: code/cascaded_union.py
+.. plot:: code/unary_union.py
 
 .. function:: shapely.ops.unary_union(geoms)
 
   Returns a representation of the union of the given geometric objects.
+
+  Areas of overlapping `Polygons` will get merged. `LineStrings` will
+  get fully dissolved and noded. Duplicate `Points` will get merged.
 
   .. code-block:: pycon
 
@@ -2108,15 +2111,21 @@ efficient than accumulating with :meth:`union`.
     >>> unary_union(polygons)
     <shapely.geometry.polygon.Polygon object at 0x...>
 
-  The function is particularly useful in dissolving `MultiPolygons`.
+  Because the union merges the areas of overlapping `Polygons` it can be
+  used in an attempt to fix invalid `MultiPolygons`. As with the zero
+  distance :meth:`buffer` trick, your mileage may vary when using this.
 
   .. code-block:: pycon
 
     >>> m = MultiPolygon(polygons)
     >>> m.area
     7.6845438018375516
+    >>> m.is_valid
+    False
     >>> unary_union(m).area
     6.6103013551167971
+    >>> unary_union(m).is_valid
+    True
 
 .. function:: shapely.ops.cascaded_union(geoms)
 
@@ -2124,10 +2133,10 @@ efficient than accumulating with :meth:`union`.
 
   .. note::
 
-     Since 1.2.16 :func:`shapely.ops.cascaded_union` is superceded by
-     :func:`shapely.ops.unary_union` if GEOS 3.2+ is used. The unary union
+     In 1.2.16 :func:`shapely.ops.cascaded_union` was transparently superseded by
+     :func:`shapely.ops.unary_union` if GEOS 3.3+ is used. The unary union
      function can operate on different geometry types, not only polygons as is
-     the case for the older cascaded unions.
+     the case for the older cascaded union.
 
 Delaunay triangulation
 ----------------------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2148,7 +2148,7 @@ Delaunay triangulation from a collection of points.
 
 .. function:: shapely.ops.triangulate(geom, tolerance=0.0, edges=False)
 
-   Returns a Delaunary triangulation of the vertices of the input geometry.
+   Returns a Delaunay triangulation of the vertices of the input geometry.
 
    The source may be any geometry type. All vertices of the geometry will be
    used as the points of the triangulation.

--- a/shapely/examples/dissolve.py
+++ b/shapely/examples/dissolve.py
@@ -9,7 +9,7 @@ import random
 import pylab
 
 from shapely.geometry import Point
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 # Use a partial function to make 100 points uniformly distributed in a 40x40 
 # box centered on 0,0.
@@ -19,9 +19,9 @@ points = [Point(r(), r()) for i in range(100)]
 # Buffer the points, producing 100 polygon spots
 spots = [p.buffer(2.5) for p in points]
 
-# Perform a cascaded union of the polygon spots, dissolving them into a 
+# Perform a unary union of the polygon spots, dissolving them into a
 # collection of polygon patches
-patches = cascaded_union(spots)
+patches = unary_union(spots)
 
 if __name__ == "__main__":
     # Illustrate the results using matplotlib's pylab interface

--- a/shapely/examples/intersect.py
+++ b/shapely/examples/intersect.py
@@ -9,13 +9,13 @@ import random
 import pylab
 
 from shapely.geometry import LineString, Point
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 # Build patches as in dissolved.py
 r = partial(random.uniform, -20.0, 20.0)
 points = [Point(r(), r()) for i in range(100)]
 spots = [p.buffer(2.5) for p in points]
-patches = cascaded_union(spots)
+patches = unary_union(spots)
 
 # Represent the following geolocation parameters
 #

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -120,7 +120,7 @@ class CollectionOperator(object):
     def cascaded_union(self, geoms):
         """Returns the union of a sequence of geometries
 
-        This is the most efficient method of dissolving many polygons.
+        This method was superseded by :meth:`unary_union`.
         """
         try:
             L = len(geoms)
@@ -138,7 +138,6 @@ class CollectionOperator(object):
 
         This method replaces :meth:`cascaded_union` as the
         prefered method for dissolving many polygons.
-
         """
         try:
             L = len(geoms)


### PR DESCRIPTION
- Brief info about what happens with different kinds of geometries (via
https://geos.osgeo.org/doxygen/classgeos_1_1operation_1_1geounion_1_1UnaryUnionOp.html)
- Extend doc example with validity of MultiPolygon
- Demote cascaded_union from being worthy of mention
- Fix GEOS version in note
- Update plot generation from cascaded to unary
- Update examples from cascaded to unary
- "Hypier" and more abstract section title