### PR TITLE
Load libc on darwin in any cases

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -135,7 +135,11 @@ elif sys.platform == 'darwin':
             ]
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 
-    free = load_dll('c').free
+    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
+    # manpage says, "If filename is NULL, then the returned handle is for the
+    # main program". This way we can let the linker do the work to figure out
+    # which libc Python is actually using.
+    free = CDLL(None).free
     free.argtypes = [c_void_p]
     free.restype = None
 


### PR DESCRIPTION
Per #888 

`load_dll('c').free` fail on Darwin, without MacPort or Homebrew, because libc is not found on my system.
By default, on Mac, `libc` is provided by `libSystem.dylib`.

A robust solution is to replace `load_dll('c').free` by `CDLL(None).free` because Python is already using libc.

>     CDLL(None) internally calls dlopen(NULL), and as the dlopen
>     manpage says, "If filename is NULL, then the returned handle is for the
>     # main program". This way we can let the linker do the work to figure out
>     # which libc Python is actually using.
> 
