### PR TITLE
Guard for empty geometries in affinity functions

### DIFF
--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -254,6 +254,8 @@ def translate(geom, xoff=0.0, yoff=0.0, zoff=0.0):
         | 0  0  1 zoff |
         \ 0  0  0   1  /
     """
+    if geom.is_empty:
+        return geom
     matrix = (1.0, 0.0, 0.0,
               0.0, 1.0, 0.0,
               0.0, 0.0, 1.0,

--- a/shapely/affinity.py
+++ b/shapely/affinity.py
@@ -151,6 +151,8 @@ def rotate(geom, angle, origin='center', use_radians=False):
         xoff = x0 - x0 * cos(r) + y0 * sin(r)
         yoff = y0 - x0 * sin(r) - y0 * cos(r)
     """
+    if geom.is_empty:
+        return geom
     if not use_radians:  # convert from degrees
         angle *= pi/180.0
     cosp = cos(angle)
@@ -190,6 +192,8 @@ def scale(geom, xfact=1.0, yfact=1.0, zfact=1.0, origin='center'):
         yoff = y0 - y0 * yfact
         zoff = z0 - z0 * zfact
     """
+    if geom.is_empty:
+        return geom
     x0, y0, z0 = interpret_origin(geom, origin, 3)
 
     matrix = (xfact, 0.0, 0.0,
@@ -220,6 +224,8 @@ def skew(geom, xs=0.0, ys=0.0, origin='center', use_radians=False):
         xoff = -y0 * tan(xs)
         yoff = -x0 * tan(ys)
     """
+    if geom.is_empty:
+        return geom
     if not use_radians:  # convert from degrees
         xs *= pi/180.0
         ys *= pi/180.0

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -155,7 +155,8 @@ class TransformOpsTestCase(unittest.TestCase):
         rls = affinity.rotate(ls, 90, origin=Point(0, 0))
         els = load_wkt('LINESTRING(-400 240, -300 240, -300 300)')
         self.assertTrue(rls.equals(els))
-        # empty
+    
+    def test_rotate_empty(self):
         rls = affinity.rotate(load_wkt('LINESTRING EMPTY'), 90)
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(rls.equals(els))
@@ -194,7 +195,8 @@ class TransformOpsTestCase(unittest.TestCase):
         for a, b in zip(sls.coords, els.coords):
             for ap, bp in zip(a, b):
                 self.assertEqual(ap, bp)
-        # empty
+    
+    def test_scale_empty(self):
         sls = affinity.scale(load_wkt('LINESTRING EMPTY'))
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(sls.equals(els))
@@ -235,7 +237,8 @@ class TransformOpsTestCase(unittest.TestCase):
                        '320.3847577293367976 161.4359353944898317, '
                        '380.3847577293367976 126.7949192431122754)')
         self.assertTrue(sls.almost_equals(els))
-        # empty
+    
+    def test_skew_empty(self):
         sls = affinity.skew(load_wkt('LINESTRING EMPTY'))
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(sls.equals(els))
@@ -256,7 +259,8 @@ class TransformOpsTestCase(unittest.TestCase):
         # retest with named parameters for the same result
         tls = affinity.translate(geom=ls, xoff=100, yoff=400, zoff=-10)
         self.assertTrue(tls.equals(els))
-        # empty
+    
+    def test_translate_empty(self):
         tls = affinity.translate(load_wkt('LINESTRING EMPTY'))
         els = load_wkt('LINESTRING EMPTY')
         self.assertTrue(tls.equals(els))

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -156,9 +156,9 @@ class TransformOpsTestCase(unittest.TestCase):
         els = load_wkt('LINESTRING(-400 240, -300 240, -300 300)')
         self.assertTrue(rls.equals(els))
         # empty
-        ls = load_wkt('LINESTRING EMPTY')
-        rls = affinity.rotate(ls, 90)
-        self.assertTrue(rls.is_empty)
+        rls = affinity.rotate(load_wkt('LINESTRING EMPTY'), 90)
+        els = load_wkt('LINESTRING EMPTY')
+        self.assertTrue(rls.equals(els))
 
     def test_scale(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -195,9 +195,9 @@ class TransformOpsTestCase(unittest.TestCase):
             for ap, bp in zip(a, b):
                 self.assertEqual(ap, bp)
         # empty
-        ls = load_wkt('LINESTRING EMPTY')
-        sls = affinity.scale(ls)
-        self.assertTrue(sls.is_empty)
+        sls = affinity.scale(load_wkt('LINESTRING EMPTY'))
+        els = load_wkt('LINESTRING EMPTY')
+        self.assertTrue(sls.equals(els))
 
     def test_skew(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -236,9 +236,9 @@ class TransformOpsTestCase(unittest.TestCase):
                        '380.3847577293367976 126.7949192431122754)')
         self.assertTrue(sls.almost_equals(els))
         # empty
-        ls = load_wkt('LINESTRING EMPTY')
-        sls = affinity.skew(ls)
-        self.assertTrue(sls.is_empty)
+        sls = affinity.skew(load_wkt('LINESTRING EMPTY'))
+        els = load_wkt('LINESTRING EMPTY')
+        self.assertTrue(sls.equals(els))
 
     def test_translate(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -257,9 +257,9 @@ class TransformOpsTestCase(unittest.TestCase):
         tls = affinity.translate(geom=ls, xoff=100, yoff=400, zoff=-10)
         self.assertTrue(tls.equals(els))
         # empty
-        ls = load_wkt('LINESTRING EMPTY')
-        tls = affinity.translate(ls)
-        self.assertTrue(tls.is_empty)
+        tls = affinity.translate(load_wkt('LINESTRING EMPTY'))
+        els = load_wkt('LINESTRING EMPTY')
+        self.assertTrue(tls.equals(els))
 
 
 def test_suite():

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -155,6 +155,10 @@ class TransformOpsTestCase(unittest.TestCase):
         rls = affinity.rotate(ls, 90, origin=Point(0, 0))
         els = load_wkt('LINESTRING(-400 240, -300 240, -300 300)')
         self.assertTrue(rls.equals(els))
+        # empty
+        ls = load_wkt('LINESTRING EMPTY')
+        rls = affinity.rotate(ls, 90)
+        self.assertTrue(rls.is_empty)
 
     def test_scale(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -190,6 +194,10 @@ class TransformOpsTestCase(unittest.TestCase):
         for a, b in zip(sls.coords, els.coords):
             for ap, bp in zip(a, b):
                 self.assertEqual(ap, bp)
+        # empty
+        ls = load_wkt('LINESTRING EMPTY')
+        sls = affinity.scale(ls)
+        self.assertTrue(sls.is_empty)
 
     def test_skew(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -227,6 +235,10 @@ class TransformOpsTestCase(unittest.TestCase):
                        '320.3847577293367976 161.4359353944898317, '
                        '380.3847577293367976 126.7949192431122754)')
         self.assertTrue(sls.almost_equals(els))
+        # empty
+        ls = load_wkt('LINESTRING EMPTY')
+        sls = affinity.skew(ls)
+        self.assertTrue(sls.is_empty)
 
     def test_translate(self):
         ls = load_wkt('LINESTRING(240 400 10, 240 300 30, 300 300 20)')
@@ -244,6 +256,10 @@ class TransformOpsTestCase(unittest.TestCase):
         # retest with named parameters for the same result
         tls = affinity.translate(geom=ls, xoff=100, yoff=400, zoff=-10)
         self.assertTrue(tls.equals(els))
+        # empty
+        ls = load_wkt('LINESTRING EMPTY')
+        tls = affinity.translate(ls)
+        self.assertTrue(tls.is_empty)
 
 
 def test_suite():


### PR DESCRIPTION
`affine_transform` checks if empty but the functions in affinity will raise an Exception before reaching that check as noted in #763. This resolves #763