### PR TITLE
Update docs re: WKT serialization

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2541,6 +2541,11 @@ counterparts. To serialize a geometric object to a binary or text string, use
 ``dumps()``. To deserialize a string and get a new geometric object of the
 appropriate type, use ``loads()``.
 
+The default settings for the wkt attribute and `shapely.wkt.dumps()` function
+are different. By default, the property's value is trimmed of excess decimals,
+while this is not the case for `dumps()`, though it can be replicated by setting
+`trim=True`.
+
 .. function:: shapely.wkb.dumps(ob)
 
   Returns a WKB representation of `ob`.
@@ -2551,18 +2556,23 @@ appropriate type, use ``loads()``.
 
 .. code-block:: pycon
 
-  >> from shapely.wkb import dumps, loads
-  >>> wkb = dumps(Point(0, 0))
-  >>> wkb.encode('hex')
+  >>> from shapely import wkb
+  >>> pt = Point(0, 0)
+  >>> wkb.dumps(pt)
+  b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  >>> pt.wkb
+  b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+  >>> pt.wkb_hex
   '010100000000000000000000000000000000000000'
-  >>> loads(wkb).wkt
-  'POINT (0.0000000000000000 0.0000000000000000)'
+  >>> wkb.loads(pt.wkb).wkt
+  'POINT (0 0)'
 
 All of Shapely's geometry types are supported by these functions.
 
 .. function:: shapely.wkt.dumps(ob)
 
-  Returns a WKT representation of `ob`.
+  Returns a WKT representation of `ob`. Several keyword arguments are available
+  to alter the WKT which is returned; see the docstrings for more details.
 
 .. function:: shapely.wkt.loads(wkt)
 
@@ -2570,11 +2580,14 @@ All of Shapely's geometry types are supported by these functions.
 
 .. code-block:: pycon
 
-  >> from shapely.wkt import dumps, loads
-  >> wkt = dumps(Point(0, 0))
-  >>> wkt
+  >>> from shapely import wkt
+  >>> pt = Point(0, 0)
+  >>> thewkt = wkt.dumps(pt)
+  >>> thewkt
   'POINT (0.0000000000000000 0.0000000000000000)'
-  >>> loads(wkt).wkt
+  >>> pt.wkt
+  'POINT (0 0)'
+  >>> wkt.dumps(pt, trim=True)
   'POINT (0 0)'
 
 Numpy and Python Arrays

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2542,7 +2542,7 @@ counterparts. To serialize a geometric object to a binary or text string, use
 appropriate type, use ``loads()``.
 
 The default settings for the wkt attribute and `shapely.wkt.dumps()` function
-are different. By default, the property's value is trimmed of excess decimals,
+are different. By default, the attribute's value is trimmed of excess decimals,
 while this is not the case for `dumps()`, though it can be replicated by setting
 `trim=True`.
 

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -6,21 +6,76 @@ from shapely import geos
 # Pickle-like convenience functions
 
 def loads(data):
-    """Load a geometry from a WKT string."""
+    """
+    Load a geometry from a WKT string.
+
+    Parameters
+    ----------
+    data :
+        A WKT string
+
+    Returns
+    -------
+    Shapely geometry object
+    """
     return geos.WKTReader(geos.lgeos).read(data)
 
 def load(fp):
-    """Load a geometry from an open file."""
+    """
+    Load a geometry from an open file.
+
+    Parameters
+    ----------
+    fp :
+        A file-like object which implements a `read` method.
+
+    Returns
+    -------
+    Shapely geometry object
+    """
     data = fp.read()
     return loads(data)
 
 def dumps(ob, trim=False, **kw):
-    """Dump a WKT representation of a geometry to a string.
+    """
+    Dump a WKT representation of a geometry to a string.
 
-    See available keyword output settings in ``shapely.geos.WKTWriter``.
+    Parameters
+    ----------
+    ob :
+        A geometry object of any type to be dumped to WKT.
+    trim :
+        Remove excess decimals from the WKT.
+    rounding_precision (GEOS 3.3+):
+        Round output to the specified number of digits
+    output_dimension (GEOS 3.3+)
+        Force removal of dimensions above the one specified
+
+    Returns
+    -------
+    input geometry as WKT string
     """
     return geos.WKTWriter(geos.lgeos, trim=trim, **kw).write(ob)
 
 def dump(ob, fp, **settings):
-    """Dump a geometry to an open file."""
+    """
+    Dump a geometry to an open file.
+
+    Parameters
+    ----------
+    ob :
+        A geometry object of any type to be dumped to WKT.
+    fp :
+        A file-like object which implements a `write` method.
+    trim :
+        Remove excess decimals from the WKT.
+    rounding_precision (GEOS 3.3+):
+        Round output to the specified number of digits
+    output_dimension (GEOS 3.3+)
+        Force removal of dimensions above the one specified
+
+    Returns
+    -------
+    None
+    """
     fp.write(dumps(ob, **settings))

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -48,8 +48,9 @@ def dumps(ob, trim=False, **kw):
         Remove excess decimals from the WKT.
     rounding_precision (GEOS 3.3+):
         Round output to the specified number of digits
-    output_dimension (GEOS 3.3+)
-        Force removal of dimensions above the one specified
+    output_dimension (GEOS 3.3+):
+        Force removal of dimensions above the one specified.
+        Defaults to 3.
 
     Returns
     -------

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -5,13 +5,14 @@ from shapely import geos
 
 # Pickle-like convenience functions
 
+
 def loads(data):
     """
     Load a geometry from a WKT string.
 
     Parameters
     ----------
-    data :
+    data : str
         A WKT string
 
     Returns
@@ -19,6 +20,7 @@ def loads(data):
     Shapely geometry object
     """
     return geos.WKTReader(geos.lgeos).read(data)
+
 
 def load(fp):
     """
@@ -36,6 +38,7 @@ def load(fp):
     data = fp.read()
     return loads(data)
 
+
 def dumps(ob, trim=False, **kw):
     """
     Dump a WKT representation of a geometry to a string.
@@ -44,19 +47,20 @@ def dumps(ob, trim=False, **kw):
     ----------
     ob :
         A geometry object of any type to be dumped to WKT.
-    trim :
+    trim : bool, default False
         Remove excess decimals from the WKT.
-    rounding_precision (GEOS 3.3+):
-        Round output to the specified number of digits
-    output_dimension (GEOS 3.3+):
+    rounding_precision (GEOS 3.3+) : int
+        Round output to the specified number of digits.
+        Default behavior returns full precision.
+    output_dimension (GEOS 3.3+): int, default 3
         Force removal of dimensions above the one specified.
-        Defaults to 3.
 
     Returns
     -------
     input geometry as WKT string
     """
     return geos.WKTWriter(geos.lgeos, trim=trim, **kw).write(ob)
+
 
 def dump(ob, fp, **settings):
     """
@@ -68,12 +72,13 @@ def dump(ob, fp, **settings):
         A geometry object of any type to be dumped to WKT.
     fp :
         A file-like object which implements a `write` method.
-    trim :
+    trim : bool, default False
         Remove excess decimals from the WKT.
-    rounding_precision (GEOS 3.3+):
-        Round output to the specified number of digits
-    output_dimension (GEOS 3.3+)
-        Force removal of dimensions above the one specified
+    rounding_precision (GEOS 3.3+) : int
+        Round output to the specified number of digits.
+        Default behavior returns full precision.
+    output_dimension (GEOS 3.3+): int, default 3
+        Force removal of dimensions above the one specified.
 
     Returns
     -------


### PR DESCRIPTION
Adds some more detail to docs around WKT serializiation, addressing #910. Also adds docstrings to `wkt.dump` and `wkt.dumps` to explicitly list available keyword arguments.