### PR TITLE
Cleanup References

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -68,6 +68,6 @@ Additional help from:
 * Sandro Santilli, Mateusz Loskot, Paul Ramsey, et al (GEOS Project)
 
 Major portions of this work were supported by a grant (for Pleiades_) from the
-U.S. National Endowment for the Humanities (http://www.neh.gov).
+U.S. National Endowment for the Humanities (https://www.neh.gov).
 
-.. _Pleiades: http://pleiades.stoa.org
+.. _Pleiades: https://pleiades.stoa.org

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Manipulation and analysis of geometric objects in the Cartesian plane.
 
 Shapely is a BSD-licensed Python package for manipulation and analysis of
 planar geometric objects. It is based on the widely deployed `GEOS
-<http://trac.osgeo.org/geos/>`__ (the engine of `PostGIS
+<https://trac.osgeo.org/geos/>`__ (the engine of `PostGIS
 <http://postgis.org>`__) and `JTS
 <https://locationtech.github.io/jts/>`__ (from which GEOS is ported)
 libraries. Shapely is not concerned with data formats or coordinate systems,
@@ -43,8 +43,8 @@ Built distributions
 -------------------
 
 Windows users have two good installation options: the wheels at
-http://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely and the 
-Anaconda platform's `conda-forge <https://conda-forge.github.io/>`__
+https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely and the 
+Anaconda platform's `conda-forge <https://conda-forge.org/>`__
 channel.
 
 OS X and Linux users can get Shapely wheels with GEOS included from the 
@@ -155,7 +155,7 @@ Support
 =======
 
 Questions about using Shapely may be asked on the `GIS StackExchange 
-<http://gis.stackexchange.com/questions/tagged/shapely>`__ using the "shapely"
+<https://gis.stackexchange.com/questions/tagged/shapely>`__ using the "shapely"
 tag.
 
 Bugs may be reported at https://github.com/Toblerity/Shapely/issues.

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -118,7 +118,7 @@ Relationships
 The spatial data model is accompanied by a group of natural language
 relationships between geometric objects – `contains`, `intersects`, `overlaps`,
 `touches`, etc. – and a theoretical framework for understanding them using the
-3x3 matrix of the mutual intersections of their component point sets [2]_: the
+3x3 matrix of the mutual intersections of their component point sets [3]_: the
 DE-9IM. A comprehensive review of the relationships in terms of the DE-9IM is
 found in [4]_ and will not be reiterated in this manual.
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2386,7 +2386,7 @@ Polylabel
 .. function:: shapely.ops.polylabel(polygon, tolerance)
 
   Finds the approximate location of the pole of inaccessibility for a given
-  polygon. Based on Vladimir Agafonkin's https://github.com/mapbox/polylabel.
+  polygon. Based on Vladimir Agafonkin's polylabel_.
 
   `New in version 1.6.0`
 
@@ -2712,12 +2712,8 @@ References
 
 .. _GEOS: https://trac.osgeo.org/geos/
 .. _Java Topology Suite: https://projects.eclipse.org/projects/locationtech.jts
-.. _JTS: https://projects.eclipse.org/projects/locationtech.jts
 .. _PostGIS: http://postgis.refractions.net
-.. _record: https://pypi.org/project/Shapely/
-.. _Open Geospatial Consortium: http://www.opengeospatial.org/
-.. _Davis: https://lin-ear-th-inking.blogspot.com/2007/06/subtleties-of-ogc-covers-spatial.html
-.. _Understanding spatial relations: http://edndoc.esri.com/arcsde/9.1/general_topics/understand_spatial_relations.htm
+.. _Open Geospatial Consortium: https://www.opengeospatial.org/
 .. _Strobl-PDF: https://giswiki.hsr.ch/images/3/3d/9dem_springer.pdf
 .. |Strobl-PDF| replace:: PDF
 .. _JTS-PDF: https://github.com/locationtech/jts/raw/master/doc/JTS%20Technical%20Specs.pdf
@@ -2725,3 +2721,4 @@ References
 .. _frozenset: https://docs.python.org/library/stdtypes.html#frozenset
 .. _Sorting HowTo: https://wiki.python.org/moin/HowTo/Sorting/
 .. _Python geo interface: https://gist.github.com/2217756
+.. _polylabel: https://github.com/mapbox/polylabel


### PR DESCRIPTION
* Removes unused references at the end of `manual.rst`
* Updates some URLs to use https
* Fixes a footnote reference (previously unreferenced)
* Switched one link to use a reference instead but the remaining links seemed fine as is

I noticed that `design.rst` is not used. Should that file be removed? 

Also, the ToC has an entry for `API Documentation <modules>` that goes unused, it looks like because `make apidocs` is still outputting txt files. Should that get updated to rst or should that entry just get removed?

Resolves #617