### PR TITLE
Fix _split_polygon_with_line performance for big polygons with many holes

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -10,6 +10,7 @@ else:
 
 from ctypes import byref, c_void_p, c_double
 
+from shapely.prepared import prep
 from shapely.geos import lgeos
 from shapely.geometry.base import geom_factory, BaseGeometry, BaseMultipartGeometry
 from shapely.geometry import asShape, asLineString, asMultiLineString, Point, MultiPoint,\
@@ -339,6 +340,11 @@ class SplitOp(object):
         assert(isinstance(splitter, LineString))
 
         union = poly.boundary.union(splitter)
+
+        # greatly improves split performance for big geometries with many
+        # holes (the following contains checks) with minimal overhead
+        # for common cases
+        poly = prep(poly)
 
         # some polygonized geometries may be holes, we do not want them
         # that's why we test if the original polygon (poly) contains


### PR DESCRIPTION
`ops.split` of a polygon by line is slow on big polygons with many holes,
because of the many `poly.contains` operations needed after polygonize

This simply prepares the polygon to speed-up greatly those operations.

The overhead for little to no holes cases is minimal.

See attached a [profiling script](https://github.com/Toblerity/Shapely/files/4360331/shapely_split_pr_profile.zip) on two cases: 100 smalls polygons, and 1 big polygon (those are real geometries coming from satellite images).


Summary of script  output: 
```
original: collection of 100 small polygons (min 4, mean 15, max 49 points, no holes)
         42367 function calls in 0.112 seconds
...
original: one big polygon (total 105 183 points) with 585 holes
         50387 function calls in 49.933 seconds
...
with prep(): collection of 100 small polygons (min 4, mean 15, max 49 points, no holes)
         45229 function calls (45199 primitive calls) in 0.102 seconds
...
with prep(): one big polygon (total 105 183 points) with 585 holes
         51024 function calls in 1.109 seconds
...
```
