### PR TITLE
In linux env add fallback load dll for libc.so.6

### DIFF
--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -165,7 +165,7 @@ if sys.platform.startswith('linux'):
     if not lgeos:
         lgeos = load_dll('geos_c',
                          fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
-    free = load_dll('c').free
+    free = load_dll('c', fallbacks=['libc.so.6']).free
     free.argtypes = [c_void_p]
     free.restype = None
 


### PR DESCRIPTION
Allow fallback for loading libc.so.6 
i'm having issue in mock for linux environment to build this package but with allowing fallback for libc.so.6 i was able to pass the build

Traceback (most recent call last):
  File "setup.py", line 80, in <module>
    from shapely._buildcfg import geos_version_string, geos_version, \
  File "/builddir/build/BUILD/Shapely-1.6.4.post2/shapely/_buildcfg.py", line 168, in <module>
    free = load_dll('c').free
  File "/builddir/build/BUILD/Shapely-1.6.4.post2/shapely/_buildcfg.py", line 161, in load_dll
    libname, fallbacks or []))
OSError: Could not find library c or load any of its variants []

