### PR TITLE
Add Python 3.9 support to setup.py and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,94 +10,110 @@ matrix:
   include:
     - python: "2.7"
       env:
-        GEOSVERSION="3.4.3"
+        GEOS_VERSION="3.4.3"
         SPEEDUPS=1
         NUMPY=1
     - python: "2.7"
       env:
-        GEOSVERSION="3.4.3"
+        GEOS_VERSION="3.4.3"
         SPEEDUPS=0
         NUMPY=1
     - python: "2.7"
       env:
-        GEOSVERSION="3.4.3"
+        GEOS_VERSION="3.4.3"
         SPEEDUPS=0
         NUMPY=0
     - python: "3.5"
       env:
-        GEOSVERSION="3.5.2"
+        GEOS_VERSION="3.5.2"
         SPEEDUPS=1
         NUMPY=1
     - python: "3.5"
       env:
-        GEOSVERSION="3.5.2"
+        GEOS_VERSION="3.5.2"
         SPEEDUPS=0
         NUMPY=1
     - python: "3.5"
       env:
-        GEOSVERSION="3.5.2"
+        GEOS_VERSION="3.5.2"
         SPEEDUPS=0
         NUMPY=0
     - python: "3.6"
       env:
-        GEOSVERSION="3.6.4"
+        GEOS_VERSION="3.6.4"
         SPEEDUPS=1
         NUMPY=1
     - python: "3.6"
       env:
-        GEOSVERSION="3.6.4"
+        GEOS_VERSION="3.6.4"
         SPEEDUPS=0
         NUMPY=1
     - python: "3.6"
       env:
-        GEOSVERSION="3.6.4"
+        GEOS_VERSION="3.6.4"
         SPEEDUPS=0
         NUMPY=0
     - python: "3.7"
       env:
-        GEOSVERSION="3.7.3"
+        GEOS_VERSION="3.7.3"
         SPEEDUPS=1
         NUMPY=1
     - python: "3.7"
       env:
-        GEOSVERSION="3.7.3"
+        GEOS_VERSION="3.7.3"
         SPEEDUPS=0
         NUMPY=1
     - python: "3.7"
       env:
-        GEOSVERSION="3.7.3"
+        GEOS_VERSION="3.7.3"
         SPEEDUPS=0
         NUMPY=0
     - python: "3.8"
       env:
-        GEOSVERSION="3.8.1"
+        GEOS_VERSION="3.8.1"
         SPEEDUPS=1
         NUMPY=1
     - python: "3.8"
       env:
-        GEOSVERSION="3.8.1"
+        GEOS_VERSION="3.8.1"
         SPEEDUPS=0
         NUMPY=1
     - python: "3.8"
       env:
-        GEOSVERSION="3.8.1"
+        GEOS_VERSION="3.8.1"
         SPEEDUPS=0
         NUMPY=0
-    - python: "3.8-dev"
+    - python: "3.9"
       env:
-        GEOSVERSION="master"
+        GEOS_VERSION="3.8.1"
+        SPEEDUPS=1
+        NUMPY=1
+    - python: "3.9"
+      env:
+        GEOS_VERSION="3.8.1"
+        SPEEDUPS=0
+        NUMPY=1
+    - python: "3.9"
+      env:
+        GEOS_VERSION="3.8.1"
+        SPEEDUPS=0
+        NUMPY=0
+    - python: "3.9-dev"
+      env:
+        GEOS_VERSION="master"
         SPEEDUPS=1
         NUMPY=1
   allow_failures:
-    - python: "3.8-dev"
+    - python: "3.9-dev"
       env:
-        GEOSVERSION="master"
+        GEOS_VERSION="master"
         SPEEDUPS=1
         NUMPY=1
 
 before_install:
   - ./ci/travis/install_geos.sh
-  - pip install --upgrade pip
+  - pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel
   # if building with speedups install cython
   - if [ "$SPEEDUPS" == "1" ]; then pip install --install-option="--no-cython-compile" cython; fi
   # if testing without numpy explicitly remove it
@@ -107,12 +123,12 @@ before_install:
   - pip install --upgrade coveralls pytest-cov pytest>=3.8
 
 install:
-  - export GEOS_CONFIG=$HOME/geosinstall/geos-$GEOSVERSION/bin/geos-config
+  - export GEOS_CONFIG=$HOME/geosinstall/geos-$GEOS_VERSION/bin/geos-config
   - pip install -v -e .[all]
 
 script:
-  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
-  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOSVERSION/lib
+  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
+  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
   - python -c "from shapely.geos import geos_version; print(geos_version)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,45 +1,51 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 platform: x64
 
 environment:
   global:
-    GEOSVERSION: "3.8.1"
+    GEOS_VERSION: "3.8.1"
 
   matrix:
 #    - PYTHON: "C:\\Python27"
 #      ARCH: x86
 #      COMPILER: msvc90
-#      GEOSVERSION: "3.5.2"
+#      GEOS_VERSION: "3.5.2"
 #      image: Visual Studio 2015
 #    - PYTHON: "C:\\Python27-x64"
 #      ARCH: x64
 #      COMPILER: msvc90
-#      GEOSVERSION: "3.5.2"
+#      GEOS_VERSION: "3.5.2"
 #      image: Visual Studio 2015
     - PYTHON: "C:\\Python35"
       ARCH: x86
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python35-x64"
       ARCH: x64
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python36"
       ARCH: x86
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python36-x64"
       ARCH: x64
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python37"
       ARCH: x86
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python37-x64"
       ARCH: x64
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python38"
       ARCH: x86
-      COMPILER: msvc2017
+      COMPILER: msvc2019
     - PYTHON: "C:\\Python38-x64"
       ARCH: x64
-      COMPILER: msvc2017
+      COMPILER: msvc2019
+    - PYTHON: "C:\\Python39"
+      ARCH: x86
+      COMPILER: msvc2019
+    - PYTHON: "C:\\Python39-x64"
+      ARCH: x64
+      COMPILER: msvc2019
 
 
 install:
@@ -59,29 +65,32 @@ build_script:
 
   - ps: 'Write-Host "Configuring PATH with $env:PYTHON" -ForegroundColor Magenta'
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - python -m pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel
 
   - ps: 'Write-Host "Configuring MSVC compiler $env:COMPILER" -ForegroundColor Magenta'
   - if %COMPILER%==msvc90 ( call "C:\Users\appveyor\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0\vcvarsall.bat" %ARCH% )
   - if %COMPILER%==msvc2017 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH% )
+  - if %COMPILER%==msvc2019 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH% )
 
   - ps: 'Write-Host "Cached dependency folder" -ForegroundColor Magenta'
   - if not exist C:\projects\deps mkdir C:\projects\deps
   - dir C:\projects\deps
 
-  - set GEOSINSTALL=C:\projects\deps\geos-%GEOSVERSION%-%COMPILER%-%ARCH%
-  - set CYTHONPF=C:\\projects\\deps\\geos-%GEOSVERSION%-%COMPILER%-%ARCH%
-  - ps: 'Write-Host "Checking GEOS build $env:GEOSINSTALL" -ForegroundColor Magenta'
+  - set GEOS_INSTALL=C:\projects\deps\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - set CYTHONPF=C:\\projects\\deps\\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - ps: 'Write-Host "Checking GEOS build $env:GEOS_INSTALL" -ForegroundColor Magenta'
   - call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\build_geos.cmd
 
-  # - ps: 'Push-AppveyorArtifact $env:GEOSINSTALL\bin\geos.dll'
-  # - ps: 'Push-AppveyorArtifact $env:GEOSINSTALL\bin\geos_c.dll'
+  # - ps: 'Push-AppveyorArtifact $env:GEOS_INSTALL\bin\geos.dll'
+  # - ps: 'Push-AppveyorArtifact $env:GEOS_INSTALL\bin\geos_c.dll'
 
   - ps: 'Write-Host "Copying and checking geos_c.dll" -ForegroundColor Magenta'
   - cd %APPVEYOR_BUILD_FOLDER%
   - dir
   - if %ARCH%==x86 ( set CPDIR=DLLs_x86_VC9 )
   - if %ARCH%==x64 ( set CPDIR=DLLs_AMD64_VC9 )
-  - xcopy %GEOSINSTALL%\bin\geos*.dll %CPDIR%
+  - xcopy %GEOS_INSTALL%\bin\geos*.dll %CPDIR%
   - cd %CPDIR%
   - dir
   - dumpbin /dependents geos_c.dll
@@ -92,8 +101,8 @@ build_script:
 
   - ps: 'Write-Host "Building wheel" -ForegroundColor Magenta'
   - pip install -r requirements-dev.txt
-  - set GEOS_LIBRARY_PATH=%GEOSINSTALL%\bin\geos_c.dll
-  - set PATH=%GEOSINSTALL%\bin;%PATH%
+  - set GEOS_LIBRARY_PATH=%GEOS_INSTALL%\bin\geos_c.dll
+  - set PATH=%GEOS_INSTALL%\bin;%PATH%
   - python setup.py build_ext -I%CYTHONPF%\\include -lgeos_c -L%CYTHONPF%\\lib bdist_wheel
 
   - ps: 'Write-Host "Checking pip install in a new environment" -ForegroundColor Magenta'

--- a/ci/appveyor/build_geos.cmd
+++ b/ci/appveyor/build_geos.cmd
@@ -1,26 +1,25 @@
 REM This script is called from appveyor.yml
 
-if exist %GEOSINSTALL% (
-  echo Using cached %GEOSINSTALL%
+if exist %GEOS_INSTALL% (
+  echo Using cached %GEOS_INSTALL%
 ) else (
-  echo Building %GEOSINSTALL%
+  echo Building %GEOS_INSTALL%
 
   cd C:\projects
 
-  curl -fsSO http://download.osgeo.org/geos/geos-%GEOSVERSION%.tar.bz2
-  7z x geos-%GEOSVERSION%.tar.bz2
-  7z x geos-%GEOSVERSION%.tar
-  cd geos-%GEOSVERSION%
+  curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar
+  cd geos-%GEOS_VERSION% || exit /B 5
 
   pip install ninja
   cmake --version
 
   mkdir build
   cd build
-  cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOSINSTALL% ..
-  cmake --build . --config Release -j 2
-  ctest . --config Release
-  cmake --install . --config Release
+  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOS_INSTALL% .. || exit /B 1
+  cmake --build . --config Release || exit /B 2
+  ctest . --config Release || exit /B 3
+  cmake --install . --config Release || exit /B 4
   cd ..
 )
-

--- a/ci/travis/install_geos.sh
+++ b/ci/travis/install_geos.sh
@@ -3,47 +3,47 @@
 set -e
 
 # Cache install directory from .travis.yml
-CACHEGEOSINST=$HOME/geosinstall
+CACHE_GEOS_INST=$HOME/geosinstall
 
 # Create directories, if they don't exit
-GEOSINSTVERSION=$CACHEGEOSINST/geos-$GEOSVERSION
-mkdir -p $GEOSINSTVERSION
+GEOS_INST_VERSION=$CACHE_GEOS_INST/geos-$GEOS_VERSION
+mkdir -p $GEOS_INST_VERSION
 
 function build_geos {
-    echo "Building geos-$GEOSVERSION"
+    echo "Building geos-$GEOS_VERSION"
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GEOSINSTVERSION ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GEOS_INST_VERSION ..
     make -j 2
     ctest .
     make install
 }
 
-if [ "$GEOSVERSION" = "master" ]; then
+if [ "$GEOS_VERSION" = "master" ]; then
     # use GitHub mirror
-    git clone --depth 1 https://github.com/libgeos/geos.git geos-$GEOSVERSION
-    cd geos-$GEOSVERSION
+    git clone --depth 1 https://github.com/libgeos/geos.git geos-$GEOS_VERSION
+    cd geos-$GEOS_VERSION
     git rev-parse HEAD > newrev.txt
     BUILD=no
     # Only build if nothing cached or if the GEOS revision changed
-    if test ! -f $GEOSINSTVERSION/rev.txt; then
+    if test ! -f $GEOS_INST_VERSION/rev.txt; then
         BUILD=yes
-    elif ! diff newrev.txt $GEOSINSTVERSION/rev.txt >/dev/null; then
+    elif ! diff newrev.txt $GEOS_INST_VERSION/rev.txt >/dev/null; then
         BUILD=yes
     fi
     if test "$BUILD" = "no"; then
-        echo "Using cached install $GEOSINSTVERSION"
+        echo "Using cached install $GEOS_INST_VERSION"
     else
-        cp newrev.txt $GEOSINSTVERSION/rev.txt
+        cp newrev.txt $GEOS_INST_VERSION/rev.txt
         build_geos
     fi
 else
-    if [ -d "$GEOSINSTVERSION/include/geos" ]; then
-        echo "Using cached install $GEOSINSTVERSION"
+    if [ -d "$GEOS_INST_VERSION/include/geos" ]; then
+        echo "Using cached install $GEOS_INST_VERSION"
     else
-        wget -q http://download.osgeo.org/geos/geos-$GEOSVERSION.tar.bz2
-        tar xfj geos-$GEOSVERSION.tar.bz2
-        cd geos-$GEOSVERSION
+        wget -q http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2
+        tar xfj geos-$GEOS_VERSION.tar.bz2
+        cd geos-$GEOS_VERSION
         build_geos
     fi
 fi

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: GIS',
     ],
     cmdclass           = {},


### PR DESCRIPTION
* Change AppVeyor image from 2017 to Visual Studio 2019
* Rename environment variable `GEOSVERSION` -> `GEOS_VERSION`
* Rename environment variable `GEOSINSTALL` -> `GEOS_INSTALL`
* Copy `build_geos.cmd` and `install_geos.sh` from master
* Do `pip install wheel` before other dependencies

This is similar to #1011, but for the `maint-1.7` branch.