### PR TITLE
Replace internal usage of Multi geom iteration with .geoms attribute

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -55,7 +55,7 @@ def dump_coords(geom):
         return geom.exterior.coords[:] + [i.coords[:] for i in geom.interiors]
     elif geom.type.startswith('Multi') or geom.type == 'GeometryCollection':
         # Recursive call
-        return [dump_coords(part) for part in geom]
+        return [dump_coords(part) for part in geom.geoms]
     else:
         raise ValueError('Unhandled geometry type: ' + repr(geom.type))
 
@@ -867,7 +867,7 @@ class BaseMultipartGeometry(BaseGeometry):
         return (
             type(other) == type(self) and
             len(self) == len(other) and
-            all(x == y for x, y in zip(self, other))
+            all(x == y for x, y in zip(self.geoms, other.geoms))
         )
 
     def __ne__(self, other):
@@ -891,7 +891,7 @@ class BaseMultipartGeometry(BaseGeometry):
         if color is None:
             color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, color) for p in self) + \
+            ''.join(p.svg(scale_factor, color) for p in self.geoms) + \
             '</g>'
 
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -74,7 +74,7 @@ class MultiLineString(BaseMultipartGeometry):
         if stroke_color is None:
             stroke_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, stroke_color) for p in self) + \
+            ''.join(p.svg(scale_factor, stroke_color) for p in self.geoms) + \
             '</g>'
 
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -79,7 +79,7 @@ class MultiPoint(BaseMultipartGeometry):
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, fill_color) for p in self) + \
+            ''.join(p.svg(scale_factor, fill_color) for p in self.geoms) + \
             '</g>'
 
     @property

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -93,7 +93,7 @@ class MultiPolygon(BaseMultipartGeometry):
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, fill_color) for p in self) + \
+            ''.join(p.svg(scale_factor, fill_color) for p in self.geoms) + \
             '</g>'
 
 

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -103,6 +103,9 @@ class CollectionOperator(object):
         source = None
         if hasattr(lines, 'type') and lines.type == 'MultiLineString':
             source = lines
+        elif hasattr(lines, 'geoms'):
+            # other Multi geometries
+            source = MultiLineString([ls.coords for ls in lines.geoms])
         elif hasattr(lines, '__iter__'):
             try:
                 source = MultiLineString([ls.coords for ls in lines])
@@ -120,6 +123,8 @@ class CollectionOperator(object):
         """
         try:
             L = len(geoms)
+            if isinstance(geoms, BaseMultipartGeometry):
+                geoms = geoms.geoms
         except TypeError:
             geoms = [geoms]
             L = 1
@@ -137,6 +142,8 @@ class CollectionOperator(object):
         """
         try:
             L = len(geoms)
+            if isinstance(geoms, BaseMultipartGeometry):
+                geoms = geoms.geoms
         except TypeError:
             geoms = [geoms]
             L = 1

--- a/tests/test_make_valid.py
+++ b/tests/test_make_valid.py
@@ -9,7 +9,7 @@ def test_make_valid_invalid_input():
     geom = Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)])
     valid = make_valid(geom)
     assert len(valid) == 2
-    assert all(geom.type == 'Polygon' for geom in valid)
+    assert all(geom.type == 'Polygon' for geom in valid.geoms)
 
 
 @requires_geos_38

--- a/tests/test_ndarrays.py
+++ b/tests/test_ndarrays.py
@@ -21,7 +21,7 @@ class TransposeTestCase(unittest.TestCase):
         arr = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         tarr = arr.T
         shape = geometry.asMultiPoint(tarr)
-        coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape])
+        coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape.geoms])
         self.assertEqual(
             coords,
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]
@@ -54,7 +54,7 @@ class TransposeTestCase(unittest.TestCase):
         arr = numpy.array([[1.0, 1.0, 2.0, 2.0, 1.0], [3.0, 4.0, 4.0, 3.0, 3.0]])
         tarr = arr.T
         shape = geometry.MultiPoint(tarr)
-        coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape])
+        coords = reduce(lambda x, y: x + y, [list(g.coords) for g in shape.geoms])
         self.assertEqual(
             coords,
             [(1.0, 3.0), (1.0, 4.0), (2.0, 4.0), (2.0, 3.0), (1.0, 3.0)]

--- a/tests/test_polygonize.py
+++ b/tests/test_polygonize.py
@@ -35,7 +35,7 @@ class PolygonizeTestCase(unittest.TestCase):
 
         result2, dangles, cuts, invalids = polygonize_full(lines2)
         self.assertEqual(len(result2), 2)
-        self.assertTrue(all([isinstance(x, Polygon) for x in result2]))
+        self.assertTrue(all([isinstance(x, Polygon) for x in result2.geoms]))
         self.assertEqual(list(dangles.geoms), [])
         self.assertTrue(all([isinstance(x, LineString) for x in cuts.geoms]))
 

--- a/tests/test_shared_paths.py
+++ b/tests/test_shared_paths.py
@@ -14,7 +14,7 @@ class SharedPaths(unittest.TestCase):
         
         self.assertTrue(isinstance(result, GeometryCollection))
         self.assertTrue(len(result) == 2)
-        a, b = result
+        a, b = result.geoms
         self.assertTrue(isinstance(a, MultiLineString))
         self.assertTrue(len(a) == 1)
         self.assertEqual(a[0].coords[:], [(5, 0), (10, 0)])
@@ -27,7 +27,7 @@ class SharedPaths(unittest.TestCase):
         
         self.assertTrue(isinstance(result, GeometryCollection))
         self.assertTrue(len(result) == 2)
-        a, b = result
+        a, b = result.geoms
         self.assertTrue(isinstance(b, MultiLineString))
         self.assertTrue(len(b) == 1)
         self.assertEqual(b[0].coords[:], [(5, 0), (10, 0)])

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -39,7 +39,7 @@ def test_edges():
     regions = voronoi_diagram(mp, edges=True)
 
     assert len(regions) == 1
-    assert all(r.type == 'LineString' for r in regions)
+    assert all(r.type == 'LineString' for r in regions.geoms)
 
 
 @requires_geos_35
@@ -50,7 +50,7 @@ def test_smaller_envelope():
     regions = voronoi_diagram(mp, envelope=poly)
 
     assert len(regions) == 2
-    assert sum(r.area for r in regions) > poly.area
+    assert sum(r.area for r in regions.geoms) > poly.area
 
 
 @requires_geos_35
@@ -64,7 +64,7 @@ def test_larger_envelope():
     regions = voronoi_diagram(mp, envelope=poly)
 
     assert len(regions) == 2
-    assert sum(r.area for r in regions) == poly.area
+    assert sum(r.area for r in regions.geoms) == poly.area
 
 
 @requires_geos_35


### PR DESCRIPTION
This should help with actually deprecating it in https://github.com/Toblerity/Shapely/pull/950