### PR TITLE
Set library paths in our CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,8 @@ install:
   - pip install -v -e .[all]
 
 script:
+  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ install:
   - pip install -v -e .[all]
 
 script:
-  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
-  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  # - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  # - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
   - python -c "from shapely.geos import geos_version; print(geos_version)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ install:
   - pip install -v -e .[all]
 
 script:
-  # - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
-  # - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
   - python -c "from shapely.geos import geos_version; print(geos_version)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ install:
 script:
   - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
   - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  - python -c "from shapely.geos import geos_version; print(geos_version)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 
 after_success:


### PR DESCRIPTION
In https://github.com/Toblerity/Shapely/pull/870 we're seeing signs that we're not using the GEOS versions we expect when we run the tests.