### PR TITLE
Add fallback path for libc.musl

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -87,8 +87,7 @@ if sys.platform.startswith('linux'):
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
     # Necessary for environments with only libc.musl
     c_alt_paths = [
-        'libc.musl-x86_64.so.1',
-        os.path.join(sys.prefix, "lib", "libc.musl-x86_64.so.1")
+        'libc.musl-x86_64.so.1'
     ]
     free = load_dll('c', fallbacks=c_alt_paths).free
     free.argtypes = [c_void_p]

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -85,7 +85,12 @@ if sys.platform.startswith('linux'):
             'libgeos_c.so',
         ]
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
-    free = load_dll('c').free
+    # Necessary for environments with only libc.musl
+    c_alt_paths = [
+        'libc.musl-x86_64.so.1',
+        os.path.join(sys.prefix, "lib", "libc.musl-x86_64.so.1")
+    ]
+    free = load_dll('c', fallbacks=c_alt_paths).free
     free.argtypes = [c_void_p]
     free.restype = None
 


### PR DESCRIPTION
With reference to https://github.com/Toblerity/Shapely/issues/394, this was the same problem that happened to me. The root cause is because `find_library("c")` returns something empty for certain linux environments. Searching through some of these forums, it looks like this won't be fixed. As such, we have to accommodate this on the package side. 

My environment only had the following `libc` libraries:
```
./lib/libc.musl-x86_64.so.1
./usr/glibc-compat/lib/libc.so.6
./usr/glibc-compat/lib/libc.so
```

The fix below adds the path for `./lib/libc.musl-x86_64.so.1`. I've tested this and it solved the issue.
