### PR TITLE
Change intersection test to check is_empty

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -22,8 +22,7 @@ class OperationsTestCase(unittest.TestCase):
         self.assertIsInstance(point.envelope, Point)
 
         # Intersection
-        self.assertIsInstance(point.intersection(Point(-1, -1)),
-                              GeometryCollection)
+        self.assertTrue(point.intersection(Point(-1, -1)).is_empty)
 
         # Buffer
         self.assertIsInstance(point.buffer(10.0), Polygon)


### PR DESCRIPTION
Simple fix to a test issue identified in https://github.com/conda-forge/shapely-feedstock/pull/58 and fixes #799

This change is related to new behaviour for `POINT EMPTY` with GEOS 3.8.0

See also #742 for a recent discussion on empty geometry handling, and I'll re-iterate that PR #352 (not merged) is still a good patch that should be revised to handle how GEOS and modern PostGIS work.