### PR TITLE
Deprecate asShape (CachingGeometryProxy adapter classes)

### DIFF
--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,7 +1,11 @@
 """
 Geometry factories based on the geo interface
 """
-from .point import Point, asPoint
+import warnings
+
+from shapely.errors import ShapelyDeprecationWarning
+
+from .point import Point, _asPoint
 from .linestring import LineString, asLineString
 from .polygon import Polygon, asPolygon
 from .multipoint import MultiPoint, asMultiPoint
@@ -153,6 +157,11 @@ def asShape(context):
     >>> poly.intersects(point)
     False
     """
+    warnings.warn(
+        "The 'asShape()' adapter is deprecated and will be removed in Shapely 2.0. "
+        "Use the 'shape()' function instead.",
+        ShapelyDeprecationWarning, stacklevel=2)
+
     if hasattr(context, "__geo_interface__"):
         ob = context.__geo_interface__
     else:
@@ -164,7 +173,7 @@ def asShape(context):
         raise ValueError("Context does not provide geo interface")
 
     if geom_type == "point":
-        return asPoint(ob["coordinates"])
+        return _asPoint(ob["coordinates"])
     elif geom_type == "linestring":
         return asLineString(ob["coordinates"])
     elif geom_type == "polygon":

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,6 +1,10 @@
 """
 Geometry factories based on the geo interface
 """
+import warnings
+
+from shapely.errors import ShapelyDeprecationWarning
+
 from .point import Point, asPoint
 from .linestring import LineString, asLineString
 from .polygon import Polygon, asPolygon
@@ -122,6 +126,12 @@ def asShape(context):
     stored in the context, and changes to them will be reflected in the
     returned geometry object.
 
+    .. deprecated:: 1.8
+       The proxy geometries (adapter classes) created by this function are
+       deprecated, and this function will be removed in Shapely 2.0.
+       Use the `shape` function instead to convert a GeoJSON-like dict
+       to a Shapely geometry.
+
     Parameters
     ----------
     context :
@@ -177,6 +187,13 @@ def asShape(context):
         return MultiPolygonAdapter(ob["coordinates"], context_type='geojson')
     elif geom_type == "geometrycollection":
         geoms = [asShape(g) for g in ob.get("geometries", [])]
+        if len(geoms) == 0:
+            # in this case no asShape call already raised the warning
+            warnings.warn(
+                "The proxy geometries (through the 'asShape()' constructor) "
+                "are deprecated and will be removed in Shapely 2.0. Use the "
+                "'shape()' function instead.",
+                ShapelyDeprecationWarning, stacklevel=2)
         return GeometryCollection(geoms)
     else:
         raise ValueError("Unknown geometry type: %s" % geom_type)

--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -1,11 +1,7 @@
 """
 Geometry factories based on the geo interface
 """
-import warnings
-
-from shapely.errors import ShapelyDeprecationWarning
-
-from .point import Point, _asPoint
+from .point import Point, asPoint
 from .linestring import LineString, asLineString
 from .polygon import Polygon, asPolygon
 from .multipoint import MultiPoint, asMultiPoint
@@ -157,11 +153,6 @@ def asShape(context):
     >>> poly.intersects(point)
     False
     """
-    warnings.warn(
-        "The 'asShape()' adapter is deprecated and will be removed in Shapely 2.0. "
-        "Use the 'shape()' function instead.",
-        ShapelyDeprecationWarning, stacklevel=2)
-
     if hasattr(context, "__geo_interface__"):
         ob = context.__geo_interface__
     else:
@@ -173,7 +164,7 @@ def asShape(context):
         raise ValueError("Context does not provide geo interface")
 
     if geom_type == "point":
-        return _asPoint(ob["coordinates"])
+        return asPoint(ob["coordinates"])
     elif geom_type == "linestring":
         return asLineString(ob["coordinates"])
     elif geom_type == "polygon":

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -154,6 +154,12 @@ class LineString(BaseGeometry):
 class LineStringAdapter(CachingGeometryProxy, LineString):
 
     def __init__(self, context):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asLineString()' or "
+            "'LineStringAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'LineString()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=4)
         self.context = context
         self.factory = geos_linestring_from_py
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -2,7 +2,9 @@
 """
 
 from ctypes import c_void_p, cast
+import warnings
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
 from shapely.geometry import linestring
@@ -82,6 +84,12 @@ class MultiLineStringAdapter(CachingGeometryProxy, MultiLineString):
     _other_owned = False
 
     def __init__(self, context):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asMultiLineString()' "
+            "or 'MultiLineStringAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'MultiLineString()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=4)
         self.context = context
         self.factory = geos_multilinestring_from_py
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -2,7 +2,9 @@
 """
 
 from ctypes import byref, c_double, c_void_p, cast
+import warnings
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.geometry.base import (
     BaseMultipartGeometry, exceptNull, geos_geom_from_py)
@@ -117,6 +119,12 @@ class MultiPointAdapter(CachingGeometryProxy, MultiPoint):
     _other_owned = False
 
     def __init__(self, context):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asMultiPoint()' "
+            "or 'MultiPointAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'MultiPoint()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=4)
         self.context = context
         self.factory = geos_multipoint_from_py
 

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -2,7 +2,9 @@
 """
 
 from ctypes import c_void_p, cast
+import warnings
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.geometry.base import BaseMultipartGeometry, geos_geom_from_py
 from shapely.geometry import polygon
@@ -101,6 +103,12 @@ class MultiPolygonAdapter(CachingGeometryProxy, MultiPolygon):
     _other_owned = False
 
     def __init__(self, context, context_type='polygons'):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asMultiPolygon()' "
+            "or 'MultiPolygonAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'MultiPolygon()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=3)
         self.context = context
         if context_type == 'geojson':
             self.factory = geos_multipolygon_from_py

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -169,6 +169,12 @@ class PointAdapter(CachingGeometryProxy, Point):
     _other_owned = False
 
     def __init__(self, context):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asPoint()' or "
+            "'PointAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'Point()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=4)
         self.context = context
         self.factory = geos_point_from_py
 
@@ -202,14 +208,6 @@ class PointAdapter(CachingGeometryProxy, Point):
 
 def asPoint(context):
     """Adapt an object to the Point interface"""
-    warnings.warn(
-        "The 'asPoint' adapter is deprecated and will be removed in Shapely 2.0. "
-        "Use the standard 'Point' constructor instead.",
-        ShapelyDeprecationWarning, stacklevel=2)
-    return _asPoint(context)
-
-
-def _asPoint(context):
     return PointAdapter(context)
 
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -202,6 +202,14 @@ class PointAdapter(CachingGeometryProxy, Point):
 
 def asPoint(context):
     """Adapt an object to the Point interface"""
+    warnings.warn(
+        "The 'asPoint' adapter is deprecated and will be removed in Shapely 2.0. "
+        "Use the standard 'Point' constructor instead.",
+        ShapelyDeprecationWarning, stacklevel=2)
+    return _asPoint(context)
+
+
+def _asPoint(context):
     return PointAdapter(context)
 
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -103,6 +103,12 @@ class LinearRingAdapter(LineStringAdapter):
     __p__ = None
 
     def __init__(self, context):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asLinearRing()' or "
+            "'LinearRingAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'LinearRing()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=3)
         self.context = context
         self.factory = geos_linearring_from_py
 
@@ -367,6 +373,12 @@ class Polygon(BaseGeometry):
 class PolygonAdapter(PolygonProxy, Polygon):
 
     def __init__(self, shell, holes=None):
+        warnings.warn(
+            "The proxy geometries (through the 'asShape()', 'asPolygon()' or "
+            "'PolygonAdapter()' constructors) are deprecated and will be "
+            "removed in Shapely 2.0. Use the 'shape()' function or the "
+            "standard 'Polygon()' constructor instead.",
+            ShapelyDeprecationWarning, stacklevel=4)
         self.shell = shell
         self.holes = holes
         self.context = (shell, holes)

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -6,8 +6,8 @@ from ctypes import byref, c_void_p, c_double
 from shapely.prepared import prep
 from shapely.geos import lgeos
 from shapely.geometry.base import geom_factory, BaseGeometry, BaseMultipartGeometry
-from shapely.geometry import asShape, asLineString, asMultiLineString, Point, MultiPoint,\
-                             LineString, MultiLineString, Polygon, GeometryCollection
+from shapely.geometry import (
+    shape, Point, MultiPoint, LineString, MultiLineString, Polygon, GeometryCollection)
 from shapely.geometry.polygon import orient as orient_
 from shapely.algorithms.polylabel import polylabel
 
@@ -25,9 +25,9 @@ class CollectionOperator(object):
             return ob
         else:
             try:
-                return asShape(ob)
-            except ValueError:
-                return asLineString(ob)
+                return shape(ob)
+            except (ValueError, AttributeError):
+                return LineString(ob)
 
     def polygonize(self, lines):
         """Creates polygons from a source of lines
@@ -105,9 +105,9 @@ class CollectionOperator(object):
             source = lines
         elif hasattr(lines, '__iter__'):
             try:
-                source = asMultiLineString([ls.coords for ls in lines])
+                source = MultiLineString([ls.coords for ls in lines])
             except AttributeError:
-                source = asMultiLineString(lines)
+                source = MultiLineString(lines)
         if source is None:
             raise ValueError("Cannot linemerge %s" % lines)
         result = lgeos.GEOSLineMerge(source._geom)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,8 +1,12 @@
-from . import unittest
+from . import unittest, shapely20_deprecated
+
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import LineString
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry import shape
 from shapely.geometry import asShape
+
+import pytest
 
 
 class CollectionTestCase(unittest.TestCase):
@@ -26,7 +30,8 @@ class CollectionTestCase(unittest.TestCase):
         # access geometry, this should not seg fault as 1.2.15 did
         self.assertIsNotNone(child.wkt)
 
-    def test_geointerface(self):
+    @shapely20_deprecated
+    def test_geointerface_adapter(self):
         d = {"type": "GeometryCollection","geometries": [
                 {"type": "Point", "coordinates": (0, 3)},
                 {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
@@ -40,6 +45,12 @@ class CollectionTestCase(unittest.TestCase):
         self.assertIn("Point", geom_types)
         self.assertIn("LineString", geom_types)
 
+    def test_geointerface(self):
+        d = {"type": "GeometryCollection","geometries": [
+                {"type": "Point", "coordinates": (0, 3)},
+                {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
+            ]}
+
         # shape
         m = shape(d)
         self.assertEqual(m.geom_type, "GeometryCollection")
@@ -48,7 +59,8 @@ class CollectionTestCase(unittest.TestCase):
         self.assertIn("Point", geom_types)
         self.assertIn("LineString", geom_types)
 
-    def test_empty_geointerface(self):
+    @shapely20_deprecated
+    def test_empty_geointerface_adapter(self):
         d = {"type": "GeometryCollection", "geometries": []}
 
         # asShape
@@ -56,6 +68,9 @@ class CollectionTestCase(unittest.TestCase):
         self.assertEqual(m.geom_type, "GeometryCollection")
         self.assertEqual(len(m), 0)
         self.assertEqual(m.geoms, [])
+
+    def test_empty_geointerface(self):
+        d = {"type": "GeometryCollection", "geometries": []}
 
         # shape
         m = shape(d)
@@ -75,6 +90,19 @@ class CollectionTestCase(unittest.TestCase):
         self.assertEqual(m.geom_type, "GeometryCollection")
         self.assertEqual(len(m), 0)
         self.assertEqual(m.geoms, [])
+
+
+def test_geometrycollection_adapter_deprecated():
+    d = {"type": "GeometryCollection","geometries": [
+            {"type": "Point", "coordinates": (0, 3)},
+            {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
+    ]}
+    with pytest.warns(ShapelyDeprecationWarning):
+        asShape(d)
+
+    d = {"type": "GeometryCollection", "geometries": []}
+    with pytest.warns(ShapelyDeprecationWarning):
+        asShape(d)
 
 
 def test_suite():

--- a/tests/test_create_inconsistent_dimensionality.py
+++ b/tests/test_create_inconsistent_dimensionality.py
@@ -10,7 +10,7 @@ any dimension which is not present in every coordinate.
 import pytest
 
 from shapely import wkt
-from shapely.geometry import asShape, LineString, Polygon
+from shapely.geometry import shape, LineString, Polygon
 
 
 geojson_cases = [
@@ -37,7 +37,7 @@ wkt_cases = [
 @pytest.mark.parametrize('geojson', geojson_cases)
 def test_create_from_geojson(geojson):
     with pytest.raises(ValueError) as exc:
-        wkt = asShape(geojson).wkt
+        wkt = shape(geojson).wkt
     assert exc.match("Inconsistent coordinate dimensionality")
 
 

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -1,9 +1,13 @@
 from . import unittest
+
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry.base import BaseGeometry, EmptyGeometry
 import shapely.geometry as sgeom
 from shapely.geometry.polygon import LinearRing
 
 from shapely.geometry import MultiPolygon, mapping, shape, asShape
+
+import pytest
 
 
 empty_generator = lambda: iter([])
@@ -63,11 +67,20 @@ class EmptinessTestCase(unittest.TestCase):
         self.assertTrue(LinearRing(empty_generator()).is_empty)
 
 
+def test_shape_empty():
+    empty_mp = MultiPolygon()
+    empty_json = mapping(empty_mp)
+    empty_shape = shape(empty_json)
+    assert empty_shape.is_empty
+
+
 def test_asshape_empty():
     empty_mp = MultiPolygon()
     empty_json = mapping(empty_mp)
-    empty_asShape = asShape(empty_json)
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        empty_asShape = asShape(empty_json)
     assert empty_asShape.is_empty
+
 
 
 def test_suite():

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -50,6 +50,7 @@ class LineStringTestCase(unittest.TestCase):
                          {'type': 'LineString',
                           'coordinates': ((-1.0, -1.0), (1.0, 1.0))})
 
+    @shapely20_deprecated
     def test_linestring_adapter(self):
         # Adapt a coordinate list to a line string
         coords = [[5.0, 6.0], [7.0, 8.0]]
@@ -148,6 +149,12 @@ class LineStringTestCase(unittest.TestCase):
         la = asarray(line.coords)
         assert_array_equal(la, expected)
 
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_adapter(self):
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
         # Adapt a Numpy array to a line string
         a = array([[1.0, 2.0], [3.0, 4.0]])
         la = asLineString(a)
@@ -161,6 +168,11 @@ class LineStringTestCase(unittest.TestCase):
         pas = asarray(la)
         assert_array_equal(pas, array([[1.0, 2.0], [3.0, 4.0]]))
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_asarray(self):
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
         # From Array.txt
         a = asarray([[0.0, 0.0], [2.0, 2.0], [1.0, 1.0]])
         line = LineString(a)
@@ -173,6 +185,11 @@ class LineStringTestCase(unittest.TestCase):
         b = asarray(line)
         assert_array_equal(b, array([[0., 0.], [2., 2.], [1., 1.]]))
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_empty(self):
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
         # Test array interface of empty linestring
         le = LineString()
         a = asarray(le)
@@ -184,6 +201,11 @@ def test_linestring_mutability_deprecated():
     with pytest.warns(ShapelyDeprecationWarning, match="Setting"):
         line.coords = ((-1.0, -1.0), (1.0, 1.0))
 
+
+def test_linestring_adapter_deprecated():
+    coords = [[5.0, 6.0], [7.0, 8.0]]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asLineString(coords)
 
 
 def test_suite():

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -1,5 +1,9 @@
-from . import unittest, numpy, test_int_types
+from . import unittest, numpy, shapely20_deprecated
 from .test_multi import MultiGeometryTestCase
+
+import pytest
+
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.geometry import LineString, MultiLineString, asMultiLineString
 from shapely.geometry.base import dump_coords
@@ -66,6 +70,13 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
         self.assertEqual(len(geom.geoms), 1)
         self.assertEqual(dump_coords(geom), [[(0.0, 0.0), (1.0, 2.0)]])
 
+
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_adapter(self):
+        from numpy import array
+        from numpy.testing import assert_array_equal
+
         # Adapt a sequence of Numpy arrays to a multilinestring
         a = [array(((1.0, 2.0), (3.0, 4.0)))]
         geoma = asMultiLineString(a)
@@ -78,6 +89,12 @@ class MultiLineStringTestCase(MultiGeometryTestCase):
         line0 = LineString([(0.0, 1.0), (2.0, 3.0)])
         line1 = LineString([(4.0, 5.0), (6.0, 7.0)])
         self.subgeom_access_test(MultiLineString, [line0, line1])
+
+
+def test_multilinestring_adapter_deprecated():
+    coords = [[[5.0, 6.0], [7.0, 8.0]]]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asMultiLineString(coords)
 
 
 def test_suite():

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -1,5 +1,9 @@
-from . import unittest, numpy, test_int_types
+from . import unittest, numpy, shapely20_deprecated
 from .test_multi import MultiGeometryTestCase
+
+import pytest
+
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import Point, MultiPoint, asMultiPoint
 from shapely.geometry.base import dump_coords
 
@@ -35,6 +39,8 @@ class MultiPointTestCase(MultiGeometryTestCase):
                          {'type': 'MultiPoint',
                           'coordinates': ((1.0, 2.0), (3.0, 4.0))})
 
+    @shapely20_deprecated
+    def test_multipoint_adapter(self):
         # Adapt a coordinate list to a line string
         coords = [[5.0, 6.0], [7.0, 8.0]]
         geoma = asMultiPoint(coords)
@@ -56,6 +62,13 @@ class MultiPointTestCase(MultiGeometryTestCase):
         geom = MultiPoint((Point(1.0, 2.0), Point(3.0, 4.0)))
         assert_array_equal(array(geom), array([[1., 2.], [3., 4.]]))
 
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_adapter(self):
+
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
         # Adapt a Numpy array to a multipoint
         a = array([[1.0, 2.0], [3.0, 4.0]])
         geoma = asMultiPoint(a)
@@ -73,6 +86,13 @@ class MultiPointTestCase(MultiGeometryTestCase):
         p0 = Point(1.0, 2.0)
         p1 = Point(3.0, 4.0)
         self.subgeom_access_test(MultiPoint, [p0, p1])
+
+
+def test_multipoint_adapter_deprecated():
+    coords = [[5.0, 6.0], [7.0, 8.0]]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asMultiPoint(coords)
+
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -1,8 +1,10 @@
 import pytest
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import Polygon, MultiPolygon, asMultiPolygon
 from shapely.geometry.base import dump_coords
-from . import unittest, numpy, test_int_types
+
+from . import unittest, numpy, test_int_types, shapely20_deprecated
 from .test_multi import MultiGeometryTestCase
 
 
@@ -61,6 +63,8 @@ class MultiPolygonTestCase(MultiGeometryTestCase):
                               ((0.25, 0.25), (0.25, 0.5), (0.5, 0.5),
                                (0.5, 0.25), (0.25, 0.25)))]})
 
+    @shapely20_deprecated
+    def test_multipolygon_adapter(self):
         # Adapter
         coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
         holes_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]
@@ -87,3 +91,8 @@ def test_fail_list_of_multipolygons():
         MultiPolygon([multi])
 
 
+def test_multipolygon_adapter_deprecated():
+    coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
+    holes_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asMultiPolygon([(coords, holes_coords)])

--- a/tests/test_ndarrays.py
+++ b/tests/test_ndarrays.py
@@ -4,7 +4,7 @@
 
 from functools import reduce
 
-from . import unittest
+from . import unittest, shapely20_deprecated
 from shapely import geometry
 
 try:
@@ -15,11 +15,45 @@ except ImportError:
 
 class TransposeTestCase(unittest.TestCase):
 
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'numpy not installed')
+    def test_multipoint_adapter(self):
+        arr = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        tarr = arr.T
+        shape = geometry.asMultiPoint(tarr)
+        coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape])
+        self.assertEqual(
+            coords,
+            [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
+        )
+
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'numpy not installed')
+    def test_linestring_adapter(self):
+        a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        t = a.T
+        s = geometry.asLineString(t)
+        self.assertEqual(
+            list(s.coords),
+            [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
+        )
+
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'numpy not installed')
+    def test_polygon_adapter(self):
+        a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
+        t = a.T
+        s = geometry.asPolygon(t)
+        self.assertEqual(
+            list(s.exterior.coords),
+            [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
+        )
+
     @unittest.skipIf(not numpy, 'numpy not installed')
     def test_multipoint(self):
         arr = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         tarr = arr.T
-        shape = geometry.asMultiPoint(tarr)
+        shape = geometry.MultiPoint(tarr)
         coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape])
         self.assertEqual(
             coords,
@@ -30,7 +64,7 @@ class TransposeTestCase(unittest.TestCase):
     def test_linestring(self):
         a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         t = a.T
-        s = geometry.asLineString(t)
+        s = geometry.LineString(t)
         self.assertEqual(
             list(s.coords),
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
@@ -40,12 +74,11 @@ class TransposeTestCase(unittest.TestCase):
     def test_polygon(self):
         a = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         t = a.T
-        s = geometry.asPolygon(t)
+        s = geometry.Polygon(t)
         self.assertEqual(
             list(s.exterior.coords),
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
         )
-
 
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(TransposeTestCase)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -62,6 +62,7 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(p.__geo_interface__,
                          {'type': 'Point', 'coordinates': (0.0, 0.0)})
 
+    @shapely20_deprecated
     def test_point_adapter(self):
         p = Point(0.0, 0.0)
         # Adapt a coordinate list to a point
@@ -103,6 +104,12 @@ class LineStringTestCase(unittest.TestCase):
         p = Point(array([1.0, 2.0]))
         self.assertEqual(p.coords[:], [(1.0, 2.0)])
 
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_adapter(self):
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
         # Adapt a Numpy array to a point
         a = array([1.0, 2.0])
         pa = asPoint(a)
@@ -125,6 +132,11 @@ class LineStringTestCase(unittest.TestCase):
         self.assertIsNotNone(pa.__array_interface__)
         pas = asarray(pa)
         assert_array_equal(pas, array([1.0, 4.0]))
+
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_asarray(self):
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
 
         # From Array.txt
         p = Point(0.0, 0.0, 1.0)
@@ -165,6 +177,12 @@ def test_point_mutability_deprecated():
     p = Point(3.0, 4.0)
     with pytest.warns(ShapelyDeprecationWarning, match="Setting"):
         p.coords = (2.0, 1.0)
+
+
+def test_point_adapter_deprecated():
+    coords = [3.0, 4.0]
+    with pytest.warns(ShapelyDeprecationWarning, match="adapter is deprecated"):
+        asPoint(coords)
 
 
 def test_suite():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -181,7 +181,7 @@ def test_point_mutability_deprecated():
 
 def test_point_adapter_deprecated():
     coords = [3.0, 4.0]
-    with pytest.warns(ShapelyDeprecationWarning, match="adapter is deprecated"):
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
         asPoint(coords)
 
 

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -2,8 +2,11 @@
 """
 
 from . import unittest, numpy, shapely20_deprecated
+
+import pytest
+
 from shapely.wkb import loads as load_wkb
-from shapely.errors import TopologicalError
+from shapely.errors import TopologicalError, ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.geometry import Point, Polygon, asPolygon
 from shapely.geometry.polygon import LinearRing, LineString, asLinearRing
@@ -39,6 +42,7 @@ class PolygonTestCase(unittest.TestCase):
              'coordinates': ((0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0),
                              (0.0, 0.0))})
 
+    @shapely20_deprecated
     def test_linearring_adapter(self):
         # Test ring adapter
         coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
@@ -108,17 +112,20 @@ class PolygonTestCase(unittest.TestCase):
                              (0.0, 0.0)), ((0.25, 0.25), (0.25, 0.5),
                              (0.5, 0.5), (0.5, 0.25), (0.25, 0.25)))})
 
+        # Error handling
+        with self.assertRaises(ValueError):
+            # A LinearRing must have at least 3 coordinate tuples
+            Polygon([[1, 2], [2, 3]])
+
+    @shapely20_deprecated
+    def test_polygon_adapter(self):
         # Adapter
+        coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
         hole_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]
         pa = asPolygon(coords, hole_coords)
         self.assertEqual(len(pa.exterior.coords), 5)
         self.assertEqual(len(pa.interiors), 1)
         self.assertEqual(len(pa.interiors[0].coords), 5)
-
-        # Error handling
-        with self.assertRaises(ValueError):
-            # A LinearRing must have at least 3 coordinate tuples
-            Polygon([[1, 2], [2, 3]])
 
     def test_linearring_empty(self):
         # Test Non-operability of Null rings
@@ -271,6 +278,19 @@ class PolygonTestCase(unittest.TestCase):
     def test_empty_polygon_exterior(self):
         p = Polygon()
         assert p.exterior == LinearRing()
+
+
+def test_linearring_adapter_deprecated():
+    coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asLinearRing(coords)
+
+
+def test_polygon_adapter_deprecated():
+    coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
+    hole_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]
+    with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
+        asPolygon(coords, hole_coords)
 
 
 def test_suite():


### PR DESCRIPTION
Deprecating the adapter classes that create geometry-like proxy objects with coordinates stored in external objects (xref https://github.com/shapely/shapely-rfc/pull/1/).

I again started with the Point geometry to check if the workflow looks good. 

There are however multiple ways to create those objects. For points, you have the general `asShape` and `asPoint`, but in principle also the `PointAdapter` class constructor (but I don't know whether those are regarded as public API?). 

The way I did it now is to add a deprecation warning to both `asShape` and `asPoint`, so the message can be specific. Bu there are certainly other ways to do it as well.
