### PR TITLE
TST: 'pip install wheel' before other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,8 @@ matrix:
 
 before_install:
   - ./ci/travis/install_geos.sh
-  - pip install --upgrade pip
+  - pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel
   # if building with speedups install cython
   - if [ "$SPEEDUPS" == "1" ]; then pip install --install-option="--no-cython-compile" cython; fi
   # if testing without numpy explicitly remove it

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ build_script:
   - ps: 'Write-Host "Configuring PATH with $env:PYTHON and $env:GEOS_INSTALL\bin" -ForegroundColor Magenta'
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%GEOS_INSTALL%\bin;%PATH%
   - python -m pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel
 
   - ps: 'Write-Host "Checking GEOS build $env:GEOS_INSTALL" -ForegroundColor Magenta'
   - if not exist C:\projects\deps mkdir C:\projects\deps


### PR DESCRIPTION
This is an amendment to #1011 which initially passed all CI tests before merge, but subsequently raised a new AppVeyor failure with pip on Python 3.9 after merge, as `wheel` was not installed (despite it being part of `requirements-dev.txt`). This installs/upgrades `wheel` before other dependencies to avoid the issue.