### PR TITLE
Raise an error on creation of MultiPoint or LineString with empty components

### DIFF
--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -31,3 +31,7 @@ class TopologicalError(ShapelyError):
 
 class PredicateError(ShapelyError):
     """A geometric predicate has failed to return True/False."""
+
+
+class EmptyPartError(ShapelyError):
+    """An error signifying an empty part was encountered when creating a multi-part."""

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -132,6 +132,10 @@ def geos_multilinestring_from_py(ob):
     # add to coordinate sequence
     for l in range(L):
         geom, ndims = linestring.geos_linestring_from_py(obs[l])
+
+        if lgeos.GEOSisEmpty(geom):
+            raise ValueError("Can't create MultiLineString with empty component")
+
         subs[l] = cast(geom, c_void_p)
             
     return (lgeos.GEOSGeom_createCollection(5, subs, L), N)

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -8,6 +8,7 @@ if sys.version_info[0] < 3:
 
 from ctypes import c_void_p, cast
 
+from shapely.errors import EmptyPartError, DimensionError
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
 from shapely.geometry import linestring
@@ -134,7 +135,7 @@ def geos_multilinestring_from_py(ob):
         geom, ndims = linestring.geos_linestring_from_py(obs[l])
 
         if lgeos.GEOSisEmpty(geom):
-            raise ValueError("Can't create MultiLineString with empty component")
+            raise EmptyPartError("Can't create MultiLineString with empty component")
 
         subs[l] = cast(geom, c_void_p)
             

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -8,7 +8,7 @@ if sys.version_info[0] < 3:
 
 from ctypes import c_void_p, cast
 
-from shapely.errors import EmptyPartError, DimensionError
+from shapely.errors import EmptyPartError
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
 from shapely.geometry import linestring

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -8,6 +8,7 @@ if sys.version_info[0] < 3:
 
 from ctypes import byref, c_double, c_void_p, cast
 
+from shapely.errors import EmptyPartError, DimensionError
 from shapely.geos import lgeos
 from shapely.geometry.base import (
     BaseMultipartGeometry, exceptNull, geos_geom_from_py)
@@ -171,7 +172,7 @@ def geos_multipoint_from_py(ob):
         geom, ndims = point.geos_point_from_py(coords)
 
         if lgeos.GEOSisEmpty(geom):
-            raise ValueError("Can't create MultiPoint with empty component")
+            raise EmptyPartError("Can't create MultiPoint with empty component")
 
         subs[i] = cast(geom, c_void_p)
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -8,7 +8,7 @@ if sys.version_info[0] < 3:
 
 from ctypes import byref, c_double, c_void_p, cast
 
-from shapely.errors import EmptyPartError, DimensionError
+from shapely.errors import EmptyPartError
 from shapely.geos import lgeos
 from shapely.geometry.base import (
     BaseMultipartGeometry, exceptNull, geos_geom_from_py)

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -169,6 +169,10 @@ def geos_multipoint_from_py(ob):
     for i in range(m):
         coords = ob[i]
         geom, ndims = point.geos_point_from_py(coords)
+
+        if lgeos.GEOSisEmpty(geom):
+            raise ValueError("Can't create MultiPoint with empty component")
+
         subs[i] = cast(geom, c_void_p)
 
     return lgeos.GEOSGeom_createCollection(4, subs, m), n

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,5 +1,6 @@
 from . import unittest, numpy, test_int_types
 from .test_multi import MultiGeometryTestCase
+from shapely.errors import EmptyPartError
 from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
@@ -80,7 +81,7 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
         self.subgeom_access_test(MultiLineString, [line0, line1])
 
     def test_create_multi_with_empty_component(self):
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(EmptyPartError) as exc:
             wkt = MultiLineString([
                 LineString([(0, 0), (1, 1), (2, 2)]),
                 LineString()

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -87,7 +87,7 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
                 LineString()
             ]).wkt
 
-        self.assertRegex(str(exc.exception), "Can't create MultiLineString with empty component")
+        self.assertEqual(str(exc.exception), "Can't create MultiLineString with empty component")
 
 
 def test_suite():

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -79,6 +79,15 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
         line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
         self.subgeom_access_test(MultiLineString, [line0, line1])
 
+    def test_create_multi_with_empty_component(self):
+        with self.assertRaises(ValueError) as exc:
+            wkt = MultiLineString([
+                LineString([(0, 0), (1, 1), (2, 2)]),
+                LineString()
+            ]).wkt
+
+        self.assertRegex(str(exc.exception), "Can't create MultiLineString with empty component")
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiLineStringTestCase)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,5 +1,6 @@
 from . import unittest, numpy, test_int_types
 from .test_multi import MultiGeometryTestCase
+from shapely.errors import EmptyPartError
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
 
@@ -75,7 +76,7 @@ class MultiPointTestCase(MultiGeometryTestCase):
         self.subgeom_access_test(MultiPoint, [p0, p1])
 
     def test_create_multi_with_empty_component(self):
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(EmptyPartError) as exc:
             wkt = MultiPoint([Point(0, 0), Point()]).wkt
 
         self.assertRegex(str(exc.exception), "Can't create MultiPoint with empty component")

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -79,7 +79,7 @@ class MultiPointTestCase(MultiGeometryTestCase):
         with self.assertRaises(EmptyPartError) as exc:
             wkt = MultiPoint([Point(0, 0), Point()]).wkt
 
-        self.assertRegex(str(exc.exception), "Can't create MultiPoint with empty component")
+        self.assertEqual(str(exc.exception), "Can't create MultiPoint with empty component")
 
 
 def test_suite():

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy, test_int_types
+from . import unittest, numpy
 from .test_multi import MultiGeometryTestCase
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
@@ -73,6 +73,13 @@ class MultiPointTestCase(MultiGeometryTestCase):
         p0 = Point(1.0, 2.0)
         p1 = Point(3.0, 4.0)
         self.subgeom_access_test(MultiPoint, [p0, p1])
+
+    def test_create_multi_with_empty_component(self):
+        with self.assertRaises(ValueError) as exc:
+            wkt = MultiPoint([Point(0, 0), Point()]).wkt
+
+        self.assertRegex(str(exc.exception), "Can't create MultiPoint with empty component")
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,4 +1,4 @@
-from . import unittest, numpy
+from . import unittest, numpy, test_int_types
 from .test_multi import MultiGeometryTestCase
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords


### PR DESCRIPTION
Closes #836.

As of Shapely 1.7, asking for the WKT of a MultiPoint or -LineString with an empty component results in a segfault. I figured it made more sense to error in that case and let the user take care of the issue - realistically I can't see much utility in having a MultiPoint or -LineString with an empty component anyway, and I don't think you can create such a geometry through WKT, WKB, or GeoJSON, so it doesn't make sense to allow it through the geometry object constructor, either.