### PR TITLE
Guard against calling methods on lgeos after it's been cleaned up

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -50,6 +50,7 @@ class STRtree:
                 lgeos.GEOSSTRtree_destroy(self._tree_handle)
             except AttributeError:
                 pass  # lgeos might be empty on shutdown.
+
             self._tree_handle = None
 
     def query(self, geom):

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -45,7 +45,7 @@ class STRtree:
         self._geoms = list(geoms)
 
     def __del__(self):
-        if self._tree_handle is not None:
+        if self._tree_handle is not None and lgeos is not None:
             lgeos.GEOSSTRtree_destroy(self._tree_handle)
             self._tree_handle = None
 

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -45,8 +45,11 @@ class STRtree:
         self._geoms = list(geoms)
 
     def __del__(self):
-        if self._tree_handle is not None and lgeos is not None:
-            lgeos.GEOSSTRtree_destroy(self._tree_handle)
+        if self._tree_handle is not None:
+            try:
+                lgeos.GEOSSTRtree_destroy(self._tree_handle)
+            except AttributeError:
+                pass  # lgeos might be empty on shutdown.
             self._tree_handle = None
 
     def query(self, geom):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,12 @@ import sys
 
 import pytest
 
+from shapely.geos import geos_version
+
+
+requires_geos_342 = pytest.mark.skipif(geos_version < (3, 4, 2), reason="GEOS > 3.4.2 is required.")
+
+
 def pytest_addoption(parser):
     parser.addoption("--with-speedups", action="store_true", default=False,
                      help="Run tests with speedups.")

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -2,7 +2,8 @@ import gc
 
 from shapely.strtree import STRtree
 from shapely.geometry import Point, Polygon
-from shapely import geos
+
+from shapely import strtree
 
 from tests.conftest import requires_geos_342
 
@@ -72,9 +73,9 @@ def test_references():
 def test_safe_delete():
     tree = STRtree([])
 
-    _lgeos = geos.lgeos
-    geos.lgeos = None
+    _lgeos = strtree.lgeos
+    strtree.lgeos = None
 
     del tree
 
-    geos.lgeos = _lgeos
+    strtree.lgeos = _lgeos

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -1,69 +1,80 @@
 import gc
 
-from . import unittest
-
 from shapely.strtree import STRtree
 from shapely.geometry import Point, Polygon
-from shapely.geos import geos_version
+from shapely import geos
+
+from tests.conftest import requires_geos_342
 
 
-@unittest.skipIf(geos_version < (3, 4, 2), 'GEOS 3.4.2 required')
-class STRTestCase(unittest.TestCase):
-    def test_query(self):
-        points = [Point(i, i) for i in range(10)]
-        tree = STRtree(points)
-        results = tree.query(Point(2,2).buffer(0.99))
-        self.assertEqual(len(results), 1)
-        results = tree.query(Point(2,2).buffer(1.0))
-        self.assertEqual(len(results), 3)
-
-    def test_insert_empty_geometry(self):
-        """
-        Passing nothing but empty geometries results in an empty strtree.
-        The query segfaults if the empty geometry was actually inserted.
-        """
-        empty = Polygon()
-        geoms = [empty]
-        tree = STRtree(geoms)
-        assert(tree._n_geoms == 0)
-        query = Polygon([(0,0),(1,1),(2,0),(0,0)])
-        results = tree.query(query)
-
-    def test_query_empty_geometry(self):
-        """
-        Empty geometries should be filtered out.
-        The query segfaults if the empty geometry was actually inserted.
-        """
-        empty = Polygon()
-        point = Point(1, 0.5)
-        geoms = [empty, point]
-        tree = STRtree(geoms)
-        assert(tree._n_geoms == 1)
-        query = Polygon([(0,0),(1,1),(2,0),(0,0)])
-        results = tree.query(query)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0], point)
-
-    def test_references(self):
-        """Don't crash due to dangling references"""
-        empty = Polygon()
-        point = Point(1, 0.5)
-        geoms = [empty, point]
-        tree = STRtree(geoms)
-        assert(tree._n_geoms == 1)
-
-        empty = None
-        point = None
-        gc.collect()
-
-        query = Polygon([(0,0),(1,1),(2,0),(0,0)])
-        results = tree.query(query)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0], Point(1, 0.5))
+@requires_geos_342
+def test_query():
+    points = [Point(i, i) for i in range(10)]
+    tree = STRtree(points)
+    results = tree.query(Point(2, 2).buffer(0.99))
+    assert len(results) == 1
+    results = tree.query(Point(2, 2).buffer(1.0))
+    assert len(results) == 3
 
 
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(STRTestCase)
+@requires_geos_342
+def test_insert_empty_geometry():
+    """
+    Passing nothing but empty geometries results in an empty strtree.
+    The query segfaults if the empty geometry was actually inserted.
+    """
+    empty = Polygon()
+    geoms = [empty]
+    tree = STRtree(geoms)
+    assert tree._n_geoms == 0
+    query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
+    results = tree.query(query)
+    assert len(results) == 0
 
-if __name__ == '__main__':
-    unittest.main()
+
+@requires_geos_342
+def test_query_empty_geometry():
+    """
+    Empty geometries should be filtered out.
+    The query segfaults if the empty geometry was actually inserted.
+    """
+    empty = Polygon()
+    point = Point(1, 0.5)
+    geoms = [empty, point]
+    tree = STRtree(geoms)
+    assert tree._n_geoms == 1
+    query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
+    results = tree.query(query)
+    assert len(results) == 1
+    assert results[0] == point
+
+
+@requires_geos_342
+def test_references():
+    """Don't crash due to dangling references"""
+    empty = Polygon()
+    point = Point(1, 0.5)
+    geoms = [empty, point]
+    tree = STRtree(geoms)
+    assert tree._n_geoms == 1
+
+    empty = None
+    point = None
+    gc.collect()
+
+    query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
+    results = tree.query(query)
+    assert len(results) == 1
+    assert results[0] == Point(1, 0.5)
+
+
+@requires_geos_342
+def test_safe_delete():
+    tree = STRtree([])
+
+    _lgeos = geos.lgeos
+    geos.lgeos = None
+
+    del tree
+
+    geos.lgeos = _lgeos


### PR DESCRIPTION
Fix for #830.

I couldn't really replicate this issue on macos, but [this merge request](https://github.com/Toblerity/Shapely/pull/528) fixed a very similar issue in basically the same way, and [`PreparedGeometry`](https://github.com/Toblerity/Shapely/blob/de4838e102dcfd54aadc8af03ed33def918334e6/shapely/prepared.py#L36) has a guard against the same thing, so it seems like it is a known situation where shapely's geos handle has been disposed of before python has cleaned up other Shapely objects.

For completeness I checked all the other `__del__` methods in Shapely and it looks like this is the last unguarded one. 

I switched the tests for `STRtree` from `unittest` to `pytest` because it seems like tests are moving in that direction and I thought I'd do it while I was in there, but if that's not cool I'm happy to switch them back.
