### PR TITLE
Parallel offset docs

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1676,19 +1676,24 @@ linestring feature (right).
   Returns a LineString or MultiLineString geometry at a distance from the
   object on its right or its left side.
 
-  Distance must be a positive float value. The side parameter may be 'left' or
-  'right'. Left and right is determined by following the direction of given
-  geometric points of the LineString. The resolution of the offset around
-  each vertex of the object is parameterized as in the buffer method.
+  The `distance` parameter must be a positive float value.
 
-  The join style is for outside corners between line segments. Accepted integer
+  The `side` parameter may be 'left' or 'right'. Left and right are determined
+  by following the direction of the given geometric points of the LineString.
+  Right side offsets are returned in the reverse direction of the original
+  LineString or LineRing, while left side offsets flow in the same direction.
+
+  The `resolution` of the offset around each vertex of the object is
+  parameterized as in the :meth:`buffer` method.
+
+  The `join_style` is for outside corners between line segments. Accepted integer
   values are 1 (round), 2 (mitre), and 3 (bevel). See also
   :data:`shapely.geometry.JOIN_STYLE`.
 
-  Severely mitered corners can be controlled by the mitre_limit parameter
-  (spelled in British English, en-gb). The ratio of the distance from the
-  corner to the end of the mitred offset corner is the miter ratio. Corners
-  with a ratio which exceed the limit will be beveled.
+  Severely mitered corners can be controlled by the `mitre_limit` parameter
+  (spelled in British English, en-gb). The ratio of the `distance` parameter
+  and the distance from the corner to the end of the mitred offset corner is
+  the miter ratio. Corners with a ratio which exceed the limit will be beveled.
 
 .. note::
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1691,9 +1691,10 @@ linestring feature (right).
   :data:`shapely.geometry.JOIN_STYLE`.
 
   Severely mitered corners can be controlled by the `mitre_limit` parameter
-  (spelled in British English, en-gb). The ratio of the `distance` parameter
-  and the distance from the corner to the end of the mitred offset corner is
-  the miter ratio. Corners with a ratio which exceed the limit will be beveled.
+  (spelled in British English, en-gb). The corners of a parallel line will
+  be further from the original than most places with the mitre join style. The
+  ratio of this further distance to the specified `distance` is the miter ratio.
+  Corners with a ratio which exceed the limit will be beveled.
 
 .. note::
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1696,15 +1696,15 @@ linestring feature (right).
   ratio of this further distance to the specified `distance` is the miter ratio.
   Corners with a ratio which exceed the limit will be beveled.
 
-  .. warning::
+  .. note::
 
     This method may sometimes return a `MultiLineString` where a simple
     `LineString` was expected; for example, an offset to a slightly
     curved LineString.
 
-.. note::
+  .. note::
 
-  This method is only available for `LinearRing` and `LineString`  objects.
+    This method is only available for `LinearRing` and `LineString`  objects.
 
 .. plot:: code/parallel_offset.py
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1680,7 +1680,7 @@ linestring feature (right).
 
   The `side` parameter may be 'left' or 'right'. Left and right are determined
   by following the direction of the given geometric points of the LineString.
-  Right side offsets are returned in the reverse direction of the original
+  Right hand offsets are returned in the reverse direction of the original
   LineString or LineRing, while left side offsets flow in the same direction.
 
   The `resolution` of the offset around each vertex of the object is

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1696,6 +1696,12 @@ linestring feature (right).
   ratio of this further distance to the specified `distance` is the miter ratio.
   Corners with a ratio which exceed the limit will be beveled.
 
+  .. warning::
+
+    This method may sometimes return a `MultiLineString` where a simple
+    `LineString` was expected; for example, an offset to a slightly
+    curved LineString.
+
 .. note::
 
   This method is only available for `LinearRing` and `LineString`  objects.


### PR DESCRIPTION
Additions: 
  1. Mention right side reversal (#785)  
  2. Break up parameter descriptions into paragraphs  
  3. Italicize parameters (``)  
  4. Link buffer method where the docs for *resolution* parameter are outsourced to it.  
  5. Improved explanation of the *mitre_limit* parameter.
  6. Warn that a MultiLineString may be returned where a simple LineString is expected (#746)

Reservations:  

  1. Breaking up the parameter descriptions into paragraphs makes it consistent. But maybe harder to read because of some very short paragraphs? 
  2. Perhaps a warning about #746 is too heavy.  

Could be better: 
  1. An example of how to post-process in the case of a MultiLineString where a LineString is expected to get the LineString you want. Perhaps there is a simple solution to this that could rely on predictable ordering of the LineStrings within the returned MultiLineString? 

Edit: rst rendering checks out.
