### PR TITLE
[2.0] Remove mutability of geometries 

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -321,11 +321,7 @@ class BaseGeometry(object):
             return []
         return CoordinateSequence(self)
 
-    def _set_coords(self, ob):
-        raise NotImplementedError(
-            "set_coords must be provided by derived classes")
-
-    coords = property(_get_coords, _set_coords)
+    coords = property(_get_coords)
 
     @property
     def xy(self):
@@ -849,10 +845,6 @@ class BaseMultipartGeometry(BaseGeometry):
                                   "provide the array interface")
 
     def _get_coords(self):
-        raise NotImplementedError("Sub-geometries may have coordinate "
-                                  "sequences, but collections do not")
-
-    def _set_coords(self, ob):
         raise NotImplementedError("Sub-geometries may have coordinate "
                                   "sequences, but collections do not")
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -90,19 +90,6 @@ class LineString(BaseGeometry):
 
     __array_interface__ = property(array_interface)
 
-    # Coordinate access
-    def _set_coords(self, coordinates):
-        warnings.warn(
-            "Setting the 'coords' to mutate a Geometry in place is deprecated,"
-            " and will not be possible any more in Shapely 2.0",
-            ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
-        ret = geos_linestring_from_py(coordinates)
-        if ret is not None:
-            self._geom, self._ndim = ret
-
-    coords = property(BaseGeometry._get_coords, _set_coords)
-
     @property
     def xy(self):
         """Separate arrays of X and Y coordinate values

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -133,23 +133,6 @@ class Point(BaseGeometry):
             return ()
         return (xy[0], xy[1], xy[0], xy[1])
 
-    # Coordinate access
-
-    def _set_coords(self, *args):
-        warnings.warn(
-            "Setting the 'coords' to mutate a Geometry in place is deprecated,"
-            " and will not be possible any more in Shapely 2.0",
-            ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
-        if len(args) == 1:
-            self._geom, self._ndim = geos_point_from_py(args[0])
-        elif len(args) > 3:
-            raise TypeError("Point() takes at most 3 arguments ({} given)".format(len(args)))
-        else:
-            self._geom, self._ndim = geos_point_from_py(tuple(args))
-
-    coords = property(BaseGeometry._get_coords, _set_coords)
-
     @property
     def xy(self):
         """Separate arrays of X and Y coordinate values

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -61,22 +61,6 @@ class LinearRing(LineString):
             'coordinates': tuple(self.coords)
             }
 
-    # Coordinate access
-
-    _get_coords = BaseGeometry._get_coords
-
-    def _set_coords(self, coordinates):
-        warnings.warn(
-            "Setting the 'coords' to mutate a Geometry in place is deprecated,"
-            " and will not be possible any more in Shapely 2.0",
-            ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
-        ret = geos_linearring_from_py(coordinates)
-        if ret is not None:
-            self._geom, self._ndim = ret
-
-    coords = property(_get_coords, _set_coords)
-
     def __setstate__(self, state):
         """WKB doesn't differentiate between LineString and LinearRing so we
         need to move the coordinate sequence into the correct geometry type"""
@@ -308,10 +292,6 @@ class Polygon(BaseGeometry):
         "A polygon does not itself provide the array interface. Its rings do.")
 
     def _get_coords(self):
-        raise NotImplementedError(
-        "Component rings have coordinate sequences, but the polygon does not")
-
-    def _set_coords(self, ob):
         raise NotImplementedError(
         "Component rings have coordinate sequences, but the polygon does not")
 

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -245,6 +245,16 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(a.shape[0], 0)
 
 
+def test_linestring_immutable():
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+
+    with pytest.raises(AttributeError):
+        line.coords = [(-1.0, -1.0), (1.0, 1.0)]
+
+    with pytest.raises(TypeError):
+        line.coords[0] = (-1.0, -1.0)
+
+
 def test_linestring_adapter_deprecated():
     coords = [[5.0, 6.0], [7.0, 8.0]]
     with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -41,16 +41,6 @@ class LineStringTestCase(unittest.TestCase):
                           'coordinates': ((1.0, 2.0), (3.0, 4.0))})
 
     @shapely20_deprecated
-    def test_linestring_mutate(self):
-        line = LineString(((1.0, 2.0), (3.0, 4.0)))
-
-        # Coordinate modification
-        line.coords = ((-1.0, -1.0), (1.0, 1.0))
-        self.assertEqual(line.__geo_interface__,
-                         {'type': 'LineString',
-                          'coordinates': ((-1.0, -1.0), (1.0, 1.0))})
-
-    @shapely20_deprecated
     def test_linestring_adapter(self):
         # Adapt a coordinate list to a line string
         coords = [[5.0, 6.0], [7.0, 8.0]]
@@ -62,13 +52,6 @@ class LineStringTestCase(unittest.TestCase):
         l_null = LineString()
         self.assertEqual(l_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
         self.assertEqual(l_null.length, 0.0)
-
-    @shapely20_deprecated
-    def test_linestring_empty_mutate(self):
-        # Check that we can set coordinates of a null geometry
-        l_null = LineString()
-        l_null.coords = [(0, 0), (1, 1)]
-        self.assertAlmostEqual(l_null.length, 1.4142135623730951)
 
     def test_equals_argument_order(self):
         """
@@ -194,12 +177,6 @@ class LineStringTestCase(unittest.TestCase):
         le = LineString()
         a = asarray(le)
         self.assertEqual(a.shape[0], 0)
-
-
-def test_linestring_mutability_deprecated():
-    line = LineString(((1.0, 2.0), (3.0, 4.0)))
-    with pytest.warns(ShapelyDeprecationWarning, match="Setting"):
-        line.coords = ((-1.0, -1.0), (1.0, 1.0))
 
 
 def test_linestring_adapter_deprecated():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -50,19 +50,6 @@ class LineStringTestCase(unittest.TestCase):
                          {'type': 'Point', 'coordinates': (3.0, 4.0)})
 
     @shapely20_deprecated
-    def test_point_mutate(self):
-        # Modify coordinates
-        p = Point(3.0, 4.0)
-        p.coords = (2.0, 1.0)
-        self.assertEqual(p.__geo_interface__,
-                         {'type': 'Point', 'coordinates': (2.0, 1.0)})
-
-        # Alternate method
-        p.coords = ((0.0, 0.0),)
-        self.assertEqual(p.__geo_interface__,
-                         {'type': 'Point', 'coordinates': (0.0, 0.0)})
-
-    @shapely20_deprecated
     def test_point_adapter(self):
         p = Point(0.0, 0.0)
         # Adapt a coordinate list to a point
@@ -82,17 +69,6 @@ class LineStringTestCase(unittest.TestCase):
         self.assertEqual(p_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
         self.assertEqual(p_null.coords[:], [])
         self.assertEqual(p_null.area, 0.0)
-
-    @shapely20_deprecated
-    def test_point_empty_mutate(self):
-        # Check that we can set coordinates of a null geometry
-        p_null = Point()
-        p_null.coords = (1, 2)
-        self.assertEqual(p_null.coords[:], [(1.0, 2.0)])
-
-        # Passing > 3 arguments to Point is erroneous
-        with self.assertRaises(TypeError):
-            Point(1.0, 2.0, 3.0, 4.0)
 
     @unittest.skipIf(not numpy, 'Numpy required')
     def test_numpy(self):
@@ -171,12 +147,6 @@ def test_empty_point_bounds():
     """The bounds of an empty point is an empty tuple"""
     p = Point()
     assert p.bounds == ()
-
-
-def test_point_mutability_deprecated():
-    p = Point(3.0, 4.0)
-    with pytest.warns(ShapelyDeprecationWarning, match="Setting"):
-        p.coords = (2.0, 1.0)
 
 
 def test_point_adapter_deprecated():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -203,6 +203,16 @@ def test_empty_point_bounds():
     assert p.bounds == ()
 
 
+def test_point_immutable():
+    p = Point(3.0, 4.0)
+
+    with pytest.raises(AttributeError):
+        p.coords = (2.0, 1.0)
+
+    with pytest.raises(TypeError):
+        p.coords[0] = (2.0, 1.0)
+
+
 def test_point_adapter_deprecated():
     coords = [3.0, 4.0]
     with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -271,6 +271,16 @@ class PolygonTestCase(unittest.TestCase):
         assert p.exterior == LinearRing()
 
 
+def test_linearring_immutable():
+    ring = LinearRing([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)])
+
+    with pytest.raises(AttributeError):
+        ring.coords = [(1.0, 1.0), (2.0, 2.0), (1.0, 2.0)]
+
+    with pytest.raises(TypeError):
+        ring.coords[0] = (1.0, 1.0)
+
+
 def test_linearring_adapter_deprecated():
     coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
     with pytest.warns(ShapelyDeprecationWarning, match="proxy geometries"):

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -30,19 +30,6 @@ class PolygonTestCase(unittest.TestCase):
         self.assertEqual(LinearRing((map(Point, coords))), ring)
 
     @shapely20_deprecated
-    def test_linearring_mutate(self):
-        coords = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
-        ring = LinearRing(coords)
-
-        # Coordinate modification
-        ring.coords = ((0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0))
-        self.assertEqual(
-            ring.__geo_interface__,
-            {'type': 'LinearRing',
-             'coordinates': ((0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0),
-                             (0.0, 0.0))})
-
-    @shapely20_deprecated
     def test_linearring_adapter(self):
         # Test ring adapter
         coords = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]
@@ -132,13 +119,6 @@ class PolygonTestCase(unittest.TestCase):
         r_null = LinearRing()
         self.assertEqual(r_null.wkt, 'GEOMETRYCOLLECTION EMPTY')
         self.assertEqual(r_null.length, 0.0)
-
-    @shapely20_deprecated
-    def test_linearring_empty_mutate(self):
-        # Check that we can set coordinates of a null geometry
-        r_null = LinearRing()
-        r_null.coords = [(0, 0), (1, 1), (1, 0)]
-        self.assertAlmostEqual(r_null.length, 3.414213562373095)
 
     def test_linearring_from_closed_linestring(self):
         coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]


### PR DESCRIPTION
I branched off from master, so the shapely-2.0 branch first needs to be reset to master state for this to work (the actual commit is only the last one)