### PR TITLE
added homebrew path for supports QGIS3 for macOS

### DIFF
--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -181,6 +181,8 @@ elif sys.platform == 'darwin':
                 "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
                 # macports
                 '/opt/local/lib/libgeos_c.dylib',
+                # homebrew
+                '/usr/local/lib/libgeos_c.dylib',
             ]
         lgeos = load_dll('geos_c', fallbacks=alt_paths)
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -130,6 +130,8 @@ elif sys.platform == 'darwin':
                 "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
                 # macports
                 '/opt/local/lib/libgeos_c.dylib',
+                # homebrew
+                '/usr/local/lib/libgeos_c.dylib',
             ]
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 


### PR DESCRIPTION
I just get an error when I install QGIS 'vector tile plugin' into macOS with homebrew.
QGIS3 can't find path and use [this search path](https://github.com/Toblerity/Shapely/blob/master/shapely/geos.py#L128) but it doesn't include homebrew path.