### PR TITLE
Simplify RTD conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,8 @@
 name: _shapely
 channels:
 - defaults
-- conda-forge
 dependencies:
-- python>=3.5
-- cython
-- descartes
-- geos>=3.3
+- python==3.6.*
+- geos==3.8.*
 - matplotlib
-- numpy>=1.9
+- descartes


### PR DESCRIPTION
Fixes the failing doc builds: https://readthedocs.org/projects/shapely/builds/10532936/.

Docs here: https://shapely.readthedocs.io/en/rtd-memory-reduction/index.html.