### PR TITLE
Fixing empty-ness test for coords - accommodate numpy

### DIFF
--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -32,7 +32,7 @@ def shape(context):
     elif geom_type == "linestring":
         return LineString(ob["coordinates"])
     elif geom_type == "polygon":
-        if not ob["coordinates"]:
+        if len(ob["coordinates"]) == 0:
             return Polygon()
         else:
             return Polygon(ob["coordinates"][0], ob["coordinates"][1:])

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -32,7 +32,9 @@ def shape(context):
     elif geom_type == "linestring":
         return LineString(ob["coordinates"])
     elif geom_type == "polygon":
-        if len(ob["coordinates"]) == 0:
+        if ob["coordinates"] is None:
+            return Polygon()
+        elif len(ob["coordinates"]) == 0:
             return Polygon()
         else:
             return Polygon(ob["coordinates"][0], ob["coordinates"][1:])

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,0 +1,39 @@
+from . import unittest
+from shapely.geometry import shape, Polygon
+import numpy as np
+
+
+class ShapeTestCase(unittest.TestCase):
+
+    def test_polygon_no_coords(self):
+        # using None
+        d = {"type": "Polygon", "coordinates": None}
+        p = shape(d)
+        self.assertEqual(p, Polygon())
+
+        # using empty list
+        d = {"type": "Polygon", "coordinates": []}
+        p = shape(d)
+        self.assertEqual(p, Polygon())
+
+        # using empty array
+        d = {"type": "Polygon", "coordinates": np.array([])}
+        p = shape(d)
+        self.assertEqual(p, Polygon())
+
+    def test_polygon_with_coords_list(self):
+        # list
+        d = {"type": "Polygon", "coordinates": [[[5, 10], [10, 10], [10, 5]]]}
+        p = shape(d)
+        self.assertEqual(p, Polygon([(5, 10), (10, 10), (10, 5)]))
+
+        # numpy array
+        d = {"type": "Polygon", "coordinates": np.array([[[5, 10],
+                                                          [10, 10],
+                                                          [10, 5]]])}
+        p = shape(d)
+        self.assertEqual(p, Polygon([(5, 10), (10, 10), (10, 5)]))
+
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(ShapeTestCase)


### PR DESCRIPTION
Per #840, this updates `shapely.geometry.geo.shape()`'s `Polygon` creation functionality accommodate NumPy arrays in `ob['coordinates']`. It required an extra `if`/`elif` to check for either `None` or empty lists/arrays because [truth-testing empty numpy arrays is now deprecated and throws an error](https://github.com/numpy/numpy/issues/9583).

I tested the fix with the `solaris` functionality that uses numpy arrays as coordinates and found it works.