### PR TITLE
Deprecate the geometry .empty() method

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -181,6 +181,13 @@ class BaseGeometry(object):
     _lgeos = lgeos
 
     def empty(self, val=EMPTY):
+        warn(
+            "The 'empty()' method is deprecated and will be removed in "
+            "Shapely 2.0",
+            ShapelyDeprecationWarning, stacklevel=2)
+        self._empty(val=val)
+
+    def _empty(self, val=EMPTY):
         if not self._other_owned and self.__geom__ and self.__geom__ != EMPTY:
             try:
                 self._lgeos.GEOSGeom_destroy(self.__geom__)
@@ -198,7 +205,7 @@ class BaseGeometry(object):
         return self.__bool__()
 
     def __del__(self):
-        self.empty(val=None)
+        self._empty(val=None)
         self.__p__ = None
 
     def __str__(self):
@@ -209,7 +216,7 @@ class BaseGeometry(object):
         return (self.__class__, (), self.wkb)
 
     def __setstate__(self, state):
-        self.empty()
+        self._empty()
         self.__geom__ = deserialize_wkb(state)
         self._is_empty = False
         if lgeos.methods['has_z'](self.__geom__):
@@ -223,7 +230,7 @@ class BaseGeometry(object):
 
     @_geom.setter
     def _geom(self, val):
-        self.empty()
+        self._empty()
         self._is_empty = val in [EMPTY, None]
         self.__geom__ = val
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -110,7 +110,7 @@ class LineString(BaseGeometry):
             "Setting the 'coords' to mutate a Geometry in place is deprecated,"
             " and will not be possible any more in Shapely 2.0",
             ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
+        self._empty()
         ret = geos_linestring_from_py(coordinates)
         if ret is not None:
             self._geom, self._ndim = ret

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -155,7 +155,7 @@ class Point(BaseGeometry):
             "Setting the 'coords' to mutate a Geometry in place is deprecated,"
             " and will not be possible any more in Shapely 2.0",
             ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
+        self._empty()
         if len(args) == 1:
             self._geom, self._ndim = geos_point_from_py(args[0])
         elif len(args) > 3:

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -70,7 +70,7 @@ class LinearRing(LineString):
             "Setting the 'coords' to mutate a Geometry in place is deprecated,"
             " and will not be possible any more in Shapely 2.0",
             ShapelyDeprecationWarning, stacklevel=2)
-        self.empty()
+        self._empty()
         ret = geos_linearring_from_py(coordinates)
         if ret is not None:
             self._geom, self._ndim = ret
@@ -251,7 +251,7 @@ class Polygon(BaseGeometry):
             if ret is not None:
                 self._geom, self._ndim = ret
             else:
-                self.empty()
+                self._empty()
 
     @property
     def exterior(self):

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -1,4 +1,4 @@
-from . import unittest
+from . import unittest, shapely20_deprecated
 
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry.base import BaseGeometry, EmptyGeometry
@@ -22,6 +22,7 @@ class EmptinessTestCase(unittest.TestCase):
         g = BaseGeometry()
         self.assertTrue(g._is_empty)
 
+    @shapely20_deprecated
     def test_emptying_point(self):
         p = sgeom.Point(0, 0)
         self.assertFalse(p._is_empty)


### PR DESCRIPTION
I suppose this is more like an internal method in practice, but it's still publicly exposed, so worth officially deprecating (since it will go away in Shapely 2.0, where geometries are no longer mutable).