### PR TITLE
Small fix to encoding for Python 2.7

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -576,7 +576,7 @@ def orient(geom, sign=1.0):
     """A properly oriented copy of the given geometry.
 
     The signed area of the result will have the given sign. A sign of
-    1.0 means that the coordinates of the product’s exterior rings will
+    1.0 means that the coordinates of the product's exterior rings will
     be oriented counter-clockwise.
 
     Parameters


### PR DESCRIPTION
https://github.com/Toblerity/Shapely/commit/053df248e4663c8a0f800a4c03e80521a28e8f2e causes an encoding error for Python 2.7 because of the fancy quote. This just replaces it with a dumb one.

This fixes the build failures in the other PRs.