### PR TITLE
Update the docs and docstrings for transform

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2024,7 +2024,7 @@ If using `pyproj>=2.1.0`, the preferred method to project geometries is:
     utm = pyproj.crs.CRS('epsg:26913')
 
     project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
-    utm_point = transform(project, wgs84_point)
+    utm_point = transform(project, wgs84_pt)
 
 Otherwise, a partially applied transform function from pyproj also satisfies the requirements
 for `func`.
@@ -2044,7 +2044,7 @@ for `func`.
         wgs84,
         utm)
 
-    utm_point = transform(project, wgs84_point)
+    utm_point = transform(project, wgs84_pt)
 
 It is important to note that in the two examples above, the `always_xy` kwarg is required as Shapely only supports coordinates in X,Y
 order, and in PROJ 6 the WGS84 CRS uses the EPSG-defined Lat/Lon coordinate order instead of the expected Lon/Lat.
@@ -2066,7 +2066,7 @@ If using `pyproj < 2.1`, use syntax like:
         wgs84,
         utm)
 
-    utm_point = transform(project, wgs84_point)
+    utm_point = transform(project, wgs84_pt)
 
 Lambda expressions such as the one in
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2019,8 +2019,8 @@ If using `pyproj>=2.1.0`, the preferred method to project geometries is:
 
     wgs84_pt = Point(-72.2495, 43.886)
 
-    wgs84 = pyproj.CRS('epsg:4326')
-    utm = pyproj.CRS('epsg:32618')
+    wgs84 = pyproj.CRS('EPSG:4326')
+    utm = pyproj.CRS('EPSG:32618')
 
     project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
     utm_point = transform(project, wgs84_pt)

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2013,40 +2013,19 @@ If using `pyproj>=2.1.0`, the preferred method to project geometries is:
 .. code-block:: python
 
     import pyproj
-    import pyproj.crs
 
     from shapely.geometry import Point
     from shapely.ops import transform
 
     wgs84_pt = Point(-72.2495, 43.886)
 
-    wgs84 = pyproj.crs.CRS('epsg:4326')
-    utm = pyproj.crs.CRS('epsg:32618')
+    wgs84 = pyproj.CRS('epsg:4326')
+    utm = pyproj.CRS('epsg:32618')
 
     project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
     utm_point = transform(project, wgs84_pt)
 
-Otherwise, a partially applied transform function from pyproj also satisfies the requirements
-for `func`.
-
-.. code-block:: python
-
-    from functools import partial
-    import pyproj
-
-    from shapely.ops import transform
-
-    wgs84 = pyproj.Proj('epsg:4326', always_xy=True)
-    utm = pyproj.Proj('epsg:32618', always_xy=True)
-
-    project = partial(
-        pyproj.transform,
-        wgs84,
-        utm)
-
-    utm_point = transform(project, wgs84_pt)
-
-It is important to note that in the two examples above, the `always_xy` kwarg is required as Shapely only supports coordinates in X,Y
+It is important to note that in the example above, the `always_xy` kwarg is required as Shapely only supports coordinates in X,Y
 order, and in PROJ 6 the WGS84 CRS uses the EPSG-defined Lat/Lon coordinate order instead of the expected Lon/Lat.
 
 If using `pyproj < 2.1`, then the canonical example is:

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2018,10 +2018,10 @@ If using `pyproj>=2.1.0`, the preferred method to project geometries is:
     from shapely.geometry import Point
     from shapely.ops import transform
 
-    wgs84_pt = Point(-70, 42)
+    wgs84_pt = Point(-72.2495, 43.886)
 
     wgs84 = pyproj.crs.CRS('epsg:4326')
-    utm = pyproj.crs.CRS('epsg:26913')
+    utm = pyproj.crs.CRS('epsg:32618')
 
     project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
     utm_point = transform(project, wgs84_pt)
@@ -2037,7 +2037,7 @@ for `func`.
     from shapely.ops import transform
 
     wgs84 = pyproj.Proj('epsg:4326', always_xy=True)
-    utm = pyproj.Proj('epsg:26913', always_xy=True)
+    utm = pyproj.Proj('epsg:32618', always_xy=True)
 
     project = partial(
         pyproj.transform,
@@ -2059,7 +2059,7 @@ If using `pyproj < 2.1`, use syntax like:
     from shapely.ops import transform
 
     wgs84 = pyproj.Proj(init='epsg:4326')
-    utm = pyproj.Proj(init='epsg:26913')
+    utm = pyproj.Proj(init='epsg:32618')
 
     project = partial(
         pyproj.transform,

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1991,9 +1991,16 @@ Shapely supports map projections and other arbitrary transformations of geometri
   geometry of the same type from the transformed coordinates.
 
   `func` maps x, y, and optionally z to output xp, yp, zp. The input
-  parameters may iterable types like lists or arrays or single values.
+  parameters may be iterable types like lists or arrays or single values.
   The output shall be of the same type: scalars in, scalars out;
   lists in, lists out.
+
+  `transform` tries to determine which kind of function was passed in
+  by calling `func` first with n iterables of coordinates, where n
+  is the dimensionality of the input geometry. If `func` raises
+  a `TypeError` when called with iterables as arguments,
+  then it will instead call `func` on each individual coordinate
+  in the geometry.
 
   `New in version 1.2.18`.
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2049,7 +2049,7 @@ for `func`.
 It is important to note that in the two examples above, the `always_xy` kwarg is required as Shapely only supports coordinates in X,Y
 order, and in PROJ 6 the WGS84 CRS uses the EPSG-defined Lat/Lon coordinate order instead of the expected Lon/Lat.
 
-If using `pyproj < 2.1`, use syntax like:
+If using `pyproj < 2.1`, then the canonical example is:
 
 .. code-block:: python
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -203,16 +203,14 @@ def transform(func, geom):
 
       g2 = transform(id_func, g1)
 
-    A partially applied transform function from pyproj satisfies the
-    requirements for `func`.
+    Using pyproj >= 2.1, this example will accurately project Shapely geometries:
 
-      from functools import partial
       import pyproj
 
-      project = partial(
-          pyproj.transform,
-          pyproj.Proj('epsg:4326', always_xy=True),
-          pyproj.Proj('epsg:26913', always_xy=True))
+      wgs84 = pyproj.CRS('epsg:4326')
+      utm = pyproj.CRS('epsg:32618')
+
+      project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
 
       g2 = transform(project, g1)
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -207,8 +207,8 @@ def transform(func, geom):
 
       import pyproj
 
-      wgs84 = pyproj.CRS('epsg:4326')
-      utm = pyproj.CRS('epsg:32618')
+      wgs84 = pyproj.CRS('EPSG:4326')
+      utm = pyproj.CRS('EPSG:32618')
 
       project = pyproj.Transformer.from_crs(wgs84, utm, always_xy=True).transform
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -211,10 +211,13 @@ def transform(func, geom):
 
       project = partial(
           pyproj.transform,
-          pyproj.Proj(init='epsg:4326'),
-          pyproj.Proj(init='epsg:26913'))
+          pyproj.Proj('epsg:4326', always_xy=True),
+          pyproj.Proj('epsg:26913', always_xy=True))
 
       g2 = transform(project, g1)
+
+    Note that the always_xy kwarg is required here as Shapely geometries only support
+    X,Y coordinate ordering.
 
     Lambda expressions such as the one in
 


### PR DESCRIPTION
This should address both #878 and #826. The docs now reflect the updated API in `pyproj >= 2.1`, demonstrate use of `Transformer` and `CRS`; show clearly and call out the necessity of `always_xy` per #878; and include the classic example using older versions of `pyproj`. I also changed the order of the examples to show the more current behavior of `pyproj` first.