### PR TITLE
TST: clean-up + more cases for Point/LineString constructor tests

### DIFF
--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -42,7 +42,7 @@ def test_from_linestring():
     line = LineString(((1.0, 2.0), (3.0, 4.0)))
     copy = LineString(line)
     assert copy.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
-    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+    assert copy.geom_type == 'LineString'
 
 
 def test_from_linearring():
@@ -50,7 +50,7 @@ def test_from_linearring():
     ring = LinearRing(coords)
     copy = LineString(ring)
     assert copy.coords[:] == coords
-    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+    assert copy.geom_type == 'LineString'
 
 
 def test_from_linestring_z():
@@ -58,7 +58,7 @@ def test_from_linestring_z():
     line = LineString(coords)
     copy = LineString(line)
     assert copy.coords[:] == coords
-    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+    assert copy.geom_type == 'LineString'
 
 
 def test_from_generator():

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -2,7 +2,6 @@ from . import unittest, numpy, shapely20_deprecated
 import pytest
 
 from shapely.errors import ShapelyDeprecationWarning
-from shapely.geos import lgeos
 from shapely.geometry import LineString, asLineString, Point, LinearRing
 
 

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -6,6 +6,109 @@ from shapely.geos import lgeos
 from shapely.geometry import LineString, asLineString, Point, LinearRing
 
 
+def test_from_coordinate_sequence():
+    # From coordinate tuples
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+    assert len(line.coords) == 2
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+    line = LineString([(1.0, 2.0), (3.0, 4.0)])
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_from_coordinate_sequence_3D():
+    line = LineString(((1.0, 2.0, 3.0), (3.0, 4.0, 5.0)))
+    assert line.has_z
+    assert line.coords[:] == [(1.0, 2.0, 3.0), (3.0, 4.0, 5.0)]
+
+
+def test_from_points():
+    # From Points
+    line = LineString((Point(1.0, 2.0), Point(3.0, 4.0)))
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+    line = LineString([Point(1.0, 2.0), Point(3.0, 4.0)])
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_from_mix():
+    # From mix of tuples and Points
+    line = LineString((Point(1.0, 2.0), (2.0, 3.0), Point(3.0, 4.0)))
+    assert line.coords[:] == [(1.0, 2.0), (2.0, 3.0), (3.0, 4.0)]
+
+
+def test_from_linestring():
+    # From another linestring
+    line = LineString(((1.0, 2.0), (3.0, 4.0)))
+    copy = LineString(line)
+    assert copy.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+
+
+def test_from_linearring():
+    coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]
+    ring = LinearRing(coords)
+    copy = LineString(ring)
+    assert copy.coords[:] == coords
+    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+
+
+def test_from_linestring_z():
+    coords = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
+    line = LineString(coords)
+    copy = LineString(line)
+    assert copy.coords[:] == coords
+    assert lgeos.GEOSGeomType(copy._geom).decode('ascii') == 'LineString'
+
+
+def test_from_generator():
+    gen = (coord for coord in [(1.0, 2.0), (3.0, 4.0)])
+    line = LineString(gen)
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_from_empty():
+    line = LineString()
+    assert line.is_empty
+    assert line.coords[:] == []
+
+    line = LineString([])
+    assert line.is_empty
+    assert line.coords[:] == []
+
+
+def test_from_numpy():
+    # Construct from a numpy array
+    np = pytest.importorskip("numpy")
+
+    line = LineString(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
+
+
+def test_from_invalid_dim():
+    with pytest.raises(ValueError, match="at least 2 coordinate tuples"):
+        LineString([(1, 2)])
+
+    with pytest.raises(ValueError, match="Inconsistent coordinate dimensionality"):
+        LineString([(1, 2, 3), (4, 5)])
+
+    # TODO this does not fail
+    # with pytest.raises(ValueError, match="Inconsistent coordinate dimensionality"):
+    #     LineString([(1, 2), (3, 4, 5)]))
+
+    # TODO better error, right now raises AssertionError
+    with pytest.raises(Exception):
+        LineString([(1, 2, 3, 4), (4, 5, 6, 7)])
+
+
+def test_from_single_coordinate():
+    """Test for issue #486"""
+    coords = [[-122.185933073564, 37.3629353839073]]
+    with pytest.raises(ValueError):
+        ls = LineString(coords)
+        ls.geom_type # caused segfault before fix
+
+
 class LineStringTestCase(unittest.TestCase):
 
     def test_linestring(self):
@@ -14,16 +117,6 @@ class LineStringTestCase(unittest.TestCase):
         line = LineString(((1.0, 2.0), (3.0, 4.0)))
         self.assertEqual(len(line.coords), 2)
         self.assertEqual(line.coords[:], [(1.0, 2.0), (3.0, 4.0)])
-
-        # From Points
-        line2 = LineString((Point(1.0, 2.0), Point(3.0, 4.0)))
-        self.assertEqual(len(line2.coords), 2)
-        self.assertEqual(line2.coords[:], [(1.0, 2.0), (3.0, 4.0)])
-
-        # From mix of tuples and Points
-        line3 = LineString((Point(1.0, 2.0), (2.0, 3.0), Point(3.0, 4.0)))
-        self.assertEqual(len(line3.coords), 3)
-        self.assertEqual(line3.coords[:], [(1.0, 2.0), (2.0, 3.0), (3.0, 4.0)])
 
         # Bounds
         self.assertEqual(line.bounds, (1.0, 2.0, 3.0, 4.0))
@@ -91,42 +184,6 @@ class LineStringTestCase(unittest.TestCase):
         self.assertTrue(lr.__eq__(lr_clone))
         self.assertTrue(ls == ls_clone)
         self.assertTrue(lr == lr_clone)
-
-
-    def test_from_linestring(self):
-        line = LineString(((1.0, 2.0), (3.0, 4.0)))
-        copy = LineString(line)
-        self.assertEqual(len(copy.coords), 2)
-        self.assertEqual(copy.coords[:], [(1.0, 2.0), (3.0, 4.0)])
-        self.assertEqual('LineString',
-                         lgeos.GEOSGeomType(copy._geom).decode('ascii'))
-
-
-    def test_from_linestring_z(self):
-        coords = [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)]
-        line = LineString(coords)
-        copy = LineString(line)
-        self.assertEqual(len(copy.coords), 2)
-        self.assertEqual(copy.coords[:], coords)
-        self.assertEqual('LineString',
-                         lgeos.GEOSGeomType(copy._geom).decode('ascii'))
-
-
-    def test_from_linearring(self):
-        coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)]
-        ring = LinearRing(coords)
-        copy = LineString(ring)
-        self.assertEqual(len(copy.coords), 4)
-        self.assertEqual(copy.coords[:], coords)
-        self.assertEqual('LineString',
-                         lgeos.GEOSGeomType(copy._geom).decode('ascii'))
-
-    def test_from_single_coordinate(self):
-        """Test for issue #486"""
-        coords = [[-122.185933073564, 37.3629353839073]]
-        with pytest.raises(ValueError):
-            ls = LineString(coords)
-            ls.geom_type # caused segfault before fix
 
     @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
@@ -237,7 +294,3 @@ def test_linestring_array_interface_numpy_deprecated():
     line = LineString(((1.0, 2.0), (3.0, 4.0)))
     with pytest.warns(ShapelyDeprecationWarning, match="array interface"):
         np.array(line)
-
-
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(LineStringTestCase)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -14,6 +14,7 @@ def test_from_coordinates():
     # 3D Point
     p = Point(1.0, 2.0, 3.0)
     assert p.coords[:] == [(1.0, 2.0, 3.0)]
+    assert p.has_z
 
     # empty
     p = Point()
@@ -32,6 +33,14 @@ def test_from_sequence():
     p = Point([(3.0, 4.0)])
     assert p.coords[:] == [(3.0, 4.0)]
 
+    # 3D
+    p = Point((3.0, 4.0, 5.0))
+    assert p.coords[:] == [(3.0, 4.0, 5.0)]
+    p = Point([3.0, 4.0, 5.0])
+    assert p.coords[:] == [(3.0, 4.0, 5.0)]
+    p = Point([(3.0, 4.0, 5.0)])
+    assert p.coords[:] == [(3.0, 4.0, 5.0)]
+
 
 def test_from_numpy():
     # Construct from a numpy array
@@ -40,12 +49,19 @@ def test_from_numpy():
     p = Point(np.array([1.0, 2.0]))
     assert p.coords[:] == [(1.0, 2.0)]
 
+    p = Point(np.array([1.0, 2.0, 3.0]))
+    assert p.coords[:] == [(1.0, 2.0, 3.0)]
+
 
 def test_from_point():
     # From another point
     p = Point(3.0, 4.0)
     q = Point(p)
     assert q.coords[:] == [(3.0, 4.0)]
+
+    p = Point(3.0, 4.0, 5.0)
+    q = Point(p)
+    assert q.coords[:] == [(3.0, 4.0, 5.0)]
 
 
 def test_from_generator():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -5,6 +5,61 @@ from shapely.errors import DimensionError, ShapelyDeprecationWarning
 import pytest
 
 
+def test_from_coordinates():
+    # 2D points
+    p = Point(1.0, 2.0)
+    assert p.coords[:] == [(1.0, 2.0)]
+    assert p.has_z is False
+
+    # 3D Point
+    p = Point(1.0, 2.0, 3.0)
+    assert p.coords[:] == [(1.0, 2.0, 3.0)]
+
+    # empty
+    p = Point()
+    assert p.is_empty
+    assert p.coords[:] == []
+
+
+def test_from_sequence():
+    # From single coordinate pair
+    p = Point((3.0, 4.0))
+    assert p.coords[:] == [(3.0, 4.0)]
+    p = Point([3.0, 4.0])
+    assert p.coords[:] == [(3.0, 4.0)]
+
+    # From coordinate sequence
+    p = Point([(3.0, 4.0)])
+    assert p.coords[:] == [(3.0, 4.0)]
+
+
+def test_from_numpy():
+    # Construct from a numpy array
+    np = pytest.importorskip("numpy")
+
+    p = Point(np.array([1.0, 2.0]))
+    assert p.coords[:] == [(1.0, 2.0)]
+
+
+def test_from_point():
+    # From another point
+    p = Point(3.0, 4.0)
+    q = Point(p)
+    assert q.coords[:] == [(3.0, 4.0)]
+
+
+def test_from_generator():
+    gen = (coord for coord in [(1.0, 2.0)])
+    p = Point(gen)
+    assert p.coords[:] == [(1.0, 2.0)]
+
+
+def test_from_invalid():
+
+    with pytest.raises(TypeError, match="takes at most 3 arguments"):
+        Point(1, 2, 3, 4)
+
+
 class LineStringTestCase(unittest.TestCase):
 
     def test_point(self):
@@ -26,15 +81,8 @@ class LineStringTestCase(unittest.TestCase):
         self.assertTrue(p.has_z)
         self.assertEqual(p.z, 3.0)
 
-        # From coordinate sequence
-        p = Point((3.0, 4.0))
-        self.assertEqual(p.coords[:], [(3.0, 4.0)])
-
-        # From another point
-        q = Point(p)
-        self.assertEqual(q.coords[:], [(3.0, 4.0)])
-
         # Coordinate access
+        p = Point((3.0, 4.0))
         self.assertEqual(p.x, 3.0)
         self.assertEqual(p.y, 4.0)
         self.assertEqual(tuple(p.coords), ((3.0, 4.0),))
@@ -93,16 +141,6 @@ class LineStringTestCase(unittest.TestCase):
         # Passing > 3 arguments to Point is erroneous
         with self.assertRaises(TypeError):
             Point(1.0, 2.0, 3.0, 4.0)
-
-    @unittest.skipIf(not numpy, 'Numpy required')
-    def test_numpy(self):
-
-        from numpy import array, asarray
-        from numpy.testing import assert_array_equal
-
-        # Construct from a numpy array
-        p = Point(array([1.0, 2.0]))
-        self.assertEqual(p.coords[:], [(1.0, 2.0)])
 
     @shapely20_deprecated
     @unittest.skipIf(not numpy, 'Numpy required')
@@ -203,7 +241,3 @@ def test_point_array_interface_numpy_deprecated():
     p = Point(3.0, 4.0)
     with pytest.warns(ShapelyDeprecationWarning, match="array interface"):
         np.array(p)
-
-
-def test_suite():
-    return unittest.TestLoader().loadTestsFromTestCase(LineStringTestCase)


### PR DESCRIPTION
While refactoring the class constructors based on pygeos, I noticed that not all cases that are currently supported are fully covered by the tests (eg generator, single-element list for Point, ...). So I added some more tests, and at once cleaned up the existing constructor tests.