### PR TITLE
Exterior of an empty polygon is equivalent to LinearRing()

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -245,7 +245,7 @@ class Polygon(BaseGeometry):
     @property
     def exterior(self):
         if self.is_empty:
-            return None
+            return LinearRing()
         elif self._exterior is None or self._exterior() is None:
             g = lgeos.GEOSGetExteriorRing(self._geom)
             ring = LinearRing()
@@ -311,7 +311,7 @@ class Polygon(BaseGeometry):
 
     @property
     def __geo_interface__(self):
-        if not self.exterior:
+        if self.exterior == LinearRing():
             coords = []
         else:
             coords = [tuple(self.exterior.coords)]

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -257,6 +257,10 @@ class PolygonTestCase(unittest.TestCase):
             Polygon(coords),
             Polygon.from_bounds(xmin, ymin, xmax, ymax))
 
+    def test_empty_polygon_exterior(self):
+        p = Polygon()
+        assert p.exterior == LinearRing()
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(PolygonTestCase)


### PR DESCRIPTION
Fix for https://github.com/Toblerity/Shapely/issues/712 as was suggested by @sgillies.