### PR TITLE
Bounds of an empty point is an empty tuple. Fixes #716

### DIFF
--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -118,7 +118,11 @@ class Point(BaseGeometry):
 
     @property
     def bounds(self):
-        xy = self.coords[0]
+        """Returns minimum bounding region (minx, miny, maxx, maxy)"""
+        try:
+            xy = self.coords[0]
+        except IndexError:
+            return ()
         return (xy[0], xy[1], xy[0], xy[1])
 
     # Coordinate access

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -144,5 +144,11 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(a.shape[0], 0)
 
 
+def test_empty_point_bounds():
+    """The bounds of an empty point is an empty tuple"""
+    p = Point()
+    assert p.bounds == ()
+
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(LineStringTestCase)


### PR DESCRIPTION
The `.bounds` method of an empty point should return an empty tuple, the same as it does for other geomety types. Without this fix an `IndexError` is raised when the method tries to access the zeroth coordinate which doesn't exist.

I've used the pytest style syntax for the test, but the rest of the test module is still using the older unittest syntax.

Fun fact: the existing behaviour is 9 years old.