### PR TITLE
Drop Python 2.7 and Python 2 related logic and functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,6 @@ cache:
 
 matrix:
   include:
-    - python: "2.7"
-      env:
-        GEOSVERSION="3.4.3"
-        SPEEDUPS=1
-        NUMPY=1
-    - python: "2.7"
-      env:
-        GEOSVERSION="3.4.3"
-        SPEEDUPS=0
-        NUMPY=1
-    - python: "2.7"
-      env:
-        GEOSVERSION="3.4.3"
-        SPEEDUPS=0
-        NUMPY=0
     - python: "3.5"
       env:
         GEOSVERSION="3.5.2"

--- a/_vendor/packaging/_compat.py
+++ b/_vendor/packaging/_compat.py
@@ -1,20 +1,8 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
-from __future__ import absolute_import, division, print_function
-
-import sys
-
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 # flake8: noqa
-
-if PY3:
-    string_types = str,
-else:
-    string_types = basestring,
 
 
 def with_metaclass(meta, *bases):

--- a/_vendor/packaging/markers.py
+++ b/_vendor/packaging/markers.py
@@ -12,7 +12,6 @@ from pyparsing import ParseException, ParseResults, stringStart, stringEnd
 from pyparsing import ZeroOrMore, Group, Forward, QuotedString
 from pyparsing import Literal as L  # noqa
 
-from ._compat import string_types
 from .specifiers import Specifier, InvalidSpecifier
 
 
@@ -132,7 +131,7 @@ def _coerce_parse_result(results):
 
 
 def _format_marker(marker, first=True):
-    assert isinstance(marker, (list, tuple, string_types))
+    assert isinstance(marker, (list, tuple, str))
 
     # Sometimes we have a structure like [[...]] which is a single item list
     # where the single item is itself it's own list. In that case we want skip
@@ -201,7 +200,7 @@ def _evaluate_markers(markers, environment):
     groups = [[]]
 
     for marker in markers:
-        assert isinstance(marker, (list, tuple, string_types))
+        assert isinstance(marker, (list, tuple, str))
 
         if isinstance(marker, list):
             groups[-1].append(_evaluate_markers(marker, environment))

--- a/_vendor/packaging/specifiers.py
+++ b/_vendor/packaging/specifiers.py
@@ -8,7 +8,7 @@ import functools
 import itertools
 import re
 
-from ._compat import string_types, with_metaclass
+from ._compat import with_metaclass
 from .version import Version, LegacyVersion, parse
 
 
@@ -112,7 +112,7 @@ class _IndividualSpecifier(BaseSpecifier):
         return hash(self._spec)
 
     def __eq__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             try:
                 other = self.__class__(other)
             except InvalidSpecifier:
@@ -123,7 +123,7 @@ class _IndividualSpecifier(BaseSpecifier):
         return self._spec == other._spec
 
     def __ne__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             try:
                 other = self.__class__(other)
             except InvalidSpecifier:
@@ -625,7 +625,7 @@ class SpecifierSet(BaseSpecifier):
         return hash(self._specs)
 
     def __and__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             other = SpecifierSet(other)
         elif not isinstance(other, SpecifierSet):
             return NotImplemented
@@ -648,7 +648,7 @@ class SpecifierSet(BaseSpecifier):
         return specifier
 
     def __eq__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             other = SpecifierSet(other)
         elif isinstance(other, _IndividualSpecifier):
             other = SpecifierSet(str(other))
@@ -658,7 +658,7 @@ class SpecifierSet(BaseSpecifier):
         return self._specs == other._specs
 
     def __ne__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             other = SpecifierSet(other)
         elif isinstance(other, _IndividualSpecifier):
             other = SpecifierSet(str(other))

--- a/setup.py
+++ b/setup.py
@@ -61,24 +61,13 @@ import re
 import shutil
 import subprocess
 import sys
-try:
-    # If possible, use setuptools
-    from setuptools import setup
-    from setuptools.extension import Extension
-    from setuptools.command.build_ext import build_ext as distutils_build_ext
-except ImportError:
-    from distutils.core import setup
-    from distutils.extension import Extension
-    from distutils.command.build_ext import build_ext as distutils_build_ext
+from setuptools import setup
+from setuptools.extension import Extension
+from setuptools.command.build_ext import build_ext as distutils_build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError
 
 from _vendor.packaging.version import Version
-
-# Ensure minimum version of Python is running
-py_version = sys.version_info[0:2]
-if not (py_version == (2, 7) or py_version >= (3, 4)):
-    raise RuntimeError('Shapely requires Python 2.7, >=3.4')
 
 # Get geos_version from GEOS dynamic library, which depends on
 # GEOS_LIBRARY_PATH and/or GEOS_CONFIG environment variables
@@ -110,10 +99,7 @@ class GEOSConfig(object):
             raise OSError("Could not find geos-config script")
         if stderr and not stdout:
             raise ValueError(stderr.strip())
-        if sys.version_info[0] >= 3:
-            result = stdout.decode('ascii').strip()
-        else:
-            result = stdout.strip()
+        result = stdout.decode('ascii').strip()
         log.debug('%s %s: %r', self.cmd, option, result)
         return result
 
@@ -163,21 +149,16 @@ if geos_config and not os.environ.get('NO_GEOS_CHECK') or sys.platform == 'win32
             "Installation continuing. GEOS version will be "
             "checked on import of shapely.", exc)
 
-# Handle UTF-8 encoding of certain text files.
-open_kwds = {}
-if sys.version_info >= (3,):
-    open_kwds['encoding'] = 'utf-8'
-
-with open('VERSION.txt', 'w', **open_kwds) as fp:
+with open('VERSION.txt', 'w') as fp:
     fp.write(str(shapely_version))
 
-with open('README.rst', 'r', **open_kwds) as fp:
+with open('README.rst', 'r') as fp:
     readme = fp.read()
 
-with open('CREDITS.txt', 'r', **open_kwds) as fp:
+with open('CREDITS.txt', 'r', encoding='utf-8') as fp:
     credits = fp.read()
 
-with open('CHANGES.txt', 'r', **open_kwds) as fp:
+with open('CHANGES.txt', 'r') as fp:
     changes = fp.read()
 
 long_description = readme + '\n\n' + credits + '\n\n' + changes
@@ -185,7 +166,6 @@ long_description = readme + '\n\n' + credits + '\n\n' + changes
 extra_reqs = {
     'test': ['pytest', 'pytest-cov'],
     'vectorized': ['numpy']}
-
 extra_reqs['all'] = list(it.chain.from_iterable(extra_reqs.values()))
 
 # Make a dict of setup arguments. Some items will be updated as
@@ -193,7 +173,6 @@ extra_reqs['all'] = list(it.chain.from_iterable(extra_reqs.values()))
 setup_args = dict(
     name                = 'Shapely',
     version             = str(shapely_version),
-    requires            = ['Python (>=2.7)', 'libgeos_c (>=3.3)'],
     description         = 'Geometric objects, predicates, and operations',
     license             = 'BSD',
     keywords            = 'geometry topology gis',
@@ -217,8 +196,6 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -227,6 +204,7 @@ setup_args = dict(
         'Topic :: Scientific/Engineering :: GIS',
     ],
     cmdclass           = {},
+    python_requires    = '>=3.5',
     extras_require     = extra_reqs,
     package_data={
         'shapely': ['shapely/_geos.pxi']},

--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -76,10 +76,7 @@ def get_geos_config(option):
             'Could not find geos-config %r: %s' % (geos_config, ex))
     if stderr and not stdout:
         raise ValueError(stderr.strip())
-    if sys.version_info[0] >= 3:
-        result = stdout.decode('ascii').strip()
-    else:
-        result = stdout.strip()
+    result = stdout.decode('ascii').strip()
     log.debug('%s %s: %r', geos_config, option, result)
     return result
 
@@ -239,9 +236,7 @@ def _geos_version():
     GEOSversion.restype = c_char_p
     GEOSversion.argtypes = []
     # #define GEOS_CAPI_VERSION "@VERSION@-CAPI-@CAPI_VERSION@"
-    geos_version_string = GEOSversion()
-    if sys.version_info[0] >= 3:
-        geos_version_string = geos_version_string.decode('ascii')
+    geos_version_string = GEOSversion().decode('ascii')
 
     res = re.findall(r'(\d+)\.(\d+)\.(\d+)', geos_version_string)
     geos_version = tuple(int(x) for x in res[0])

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -8,9 +8,6 @@ from ctypes import byref, c_double, c_uint
 from shapely.geos import lgeos
 from shapely.topology import Validating
 
-if sys.version_info[0] < 3:
-    range = xrange
-
 
 class CoordinateSequence(object):
     """

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -22,18 +22,11 @@ from shapely.geos import lgeos
 from shapely.impl import DefaultImplementation, delegated
 
 
-if sys.version_info[0] < 3:
-    range = xrange
-    integer_types = (int, long)
-else:
-    integer_types = (int,)
-
-
 try:
     import numpy as np
-    integer_types = integer_types + (np.integer,)
+    integer_types = (int, np.integer)
 except ImportError:
-    pass
+    integer_types = (int,)
 
 
 GEOMETRY_TYPES = [
@@ -97,8 +90,7 @@ def geom_factory(g, parent=None):
 def geom_from_wkt(data):
     warn("`geom_from_wkt` is deprecated. Use `geos.wkt_reader.read(data)`.",
          DeprecationWarning)
-    if sys.version_info[0] >= 3:
-        data = data.encode('ascii')
+    data = data.encode('ascii')
     geom = lgeos.GEOSGeomFromWKT(c_char_p(data))
     if not geom:
         raise WKTReadingError(

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -1,11 +1,6 @@
 """Line strings and related utilities
 """
 
-import sys
-
-if sys.version_info[0] < 3:
-    range = xrange
-
 from ctypes import c_double
 
 from shapely.geos import lgeos, TopologicalError
@@ -204,7 +199,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
 
     try:
         m = len(ob)
-    except TypeError:  # Iterators, e.g. Python 3 zip
+    except TypeError:  # generators
         ob = list(ob)
         m = len(ob)
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -1,11 +1,6 @@
 """Collections of linestrings and related utilities
 """
 
-import sys
-
-if sys.version_info[0] < 3:
-    range = xrange
-
 from ctypes import c_void_p, cast
 
 from shapely.geos import lgeos

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -1,11 +1,6 @@
 """Collections of points and related utilities
 """
 
-import sys
-
-if sys.version_info[0] < 3:
-    range = xrange
-
 from ctypes import byref, c_double, c_void_p, cast
 
 from shapely.geos import lgeos

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -1,11 +1,6 @@
 """Collections of polygons and related utilities
 """
 
-import sys
-
-if sys.version_info[0] < 3:
-    range = xrange
-
 from ctypes import c_void_p, cast
 
 from shapely.geos import lgeos

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -203,7 +203,7 @@ def geos_point_from_py(ob, update_geom=None, update_ndim=0):
         return geos_geom_from_py(ob)
 
     # Accept either (x, y) or [(x, y)]
-    if not hasattr(ob, '__getitem__'):  # Iterators, e.g. Python 3 zip
+    if not hasattr(ob, '__getitem__'):  # generators
         ob = list(ob)
 
     if isinstance(ob[0], tuple):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -3,9 +3,6 @@
 
 import sys
 
-if sys.version_info[0] < 3:
-    range = xrange
-
 from ctypes import c_void_p, cast, POINTER
 import weakref
 
@@ -145,9 +142,6 @@ class InteriorRingSequence(object):
             return ring
         else:
             raise StopIteration
-
-    if sys.version_info[0] < 3:
-        next = __next__
 
     def __len__(self):
         return lgeos.GEOSGetNumInteriorRings(self._geom)
@@ -425,7 +419,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
 
     try:
         m = len(ob)
-    except TypeError:  # Iterators, e.g. Python 3 zip
+    except TypeError:  # generators
         ob = list(ob)
         m = len(ob)
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -1,13 +1,6 @@
 """Support for various GEOS geometry operations
 """
 
-import sys
-
-if sys.version_info[0] < 3:
-    from itertools import izip
-else:
-    izip = zip
-
 from ctypes import byref, c_void_p, c_double
 
 from shapely.prepared import prep
@@ -232,11 +225,11 @@ def transform(func, geom):
         # extra cost.
         try:
             if geom.type in ('Point', 'LineString', 'LinearRing'):
-                return type(geom)(zip(*func(*izip(*geom.coords))))
+                return type(geom)(zip(*func(*zip(*geom.coords))))
             elif geom.type == 'Polygon':
                 shell = type(geom.exterior)(
-                    zip(*func(*izip(*geom.exterior.coords))))
-                holes = list(type(ring)(zip(*func(*izip(*ring.coords))))
+                    zip(*func(*zip(*geom.exterior.coords))))
+                holes = list(type(ring)(zip(*func(*zip(*ring.coords))))
                              for ring in geom.interiors)
                 return type(geom)(shell, holes)
 

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 # geos_linestring_from_py was transcribed from shapely.geometry.linestring
 # geos_linearring_from_py was transcribed from shapely.geometry.polygon
 # coordseq_ctypes was transcribed from shapely.coords.CoordinateSequence.ctypes
@@ -126,7 +128,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
             cs = GEOSCoordSeq_create_r(handle, <int>m, <int>n)
 
         # add to coordinate sequence
-        for i in xrange(m):
+        for i in range(m):
             dx = cp[sm*i]
             dy = cp[sm*i+sn]
             dz = 0
@@ -144,7 +146,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
         # Fall back on list
         try:
             m = len(ob)
-        except TypeError:  # Iterators, e.g. Python 3 zip
+        except TypeError:  # generators
             ob = list(ob)
             m = len(ob)
 
@@ -182,7 +184,7 @@ def geos_linestring_from_py(ob, update_geom=None, update_ndim=0):
             cs = GEOSCoordSeq_create_r(handle, <int>m, <int>n)
 
         # add to coordinate sequence
-        for i in xrange(m):
+        for i in range(m):
             coords = _coords(ob[i])
             dx = coords[0]
             dy = coords[1]
@@ -289,7 +291,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
             cs = GEOSCoordSeq_create_r(handle, M, n)
 
         # add to coordinate sequence
-        for i in xrange(m):
+        for i in range(m):
             dx = cp[sm*i]
             dy = cp[sm*i+sn]
             dz = 0
@@ -322,7 +324,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
         # Fall back on list
         try:
             m = len(ob)
-        except TypeError:  # Iterators, e.g. Python 3 zip
+        except TypeError:  # generators
             ob = list(ob)
             m = len(ob)
 
@@ -362,7 +364,7 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
             cs = GEOSCoordSeq_create_r(handle, M, n)
         
         # add to coordinate sequence
-        for i in xrange(m):
+        for i in range(m):
             coords = _coords(ob[i])
             dx = coords[0]
             dy = coords[1]
@@ -417,7 +419,7 @@ def coordseq_ctypes(self):
     cs = cast_seq(self._cseq)
     data_p = <double *><uintptr_t>ctypes.addressof(data)
     
-    for i in xrange(m):
+    for i in range(m):
         GEOSCoordSeq_getX_r(handle, cs, i, &temp)
         data_p[n*i] = temp
         GEOSCoordSeq_getY_r(handle, cs, i, &temp)

--- a/shapely/vectorized/_vectorized.pyx
+++ b/shapely/vectorized/_vectorized.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=3
+
 import cython
 cimport cpython.array
 
@@ -105,7 +107,7 @@ cdef _predicated_1d(geometry, np.double_t[:] x, np.double_t[:] y, predicate fn):
     geos_geom = geos_from_prepared(geometry)
 
     with nogil:
-        for idx in xrange(n):
+        for idx in range(n):
             # Construct a coordinate sequence with our x, y values.
             cs = GEOSCoordSeq_create_r(geos_h, 1, 2)
             GEOSCoordSeq_setX_r(geos_h, cs, 0, x[idx])

--- a/tests/test_geos_err_handler.py
+++ b/tests/test_geos_err_handler.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import pytest
 
@@ -43,7 +42,6 @@ def test_error_handler_wrong_type():
         loads(1)
 
 
-@pytest.mark.skipif(sys.version_info[0] < 3, reason='accept str and unicode for python2 and str for python3')
 def test_error_handler_for_bytes():
     with pytest.raises(TypeError):
         loads(b'POINT (10 10)')

--- a/tests/test_ndarrays.py
+++ b/tests/test_ndarrays.py
@@ -2,10 +2,7 @@
 # https://github.com/sgillies/shapely/issues/26 for discussion.
 # Requires numpy.
 
-import sys
-
-if sys.version_info[0] >= 3:
-    from functools import reduce
+from functools import reduce
 
 from . import unittest
 from shapely import geometry

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -9,14 +9,6 @@ import struct
 
 class PersistTestCase(unittest.TestCase):
 
-    @staticmethod
-    def _byte(i):
-        """Convert an integer in the range [0, 256) to a byte."""
-        if bytes == str: # Python 2
-            return chr(i)
-        else: # Python 3
-            return int(i)
-
     def test_pickle(self):
 
         p = Point(0.0, 0.0)
@@ -44,8 +36,8 @@ class PersistTestCase(unittest.TestCase):
         # Simple Features Specification for SQL, revision 1.1, the
         # first byte of a WKB representation indicates byte order.
         # Big-endian is 0, little-endian is 1.
-        self.assertEqual(wkb_big_endian[0], self._byte(0))
-        self.assertEqual(wkb_little_endian[0], self._byte(1))
+        self.assertEqual(wkb_big_endian[0], 0)
+        self.assertEqual(wkb_little_endian[0], 1)
         # Check that the doubles (0.5, 2.0) are in correct byte order
         double_size = struct.calcsize('d')
         self.assertEqual(

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,11 +1,7 @@
 import pytest
 from shapely.geometry import Point, LineString, LinearRing, Polygon, MultiPoint
 
-import sys
-if sys.version_info[0] >= 3:
-    from pickle import dumps, loads, HIGHEST_PROTOCOL
-else:
-    from cPickle import dumps, loads, HIGHEST_PROTOCOL
+from pickle import dumps, loads, HIGHEST_PROTOCOL
 
 TEST_DATA = {
     "point2d": (Point, [(1.0, 2.0)]),


### PR DESCRIPTION
* Minimum Python version 3.5
* Simplify/remove if-blocks that handled Python 2 or 3 logic
* No more izip or xrange
* Set cython: language_level=3
* Rearrange setup() kwargs for distutils or setuptools

Closes #743