### PR TITLE
Increase test coverage for GeometryCollection class

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -30,6 +30,7 @@ def geometrycollection_geojson():
 def test_empty(geom):
     assert geom.type == "GeometryCollection"
     assert geom.type == geom.geom_type
+    assert geom.is_empty
     assert len(geom) == 0
     assert geom.geoms == []
 
@@ -83,6 +84,7 @@ def test_empty_geointerface_adapter():
     assert m.geom_type == "GeometryCollection"
     assert len(m) == 0
     assert m.geoms == []
+    assert m.is_empty
 
 
 def test_geometrycollection_adapter_deprecated(geometrycollection_geojson):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,7 +1,8 @@
-from . import unittest, shapely20_deprecated
+from shapely import wkt
+from . import shapely20_deprecated
 
 from shapely.errors import ShapelyDeprecationWarning
-from shapely.geometry import LineString
+from shapely.geometry import LineString, Point
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry import shape
 from shapely.geometry import asShape
@@ -9,101 +10,86 @@ from shapely.geometry import asShape
 import pytest
 
 
-class CollectionTestCase(unittest.TestCase):
-
-    def test_array_interface(self):
-        m = GeometryCollection()
-        self.assertEqual(len(m), 0)
-        self.assertEqual(m.geoms, [])
-
-    def test_child_with_deleted_parent(self):
-        # test that we can remove a collection while having
-        # childs around
-        a = LineString([(0, 0), (1, 1), (1, 2), (2, 2)])
-        b = LineString([(0, 0), (1, 1), (2, 1), (2, 2)])
-        collection = a.intersection(b)
-
-        child = collection.geoms[0]
-        # delete parent of child
-        del collection
-
-        # access geometry, this should not seg fault as 1.2.15 did
-        self.assertIsNotNone(child.wkt)
-
-    @shapely20_deprecated
-    def test_geointerface_adapter(self):
-        d = {"type": "GeometryCollection","geometries": [
-                {"type": "Point", "coordinates": (0, 3)},
-                {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
-            ]}
-
-        # asShape
-        m = asShape(d)
-        self.assertEqual(m.geom_type, "GeometryCollection")
-        self.assertEqual(len(m), 2)
-        geom_types = [g.geom_type for g in m.geoms]
-        self.assertIn("Point", geom_types)
-        self.assertIn("LineString", geom_types)
-
-    def test_geointerface(self):
-        d = {"type": "GeometryCollection","geometries": [
-                {"type": "Point", "coordinates": (0, 3)},
-                {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
-            ]}
-
-        # shape
-        m = shape(d)
-        self.assertEqual(m.geom_type, "GeometryCollection")
-        self.assertEqual(len(m), 2)
-        geom_types = [g.geom_type for g in m.geoms]
-        self.assertIn("Point", geom_types)
-        self.assertIn("LineString", geom_types)
-
-    @shapely20_deprecated
-    def test_empty_geointerface_adapter(self):
-        d = {"type": "GeometryCollection", "geometries": []}
-
-        # asShape
-        m = asShape(d)
-        self.assertEqual(m.geom_type, "GeometryCollection")
-        self.assertEqual(len(m), 0)
-        self.assertEqual(m.geoms, [])
-
-    def test_empty_geointerface(self):
-        d = {"type": "GeometryCollection", "geometries": []}
-
-        # shape
-        m = shape(d)
-        self.assertEqual(m.geom_type, "GeometryCollection")
-        self.assertEqual(len(m), 0)
-        self.assertEqual(m.geoms, [])
-
-    def test_empty_coordinates(self):
-
-        d = {"type": "GeometryCollection", "geometries": [
-            {"type": "Point", "coordinates": ()},
-            {"type": "LineString", "coordinates": (())}
-        ]}
-
-        # shape
-        m = shape(d)
-        self.assertEqual(m.geom_type, "GeometryCollection")
-        self.assertEqual(len(m), 0)
-        self.assertEqual(m.geoms, [])
-
-
-def test_geometrycollection_adapter_deprecated():
-    d = {"type": "GeometryCollection","geometries": [
-            {"type": "Point", "coordinates": (0, 3)},
-            {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
+@pytest.fixture()
+def geometrycollection_geojson():
+    return {"type": "GeometryCollection", "geometries": [
+        {"type": "Point", "coordinates": (0, 3, 0)},
+        {"type": "LineString", "coordinates": ((2, 0), (1, 0))}
     ]}
+
+
+@pytest.mark.parametrize('geom', [
+    GeometryCollection(),
+    shape({"type": "GeometryCollection", "geometries": []}),
+    shape({"type": "GeometryCollection", "geometries": [
+        {"type": "Point", "coordinates": ()},
+        {"type": "LineString", "coordinates": (())}
+    ]}),
+    wkt.loads('GEOMETRYCOLLECTION EMPTY'),
+])
+def test_empty(geom):
+    assert geom.type == "GeometryCollection"
+    assert geom.type == geom.geom_type
+    assert len(geom) == 0
+    assert geom.geoms == []
+
+
+def test_child_with_deleted_parent():
+    # test that we can remove a collection while keeping
+    # children around
+    a = LineString([(0, 0), (1, 1), (1, 2), (2, 2)])
+    b = LineString([(0, 0), (1, 1), (2, 1), (2, 2)])
+    collection = a.intersection(b)
+
+    child = collection.geoms[0]
+    # delete parent of child
+    del collection
+
+    # access geometry, this should not seg fault as 1.2.15 did
+    assert child.wkt is not None
+
+
+def test_from_geojson(geometrycollection_geojson):
+    geom = shape(geometrycollection_geojson)
+    assert geom.geom_type == "GeometryCollection"
+    assert len(geom) == 2
+
+    geom_types = [g.geom_type for g in geom.geoms]
+    assert "Point" in geom_types
+    assert "LineString" in geom_types
+
+
+def test_geointerface(geometrycollection_geojson):
+    geom = shape(geometrycollection_geojson)
+    assert geom.__geo_interface__ == geometrycollection_geojson
+
+
+@shapely20_deprecated
+def test_geointerface_adapter(geometrycollection_geojson):
+    geom = asShape(geometrycollection_geojson)
+    assert geom.geom_type == "GeometryCollection"
+    assert len(geom) == 2
+
+    geom_types = [g.geom_type for g in geom.geoms]
+    assert "Point" in geom_types
+    assert "LineString" in geom_types
+
+
+@shapely20_deprecated
+def test_empty_geointerface_adapter():
+    d = {"type": "GeometryCollection", "geometries": []}
+
+    m = asShape(d)
+    assert m.geom_type == "GeometryCollection"
+    assert len(m) == 0
+    assert m.geoms == []
+
+
+def test_geometrycollection_adapter_deprecated(geometrycollection_geojson):
     with pytest.warns(ShapelyDeprecationWarning):
-        asShape(d)
+        asShape(geometrycollection_geojson)
 
     d = {"type": "GeometryCollection", "geometries": []}
     with pytest.warns(ShapelyDeprecationWarning):
         asShape(d)
 
-
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CollectionTestCase)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -2,7 +2,7 @@ from shapely import wkt
 from . import shapely20_deprecated
 
 from shapely.errors import ShapelyDeprecationWarning
-from shapely.geometry import LineString, Point
+from shapely.geometry import LineString
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry import shape
 from shapely.geometry import asShape

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -80,11 +80,11 @@ def test_geointerface_adapter(geometrycollection_geojson):
 def test_empty_geointerface_adapter():
     d = {"type": "GeometryCollection", "geometries": []}
 
-    m = asShape(d)
-    assert m.geom_type == "GeometryCollection"
-    assert len(m) == 0
-    assert m.geoms == []
-    assert m.is_empty
+    geom = asShape(d)
+    assert geom.geom_type == "GeometryCollection"
+    assert geom.is_empty
+    assert len(geom) == 0
+    assert geom.geoms == []
 
 
 def test_geometrycollection_adapter_deprecated(geometrycollection_geojson):


### PR DESCRIPTION
We're about to experience a good bit of churn with the push to Shapely 2.0 & merge with PyGEOS, so this seemed like a good time to work on increasing test coverage, especially in the geometry classes where I expect we will be trying to keep the interface and behavior identical while completely changing the internal workings. I also would like to consolidate tests to use Pytest, as it seems like most new tests have been written using that framework, and I think it'd be nice to have more consistency there.

If you're a 👍 on this, I'll keep adding to this or open another PR for more work, whatever is preferred. If not, no worries, but I wanted to check in to see what other folks thought before I did too much.