### PR TITLE
Replace Python 3.8-dev with Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,13 @@ matrix:
         GEOSVERSION="3.8.1"
         SPEEDUPS=0
         NUMPY=0
-    - python: "3.8-dev"
+    - python: "3.9-dev"
       env:
         GEOSVERSION="master"
         SPEEDUPS=1
         NUMPY=1
   allow_failures:
-    - python: "3.8-dev"
+    - python: "3.9-dev"
       env:
         GEOSVERSION="master"
         SPEEDUPS=1


### PR DESCRIPTION
This should be testing with Python 3.9.0 beta 4. See [PEP 596](https://www.python.org/dev/peps/pep-0596/), where Python 3.9 is expected to be released October 2020.

See related #944