### PR TITLE
Problems with VScode users and multiples environments

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -62,8 +62,7 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
                 libname, fallbacks or []))
 
 _lgeos = None
-def 
-:
+def exists_conda_env():
     """Does this module exist in a conda environment?"""
     return os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -140,7 +140,7 @@ elif sys.platform == 'darwin':
     free.restype = None
 
 elif sys.platform == 'win32':
-    if os.getenv('CONDA_PREFIX', ''):
+    if os.getenv('CONDA_PREFIX', '') and os.path.exists(os.path.join(sys.prefix, 'conda-meta')):
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
     else:

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -62,7 +62,9 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
                 libname, fallbacks or []))
 
 _lgeos = None
-is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
+def exists_conda_env():
+    """Does this module exist in a conda environment?"""
+    return os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 
 
 if sys.platform.startswith('linux'):

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -62,6 +62,8 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
                 libname, fallbacks or []))
 
 _lgeos = None
+is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
+
 
 if sys.platform.startswith('linux'):
     # Test to see if we have a wheel repaired by 'auditwheel' containing its
@@ -76,7 +78,7 @@ if sys.platform.startswith('linux'):
         if len(geos_pyinstaller_so) == 1:
             _lgeos = CDLL(geos_pyinstaller_so[0])
             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
-    elif os.getenv('CONDA_PREFIX', ''):
+    elif is_conda:
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
     else:
@@ -107,7 +109,7 @@ elif sys.platform == 'darwin':
             _lgeos = CDLL(geos_whl_dylib)
             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
 
-    elif os.getenv('CONDA_PREFIX', ''):
+    elif is_conda:
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
     else:
@@ -140,7 +142,7 @@ elif sys.platform == 'darwin':
     free.restype = None
 
 elif sys.platform == 'win32':
-    if os.getenv('CONDA_PREFIX', '') and os.path.exists(os.path.join(sys.prefix, 'conda-meta')):
+    if is_conda:
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
     else:

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -62,7 +62,8 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
                 libname, fallbacks or []))
 
 _lgeos = None
-def exists_conda_env():
+def 
+:
     """Does this module exist in a conda environment?"""
     return os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 
@@ -80,7 +81,7 @@ if sys.platform.startswith('linux'):
         if len(geos_pyinstaller_so) == 1:
             _lgeos = CDLL(geos_pyinstaller_so[0])
             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
-    elif is_conda:
+    elif exists_conda_env():
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
     else:
@@ -111,7 +112,7 @@ elif sys.platform == 'darwin':
             _lgeos = CDLL(geos_whl_dylib)
             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
 
-    elif is_conda:
+    elif exists_conda_env():
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
     else:
@@ -144,7 +145,7 @@ elif sys.platform == 'darwin':
     free.restype = None
 
 elif sys.platform == 'win32':
-    if is_conda:
+    if exists_conda_env():
         # conda package.
         _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
     else:


### PR DESCRIPTION
## Virtual Environment VScode problem

I have multiples different environments and diferents IDEs. When I was in VScode without conda, I had the following error:

```

from MTSPTW.algorithm.clustering import Clustering...
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\prueba_test.py in 
----> 1 from MTSPTW.algorithm.clustering import Clustering

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\MTSPTW\algorithm\clustering.py in 
      2 from pandas import concat, DataFrame
      3 from sklearn.cluster import KMeans
----> 4 from geopandas import datasets, read_file
      5 from shapely.geometry import Point
      6 import matplotlib.cm as color_maps

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\geopandas\__init__.py in 
----> 1 from geopandas.geoseries import GeoSeries  # noqa
      2 from geopandas.geodataframe import GeoDataFrame  # noqa
      3 from geopandas.array import _points_from_xy as points_from_xy  # noqa
      4 
      5 from geopandas.io.file import read_file  # noqa

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\geopandas\geoseries.py in 
      8 
      9 from pyproj import CRS, Transformer
---> 10 from shapely.geometry.base import BaseGeometry
     11 from shapely.ops import transform
     12 

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\shapely\geometry\__init__.py in 
      2 """
      3 
----> 4 from .base import CAP_STYLE, JOIN_STYLE
      5 from .geo import box, shape, asShape, mapping
      6 from .point import Point, asPoint

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\shapely\geometry\base.py in 
     16 
     17 from shapely.affinity import affine_transform
---> 18 from shapely.coords import CoordinateSequence
     19 from shapely.errors import WKBReadingError, WKTReadingError
     20 from shapely.geos import WKBWriter, WKTWriter

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\shapely\coords.py in 
      6 from ctypes import byref, c_double, c_uint
      7 
----> 8 from shapely.geos import lgeos
      9 from shapely.topology import Validating
     10 

c:\Users\alberto.rubiales\Desktop\projects\MTSPTW\venv-MTSPTW\lib\site-packages\shapely\geos.py in 
    143     if os.getenv('CONDA_PREFIX', ''):
    144         # conda package.
--> 145         _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
    146     else:
    147         try:

~\AppData\Local\Programs\Python\Python37\lib\ctypes\__init__.py in __init__(self, name, mode, handle, use_errno, use_last_error)
    362 
    363         if handle is None:
--> 364             self._handle = _dlopen(self._name, mode)
    365         else:
    366             self._handle = handle

OSError: [WinError 126] The specified module could not be found
```

In VScode without Conda when you execute code in jupyter interactive console with a virtual environment and you have other environments with conda  ```os.getenv('CONDA_PREFIX', '')``` is True, and the code give and error, because your actual environment is not in conda, so you need to change the doble condition.

**I have been researching and I think that this behaviour occurs because the Interactive Jupyter Python console of VScode works internally with Conda.**  But don't have conda-meta folder.

I have tested my solution in Virtual Environments with and without conda, and both work.

my current setup is:

* Windows: 10 64bits win32
* VScode: 1.42
* Python: 3.7.6
* Conda versions: 3.5.2 and 4.8.1

Yes, I have tested in both Conda versions.

any help or additional information you need, please let me know!