### PR TITLE
Deprecate ctypes attribute and array interface

### DIFF
--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -144,9 +144,9 @@ class CoordinateSequence(object):
             }
         ai.update({'shape': (len(self), self._ndim)})
         return ai
-    
+
     __array_interface__ = property(array_interface)
-    
+
     @property
     def xy(self):
         """X and Y arrays"""

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -4,7 +4,9 @@
 import sys
 from array import array
 from ctypes import byref, c_double, c_uint
+import warnings
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import lgeos
 from shapely.topology import Validating
 
@@ -100,7 +102,7 @@ class CoordinateSequence(object):
             raise TypeError("key must be an index or slice")
 
     @property
-    def ctypes(self):
+    def _ctypes(self):
         self._update()
         has_z = self._ndim == 3
         n = self._ndim
@@ -118,6 +120,14 @@ class CoordinateSequence(object):
                 data[n*i+2] = temp.value
         return data
 
+    @property
+    def ctypes(self):
+        warnings.warn(
+            "Accessing the 'ctypes' attribute is deprecated,"
+            " and will not be possible any more in Shapely 2.0",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._ctypes
+
     def array_interface(self):
         """Provide the Numpy array protocol."""
         if sys.byteorder == 'little':
@@ -130,7 +140,7 @@ class CoordinateSequence(object):
         ai = {
             'version': 3,
             'typestr': typestr,
-            'data': self.ctypes,
+            'data': self._ctypes,
             }
         ai.update({'shape': (len(self), self._ndim)})
         return ai

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -302,7 +302,11 @@ class BaseGeometry(object):
         return self._ctypes
 
     @property
-    def array_interface_base(self):
+    def _array_interface_base(self):
+        warn(
+            "The array interface is deprecated and will no longer work in "
+            "Shapely 2.0. Convert the '.coords' to a numpy array instead.",
+            ShapelyDeprecationWarning, stacklevel=2)
         if sys.byteorder == 'little':
             typestr = '<f8'
         elif sys.byteorder == 'big':
@@ -315,6 +319,14 @@ class BaseGeometry(object):
             'typestr': typestr,
             'data': self._ctypes,
             }
+
+    @property
+    def array_interface_base(self):
+        warn(
+            "The 'array_interface_base' property is deprecated and will be "
+            "removed in Shapely 2.0.",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._array_interface_base()
 
     @property
     def __array_interface__(self):

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -17,6 +17,7 @@ from functools import wraps
 from shapely.affinity import affine_transform
 from shapely.coords import CoordinateSequence
 from shapely.errors import WKBReadingError, WKTReadingError
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import WKBWriter, WKTWriter
 from shapely.geos import lgeos
 from shapely.impl import DefaultImplementation, delegated
@@ -288,9 +289,17 @@ class BaseGeometry(object):
     # ---------------------------
 
     @property
+    def _ctypes(self):
+        raise NotImplementedError
+
+    @property
     def ctypes(self):
         """Return ctypes buffer"""
-        raise NotImplementedError
+        warn(
+            "Accessing the 'ctypes' attribute is deprecated,"
+            " and will not be possible any more in Shapely 2.0",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._ctypes
 
     @property
     def array_interface_base(self):
@@ -304,7 +313,7 @@ class BaseGeometry(object):
         return {
             'version': 3,
             'typestr': typestr,
-            'data': self.ctypes,
+            'data': self._ctypes,
             }
 
     @property

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -303,10 +303,6 @@ class BaseGeometry(object):
 
     @property
     def _array_interface_base(self):
-        warn(
-            "The array interface is deprecated and will no longer work in "
-            "Shapely 2.0. Convert the '.coords' to a numpy array instead.",
-            ShapelyDeprecationWarning, stacklevel=2)
         if sys.byteorder == 'little':
             typestr = '<f8'
         elif sys.byteorder == 'big':

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -80,7 +80,7 @@ class LineString(BaseGeometry):
             self._ctypes_data = self.coords._ctypes
         return self._ctypes_data
 
-    def array_interface(self):
+    def _array_interface(self):
         """Provide the Numpy array protocol."""
         if self.is_empty:
             ai = {'version': 3, 'typestr': '<f8', 'shape': (0,), 'data': (c_double * 0)()}
@@ -88,7 +88,21 @@ class LineString(BaseGeometry):
             ai = self.coords.array_interface()
         return ai
 
-    __array_interface__ = property(array_interface)
+    def array_interface(self):
+        """Provide the Numpy array protocol."""
+        warnings.warn(
+            "The 'array_interface' method is deprecated and will be removed "
+            "in Shapely 2.0.",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._array_interface()
+
+    @property
+    def __array_interface__(self):
+        warnings.warn(
+            "The array interface is deprecated and will no longer work in "
+            "Shapely 2.0. Convert the '.coords' to a numpy array instead.",
+            ShapelyDeprecationWarning, stacklevel=3)
+        return self._array_interface()
 
     # Coordinate access
     def _set_coords(self, coordinates):

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -75,9 +75,9 @@ class LineString(BaseGeometry):
             ).format(pnt_format, 2. * scale_factor, stroke_color)
 
     @property
-    def ctypes(self):
+    def _ctypes(self):
         if not self._ctypes_data:
-            self._ctypes_data = self.coords.ctypes
+            self._ctypes_data = self.coords._ctypes
         return self._ctypes_data
 
     def array_interface(self):

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -113,12 +113,27 @@ class MultiPoint(BaseMultipartGeometry):
         return self._ctypes
 
     @exceptNull
-    def array_interface(self):
+    def _array_interface(self):
         """Provide the Numpy array protocol."""
-        ai = self.array_interface_base
+        ai = self._array_interface_base
         ai.update({'shape': (len(self.geoms), self._ndim)})
         return ai
-    __array_interface__ = property(array_interface)
+
+    def array_interface(self):
+        """Provide the Numpy array protocol."""
+        warnings.warn(
+            "The 'array_interface' method is deprecated and will be removed "
+            "in Shapely 2.0.",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._array_interface()
+
+    @property
+    def __array_interface__(self):
+        warnings.warn(
+            "The array interface is deprecated and will no longer work in "
+            "Shapely 2.0. Convert the '.coords' to a numpy array instead.",
+            ShapelyDeprecationWarning, stacklevel=3)
+        return self._array_interface()
 
 
 class MultiPointAdapter(CachingGeometryProxy, MultiPoint):

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -84,7 +84,7 @@ class MultiPoint(BaseMultipartGeometry):
 
     @property
     @exceptNull
-    def ctypes(self):
+    def _ctypes(self):
         if not self._ctypes_data:
             temp = c_double()
             n = self._ndim
@@ -103,6 +103,14 @@ class MultiPoint(BaseMultipartGeometry):
                     data[n*i+2] = temp.value
             self._ctypes_data = data
         return self._ctypes_data
+
+    @property
+    def ctypes(self):
+        warnings.warn(
+            "Accessing the 'ctypes' attribute is deprecated,"
+            " and will not be possible any more in Shapely 2.0",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._ctypes
 
     @exceptNull
     def array_interface(self):

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -102,7 +102,7 @@ class Point(BaseGeometry):
             ).format(self, 3. * scale_factor, 1. * scale_factor, fill_color)
 
     @property
-    def ctypes(self):
+    def _ctypes(self):
         if not self._ctypes_data:
             array_type = c_double * self._ndim
             array = array_type()

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -114,15 +114,30 @@ class Point(BaseGeometry):
             self._ctypes_data = array
         return self._ctypes_data
 
-    def array_interface(self):
+    def _array_interface(self):
         """Provide the Numpy array protocol."""
         if self.is_empty:
             ai = {'version': 3, 'typestr': '<f8', 'shape': (0,), 'data': (c_double * 0)()}
         else:
-            ai = self.array_interface_base
+            ai = self._array_interface_base
             ai.update({'shape': (self._ndim,)})
         return ai
-    __array_interface__ = property(array_interface)
+
+    def array_interface(self):
+        """Provide the Numpy array protocol."""
+        warnings.warn(
+            "The 'array_interface' method is deprecated and will be removed "
+            "in Shapely 2.0.",
+            ShapelyDeprecationWarning, stacklevel=2)
+        return self._array_interface()
+
+    @property
+    def __array_interface__(self):
+        warnings.warn(
+            "The array interface is deprecated and will no longer work in "
+            "Shapely 2.0. Convert the '.coords' to a numpy array instead.",
+            ShapelyDeprecationWarning, stacklevel=3)
+        return self._array_interface()
 
     @property
     def bounds(self):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -297,9 +297,9 @@ class Polygon(BaseGeometry):
     __hash__ = None
 
     @property
-    def ctypes(self):
+    def _ctypes(self):
         if not self._ctypes_data:
-            self._ctypes_data = self.exterior.ctypes
+            self._ctypes_data = self.exterior._ctypes
         return self._ctypes_data
 
     @property

--- a/shapely/speedups/__init__.py
+++ b/shapely/speedups/__init__.py
@@ -53,8 +53,8 @@ def enable():
     if _orig:
         return
 
-    _orig['CoordinateSequence.ctypes'] = coords.CoordinateSequence.ctypes
-    coords.CoordinateSequence.ctypes = property(_speedups.coordseq_ctypes)
+    _orig['CoordinateSequence._ctypes'] = coords.CoordinateSequence._ctypes
+    coords.CoordinateSequence._ctypes = property(_speedups.coordseq_ctypes)
 
     _orig['CoordinateSequence.__iter__'] = coords.CoordinateSequence.__iter__
     coords.CoordinateSequence.__iter__ = method_wrapper(
@@ -84,7 +84,7 @@ def disable():
     if not _orig:
         return
 
-    coords.CoordinateSequence.ctypes = _orig['CoordinateSequence.ctypes']
+    coords.CoordinateSequence._ctypes = _orig['CoordinateSequence._ctypes']
     coords.CoordinateSequence.__iter__ = _orig['CoordinateSequence.__iter__']
     linestring.geos_linestring_from_py = _orig['geos_linestring_from_py']
     polygon.geos_linearring_from_py = _orig['geos_linearring_from_py']

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -239,7 +239,10 @@ def geos_linearring_from_py(ob, update_geom=None, update_ndim=0):
             elif GEOSisClosed_r(handle, g) and m >= 4:
                 cs = GEOSCoordSeq_clone_r(handle, cs)
                 return <uintptr_t>GEOSGeom_createLinearRing_r(handle, cs), n
-            # else continue below.
+            else:
+                # else continue below.
+                # (and extract coords to avoid array interface of LineString)
+                ob = ob.coords
 
     # If numpy is present, we use numpy.require to ensure that we have a
     # C-continguous array that owns its data. View data will be copied.

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,6 +1,9 @@
 from . import unittest, numpy
-from shapely import geometry
 
+import pytest
+
+from shapely import geometry
+from shapely.errors import ShapelyDeprecationWarning
 
 class CoordsTestCase(unittest.TestCase):
     """
@@ -34,6 +37,12 @@ class CoordsTestCase(unittest.TestCase):
             coords[::-1].tolist(),
             processed_coords.tolist()
         )
+
+
+def test_multipoint_ctypes_deprecated():
+    coords = geometry.LineString([[12, 34], [56, 78]]).coords
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        coords.ctypes
 
 
 def test_suite():

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -39,7 +39,11 @@ class CoordsTestCase(unittest.TestCase):
         )
 
 
-def test_multipoint_ctypes_deprecated():
+def test_coords_ctypes_deprecated():
+    """
+    Test that the .ctypes attribute of a CoordinateSequence raises
+    a deprecation warning.
+    """
     coords = geometry.LineString([[12, 34], [56, 78]]).coords
     with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
         coords.ctypes

--- a/tests/test_geomseq.py
+++ b/tests/test_geomseq.py
@@ -1,8 +1,11 @@
-from . import unittest
+from . import unittest, shapely20_deprecated
+
 from shapely import geometry
 
 
 class MultiLineTestCase(unittest.TestCase):
+
+    @shapely20_deprecated
     def test_array_interface(self):
         m = geometry.MultiLineString([((0, 0), (1, 1)), ((2, 2), (3, 3))])
         ai = m.geoms[0].__array_interface__

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -168,6 +168,7 @@ class LineStringTestCase(unittest.TestCase):
         pas = asarray(la)
         assert_array_equal(pas, array([[1.0, 2.0], [3.0, 4.0]]))
 
+    @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_asarray(self):
         from numpy import array, asarray
@@ -206,6 +207,12 @@ def test_linestring_adapter_deprecated():
     coords = [[5.0, 6.0], [7.0, 8.0]]
     with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
         asLineString(coords)
+
+
+def test_linestring_ctypes_deprecated():
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        line.ctypes
 
 
 def test_suite():

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -128,7 +128,7 @@ class LineStringTestCase(unittest.TestCase):
             ls = LineString(coords)
             ls.geom_type # caused segfault before fix
 
-
+    @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy(self):
 
@@ -145,8 +145,16 @@ class LineStringTestCase(unittest.TestCase):
         expected = array([[1.0, 2.0], [3.0, 4.0]])
         assert_array_equal(la, expected)
 
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy_coords(self):
+        import numpy as np
+        from numpy.testing import assert_array_equal
+
+        line = LineString(((1.0, 2.0), (3.0, 4.0)))
+        expected = np.array([[1.0, 2.0], [3.0, 4.0]])
+
         # Coordinate sequences can be adapted as well
-        la = asarray(line.coords)
+        la = np.asarray(line.coords)
         assert_array_equal(la, expected)
 
     @shapely20_deprecated
@@ -186,6 +194,7 @@ class LineStringTestCase(unittest.TestCase):
         b = asarray(line)
         assert_array_equal(b, array([[0., 0.], [2., 2.], [1., 1.]]))
 
+    @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_empty(self):
         from numpy import array, asarray
@@ -213,6 +222,21 @@ def test_linestring_ctypes_deprecated():
     line = LineString(((1.0, 2.0), (3.0, 4.0)))
     with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
         line.ctypes
+
+
+def test_linestring_array_interface_deprecated():
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="array_interface"):
+        line.array_interface()
+
+
+@unittest.skipIf(not numpy, 'Numpy required')
+def test_linestring_array_interface_numpy_deprecated():
+    import numpy as np
+
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="array interface"):
+        np.array(line)
 
 
 def test_suite():

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -94,5 +94,11 @@ def test_multipoint_adapter_deprecated():
         asMultiPoint(coords)
 
 
+def test_multipoint_ctypes_deprecated():
+    geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        geom.ctypes
+
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(MultiPointTestCase)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -47,7 +47,7 @@ class MultiPointTestCase(MultiGeometryTestCase):
         self.assertEqual(dump_coords(geoma), [[(5.0, 6.0)], [(7.0, 8.0)]])
 
     @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy(self):
+    def test_multipoint_from_numpy(self):
 
         from numpy import array, asarray
         from numpy.testing import assert_array_equal
@@ -57,6 +57,13 @@ class MultiPointTestCase(MultiGeometryTestCase):
         self.assertIsInstance(geom, MultiPoint)
         self.assertEqual(len(geom.geoms), 2)
         self.assertEqual(dump_coords(geom), [[(0.0, 0.0)], [(1.0, 2.0)]])
+
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_numpy(self):
+
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
 
         # Geo interface (cont.)
         geom = MultiPoint((Point(1.0, 2.0), Point(3.0, 4.0)))
@@ -98,6 +105,21 @@ def test_multipoint_ctypes_deprecated():
     geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
     with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
         geom.ctypes
+
+
+def test_multipoint_array_interface_deprecated():
+    geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="array_interface"):
+        geom.array_interface()
+
+
+@unittest.skipIf(not numpy, 'Numpy required')
+def test_multipoint_array_interface_numpy_deprecated():
+    import numpy as np
+
+    geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
+    with pytest.warns(ShapelyDeprecationWarning, match="array interface"):
+        np.array(geom)
 
 
 def test_suite():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -133,6 +133,7 @@ class LineStringTestCase(unittest.TestCase):
         pas = asarray(pa)
         assert_array_equal(pas, array([1.0, 4.0]))
 
+    @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy_asarray(self):
         from numpy import array, asarray
@@ -188,6 +189,20 @@ def test_point_ctypes_deprecated():
     p = Point(3.0, 4.0)
     with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
         p.ctypes is not None
+
+def test_point_array_interface_deprecated():
+    p = Point(3.0, 4.0)
+    with pytest.warns(ShapelyDeprecationWarning, match="array_interface"):
+        p.array_interface()
+
+
+@unittest.skipIf(not numpy, 'Numpy required')
+def test_point_array_interface_numpy_deprecated():
+    import numpy as np
+
+    p = Point(3.0, 4.0)
+    with pytest.warns(ShapelyDeprecationWarning, match="array interface"):
+        np.array(p)
 
 
 def test_suite():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -142,7 +142,6 @@ class LineStringTestCase(unittest.TestCase):
         p = Point(0.0, 0.0, 1.0)
         coords = p.coords[0]
         self.assertEqual(coords, (0.0, 0.0, 1.0))
-        self.assertIsNotNone(p.ctypes)
 
         # Convert to Numpy array, passing through Python sequence
         a = asarray(coords)
@@ -183,6 +182,12 @@ def test_point_adapter_deprecated():
     coords = [3.0, 4.0]
     with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):
         asPoint(coords)
+
+
+def test_point_ctypes_deprecated():
+    p = Point(3.0, 4.0)
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        p.ctypes is not None
 
 
 def test_suite():

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -293,5 +293,18 @@ def test_polygon_adapter_deprecated():
         asPolygon(coords, hole_coords)
 
 
+def test_ctypes_deprecated():
+    coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
+    hole_coords = [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))]
+    ring = LinearRing(coords)
+    polygon = Polygon(coords, hole_coords)
+
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        ring.ctypes
+
+    with pytest.warns(ShapelyDeprecationWarning, match="ctypes"):
+        polygon.ctypes
+
+
 def test_suite():
     return unittest.TestLoader().loadTestsFromTestCase(PolygonTestCase)

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -175,7 +175,7 @@ class PolygonTestCase(unittest.TestCase):
             LinearRing(line)
 
     @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy(self):
+    def test_polygon_from_numpy(self):
 
         from numpy import array, asarray
         from numpy.testing import assert_array_equal
@@ -186,6 +186,17 @@ class PolygonTestCase(unittest.TestCase):
         self.assertEqual(dump_coords(polygon.exterior),
                          [(0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)])
         self.assertEqual(len(polygon.interiors), 0)
+
+    @shapely20_deprecated
+    @unittest.skipIf(not numpy, 'Numpy required')
+    def test_polygon_exterior_array_interface(self):
+
+        from numpy import array, asarray
+        from numpy.testing import assert_array_equal
+
+        a = asarray(((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)))
+        polygon = Polygon(a)
+
         b = asarray(polygon.exterior)
         self.assertEqual(b.shape, (5, 2))
         assert_array_equal(


### PR DESCRIPTION
Deprecating the ctypes attribute and the array_interface.

See https://github.com/shapely/shapely-rfc/pull/1/files#diff-554e526a1f0fe104169383c013e37a7cR360 for the rationale

The array interface is kept intact for the CoordinateSequence, so occurence of `np.array(geom)` can be replaced with `np.array(geom.coords)`. 
(we should eventually implement this differently (not using ctypes), but that can be left for later or even for Shapely 2.0)