### PR TITLE
Implement GEOSBufferParams to support single sided buffers.

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -135,6 +135,28 @@ def prototype(lgeos, geos_version):
             lgeos.GEOSOffsetCurve.argtypes = [
                 c_void_p, c_double, c_int, c_int, c_double]
 
+            lgeos.GEOSBufferParams_create.restype = c_void_p
+            lgeos.GEOSBufferParams_create.argtypes = None
+
+            lgeos.GEOSBufferParams_setEndCapStyle.restype = c_int
+            lgeos.GEOSBufferParams_setEndCapStyle.argtypes = [c_void_p, c_int]
+
+            lgeos.GEOSBufferParams_setJoinStyle.restype = c_int
+            lgeos.GEOSBufferParams_setJoinStyle.argtypes = [c_void_p, c_int]
+
+            lgeos.GEOSBufferParams_setMitreLimit.restype = c_int
+            lgeos.GEOSBufferParams_setMitreLimit.argtypes = [c_void_p, c_double]
+
+            lgeos.GEOSBufferParams_setQuadrantSegments.restype = c_int
+            lgeos.GEOSBufferParams_setQuadrantSegments.argtypes = [c_void_p, c_int]
+
+            lgeos.GEOSBufferParams_setSingleSided.restype = c_int
+            lgeos.GEOSBufferParams_setSingleSided.argtypes = [c_void_p, c_int]
+
+            lgeos.GEOSBufferWithParams.restype = c_void_p
+            lgeos.GEOSBufferWithParams.argtypes = [
+                c_void_p, c_void_p, c_double]
+
         else:
 
             # deprecated in GEOS 3.3.0 in favour of GEOSOffsetCurve
@@ -509,7 +531,7 @@ def prototype(lgeos, geos_version):
 
         lgeos.GEOSSTRtree_destroy.argtypes = [c_void_p]
         lgeos.GEOSSTRtree_destroy.restype = None
-    
+
     if geos_version >= (3, 6, 0):
         lgeos.GEOSDistanceCallback = CFUNCTYPE(c_int, c_void_p, c_void_p, c_void_p, c_void_p)
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -531,7 +531,7 @@ class BaseGeometry(object):
 
     def buffer(self, distance, resolution=16, quadsegs=None,
                cap_style=CAP_STYLE.round, join_style=JOIN_STYLE.round,
-               mitre_limit=5.0, single_side=0):
+               mitre_limit=5.0, single_sided=False):
         """Returns a geometry with an envelope at a distance from the object's
         envelope
 
@@ -560,9 +560,13 @@ class BaseGeometry(object):
             geometry, the mitre limit allows controlling the maximum length of the
             join corner. Corners with a ratio which exceed the limit will be
             beveled.
-        single_side: int, optional
-            A single-sided buffer is constructed on only one side of each input line.
-            The side used is determined by the sign of the buffer distance, positive being left.
+        single_side: bool, optional
+            The side used is determined by the sign of the buffer distance:
+                a positive distance indicates the left-hand side
+                a negative distance indicates the right-hand side
+            The single-sided buffer of point geometries is the same as the regular buffer.
+            The End Cap Style for single-sided buffers is always ignored, and forced to the
+            equivalent of CAP_FLAT.
 
         Example:
 
@@ -596,7 +600,7 @@ class BaseGeometry(object):
             self._lgeos.GEOSBufferParams_setJoinStyle(params, join_style)
             self._lgeos.GEOSBufferParams_setMitreLimit(params, mitre_limit)
             self._lgeos.GEOSBufferParams_setQuadrantSegments(params, res)
-            self._lgeos.GEOSBufferParams_setSingleSided(params, single_side)
+            self._lgeos.GEOSBufferParams_setSingleSided(params, single_sided)
             return geom_factory(self.impl['buffer_with_params'](self, params, distance))
 
         if cap_style == CAP_STYLE.round and join_style == JOIN_STYLE.round:

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -535,25 +535,34 @@ class BaseGeometry(object):
         """Returns a geometry with an envelope at a distance from the object's
         envelope
 
-        A negative distance has a "shrink" effect. A zero distance may be used
-        to "tidy" a polygon. The resolution of the buffer around each vertex of
-        the object increases by increasing the resolution keyword parameter
-        or second positional parameter. Note: the use of a `quadsegs` parameter
-        is deprecated and will be gone from the next major release.
-
-        The styles of caps are: CAP_STYLE.round (1), CAP_STYLE.flat (2), and
-        CAP_STYLE.square (3).
-
-        The styles of joins between offset segments are: JOIN_STYLE.round (1),
-        JOIN_STYLE.mitre (2), and JOIN_STYLE.bevel (3).
-
-        The mitre limit ratio is used for very sharp corners. The mitre ratio
-        is the ratio of the distance from the corner to the end of the mitred
-        offset corner. When two line segments meet at a sharp angle, a miter
-        join will extend the original geometry. To prevent unreasonable
-        geometry, the mitre limit allows controlling the maximum length of the
-        join corner. Corners with a ratio which exceed the limit will be
-        beveled.
+        Parameters
+        ==========
+        distance: float
+            The distance to buffer around the object. A negative distance has a "shrink" effect.
+            A zero distance may be used to "tidy" a polygon.
+        resolution: int, optional
+            The resolution of the buffer around each vertex of the object.
+        quadsegs: int, optional
+            Sets the number of line segments used to approximate an angle fillet.
+            Note: the use of a `quadsegs` parameter is deprecated and will be gone from
+            the next major release.
+        cap_style: int, optional
+            The styles of caps are: CAP_STYLE.round (1), CAP_STYLE.flat (2), and
+            CAP_STYLE.square (3).
+        join_style: int, optional
+            The styles of joins between offset segments are: JOIN_STYLE.round (1),
+            JOIN_STYLE.mitre (2), and JOIN_STYLE.bevel (3).
+        mitre_limit: float, optional
+            The mitre limit ratio is used for very sharp corners. The mitre ratio
+            is the ratio of the distance from the corner to the end of the mitred
+            offset corner. When two line segments meet at a sharp angle, a miter
+            join will extend the original geometry. To prevent unreasonable
+            geometry, the mitre limit allows controlling the maximum length of the
+            join corner. Corners with a ratio which exceed the limit will be
+            beveled.
+        single_side: int, optional
+            A single-sided buffer is constructed on only one side of each input line.
+            The side used is determined by the sign of the buffer distance, positive being left.
 
         Example:
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -842,6 +842,7 @@ class LGEOS330(LGEOS320):
         self.methods['cascaded_union'] = self.methods['unary_union']
         self.methods['snap'] = self.GEOSSnap
         self.methods['shared_paths'] = self.GEOSSharedPaths
+        self.methods['buffer_with_params'] = self.GEOSBufferWithParams
 
 
 class LGEOS340(LGEOS330):

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -144,7 +144,9 @@ IMPL320 = {
     }
 
 IMPL330 = {
-    'is_closed': (UnaryPredicate, 'is_closed')}
+    'is_closed': (UnaryPredicate, 'is_closed'),
+    'buffer_with_params': (UnaryTopologicalOp, 'buffer_with_params'),
+}
 
 
 def impl_items(defs):

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2,8 +2,8 @@ from . import unittest
 from shapely import geometry
 
 
-class BufferSideParamsCase(unittest.TestCase):
-    """ Test Buffer Point/Line/Polygon with and without single_side params """
+class BufferSingleSidedCase(unittest.TestCase):
+    """ Test Buffer Point/Line/Polygon with and without single_sided params """
 
     def test_empty(self):
         g = geometry.Point(0,0)
@@ -19,9 +19,9 @@ class BufferSideParamsCase(unittest.TestCase):
             self.assertAlmostEqual(coord[0], expected_coord[index][0])
             self.assertAlmostEqual(coord[1], expected_coord[index][1])
 
-    def test_point_single_sided(self):
+    def test_point_single_sidedd(self):
         g = geometry.Point(0, 0)
-        h = g.buffer(1, resolution=1, single_side=1)
+        h = g.buffer(1, resolution=1, single_sided=True)
         self.assertEqual(h.geom_type, 'Polygon')
         expected_coord = [(1.0, 0.0), (0, -1.0), (-1.0, 0), (0, 1.0), (1.0, 0.0)]
         for index, coord in enumerate(h.exterior.coords):
@@ -38,11 +38,20 @@ class BufferSideParamsCase(unittest.TestCase):
             self.assertAlmostEqual(coord[0], expected_coord[index][0])
             self.assertAlmostEqual(coord[1], expected_coord[index][1])
 
-    def test_line_single_sided(self):
+    def test_line_single_sideded_left(self):
         g = geometry.LineString([[0, 0], [0, 1]])
-        h = g.buffer(1, resolution=1, single_side=1)
+        h = g.buffer(1, resolution=1, single_sided=True)
         self.assertEqual(h.geom_type, 'Polygon')
         expected_coord = [(0.0, 1.0), (0.0, 0.0), (-1.0, 0.0), (-1.0, 1.0), (0.0, 1.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_line_single_sideded_right(self):
+        g = geometry.LineString([[0, 0], [0, 1]])
+        h = g.buffer(-1, resolution=1, single_sided=True)
+        self.assertEqual(h.geom_type, 'Polygon')
+        expected_coord = [(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0), (0.0, 0.0)]
         for index, coord in enumerate(h.exterior.coords):
             self.assertAlmostEqual(coord[0], expected_coord[index][0])
             self.assertAlmostEqual(coord[1], expected_coord[index][1])
@@ -57,9 +66,9 @@ class BufferSideParamsCase(unittest.TestCase):
             self.assertAlmostEqual(coord[0], expected_coord[index][0])
             self.assertAlmostEqual(coord[1], expected_coord[index][1])
 
-    def test_polygon_single_sided(self):
+    def test_polygon_single_sideded(self):
         g = geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
-        h = g.buffer(1, resolution=1, single_side=1)
+        h = g.buffer(1, resolution=1, single_sided=True)
         self.assertEqual(h.geom_type, 'Polygon')
         expected_coord = [(-1.0, 0.0), (-1.0, 1.0), (0.0, 2.0), (1.0, 2.0), (2.0, 1.0), (2.0, 0.0),
                           (1.0, -1.0), (0.0, -1.0), (-1.0, 0.0)]
@@ -68,4 +77,4 @@ class BufferSideParamsCase(unittest.TestCase):
             self.assertAlmostEqual(coord[1], expected_coord[index][1])
 
 def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(BufferSideParamsCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BufferSingleSidedCase)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,75 @@
+from . import unittest
+from shapely import geometry
+
+
+class BufferSideParamsCase(unittest.TestCase):
+    """ Test Buffer Point/Line/Polygon with and without single_side params """
+
+    def test_empty(self):
+        g = geometry.Point(0,0)
+        h = g.buffer(0)
+        assert h.is_empty
+
+    def test_point(self):
+        g = geometry.Point(0, 0)
+        h = g.buffer(1, resolution=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        expected_coord = [(1.0, 0.0), (0, -1.0), (-1.0, 0), (0, 1.0), (1.0, 0.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_point_single_sided(self):
+        g = geometry.Point(0, 0)
+        h = g.buffer(1, resolution=1, single_side=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        expected_coord = [(1.0, 0.0), (0, -1.0), (-1.0, 0), (0, 1.0), (1.0, 0.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_line(self):
+        g = geometry.LineString([[0, 0], [0, 1]])
+        h = g.buffer(1, resolution=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        print(list(h.exterior.coords))
+        expected_coord = [(-1.0, 1.0), (0, 2.0), (1.0, 1.0), (1.0, 0.0), (0, -1.0), (-1.0, 0.0),
+                          (-1.0, 1.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_line_single_sided(self):
+        g = geometry.LineString([[0, 0], [0, 1]])
+        h = g.buffer(1, resolution=1, single_side=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        print(list(h.exterior.coords))
+        expected_coord = [(0.0, 1.0), (0.0, 0.0), (-1.0, 0.0), (-1.0, 1.0), (0.0, 1.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_polygon(self):
+        g = geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+        h = g.buffer(1, resolution=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        print(list(h.exterior.coords))
+        expected_coord = [(-1.0, 0.0), (-1.0, 1.0), (0.0, 2.0), (1.0, 2.0), (2.0, 1.0), (2.0, 0.0),
+                          (1.0, -1.0), (0.0, -1.0), (-1.0, 0.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+    def test_polygon_single_sided(self):
+        g = geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+        h = g.buffer(1, resolution=1, single_side=1)
+        self.assertEqual(h.geom_type, 'Polygon')
+        print(list(h.exterior.coords))
+        expected_coord = [(-1.0, 0.0), (-1.0, 1.0), (0.0, 2.0), (1.0, 2.0), (2.0, 1.0), (2.0, 0.0),
+                          (1.0, -1.0), (0.0, -1.0), (-1.0, 0.0)]
+        for index, coord in enumerate(h.exterior.coords):
+            self.assertAlmostEqual(coord[0], expected_coord[index][0])
+            self.assertAlmostEqual(coord[1], expected_coord[index][1])
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(BufferSideParamsCase)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -32,7 +32,6 @@ class BufferSideParamsCase(unittest.TestCase):
         g = geometry.LineString([[0, 0], [0, 1]])
         h = g.buffer(1, resolution=1)
         self.assertEqual(h.geom_type, 'Polygon')
-        print(list(h.exterior.coords))
         expected_coord = [(-1.0, 1.0), (0, 2.0), (1.0, 1.0), (1.0, 0.0), (0, -1.0), (-1.0, 0.0),
                           (-1.0, 1.0)]
         for index, coord in enumerate(h.exterior.coords):
@@ -43,7 +42,6 @@ class BufferSideParamsCase(unittest.TestCase):
         g = geometry.LineString([[0, 0], [0, 1]])
         h = g.buffer(1, resolution=1, single_side=1)
         self.assertEqual(h.geom_type, 'Polygon')
-        print(list(h.exterior.coords))
         expected_coord = [(0.0, 1.0), (0.0, 0.0), (-1.0, 0.0), (-1.0, 1.0), (0.0, 1.0)]
         for index, coord in enumerate(h.exterior.coords):
             self.assertAlmostEqual(coord[0], expected_coord[index][0])
@@ -53,7 +51,6 @@ class BufferSideParamsCase(unittest.TestCase):
         g = geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
         h = g.buffer(1, resolution=1)
         self.assertEqual(h.geom_type, 'Polygon')
-        print(list(h.exterior.coords))
         expected_coord = [(-1.0, 0.0), (-1.0, 1.0), (0.0, 2.0), (1.0, 2.0), (2.0, 1.0), (2.0, 0.0),
                           (1.0, -1.0), (0.0, -1.0), (-1.0, 0.0)]
         for index, coord in enumerate(h.exterior.coords):
@@ -64,7 +61,6 @@ class BufferSideParamsCase(unittest.TestCase):
         g = geometry.Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
         h = g.buffer(1, resolution=1, single_side=1)
         self.assertEqual(h.geom_type, 'Polygon')
-        print(list(h.exterior.coords))
         expected_coord = [(-1.0, 0.0), (-1.0, 1.0), (0.0, 2.0), (1.0, 2.0), (2.0, 1.0), (2.0, 0.0),
                           (1.0, -1.0), (0.0, -1.0), (-1.0, 0.0)]
         for index, coord in enumerate(h.exterior.coords):


### PR DESCRIPTION
Attempting to add support for single sided buffers raised in this issue: https://github.com/Toblerity/Shapely/issues/727

