### PR TITLE
Deprecate setting of _geom attribute

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -80,7 +80,7 @@ def geom_factory(g, parent=None):
         [geom_type],
         )
     ob.__class__ = getattr(mod, geom_type)
-    ob._geom = g
+    ob._set_geom(g)
     ob.__p__ = parent
     if lgeos.methods['has_z'](g):
         ob._ndim = 3
@@ -223,6 +223,13 @@ class BaseGeometry(object):
 
     @_geom.setter
     def _geom(self, val):
+        warn(
+            "Setting the '_geom' attribute directly is deprecated, and will "
+            "no longer be possible in Shapely 2.0.",
+            ShapelyDeprecationWarning, stacklevel=2)
+        self._set_geom(val)
+
+    def _set_geom(self, val):
         self.empty()
         self._is_empty = val in [EMPTY, None]
         self.__geom__ = val
@@ -946,7 +953,7 @@ class GeometrySequence(object):
     def _get_geom_item(self, i):
         g = self.shape_factory()
         g._other_owned = True
-        g._geom = lgeos.GEOSGetGeometryN(self._geom, i)
+        g._set_geom(lgeos.GEOSGetGeometryN(self._geom, i))
         g._ndim = self._ndim
         g.__p__ = self
         return g

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -40,7 +40,9 @@ class GeometryCollection(BaseMultipartGeometry):
         if not geoms:
             pass
         else:
-            self._geom, self._ndim = geos_geometrycollection_from_py(geoms)
+            geom, n = geos_geometrycollection_from_py(geoms)
+            self._set_geom(geom)
+            self._ndim = n
 
     @property
     def __geo_interface__(self):

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -44,7 +44,9 @@ class LineString(BaseGeometry):
         if coordinates is not None:
             ret = geos_linestring_from_py(coordinates)
             if ret is not None:
-                self._geom, self._ndim = ret
+                geom, n = ret
+                self._set_geom(geom)
+                self._ndim = n
 
     @property
     def __geo_interface__(self):
@@ -113,7 +115,9 @@ class LineString(BaseGeometry):
         self.empty()
         ret = geos_linestring_from_py(coordinates)
         if ret is not None:
-            self._geom, self._ndim = ret
+            geom, n = ret
+            self._set_geom(geom)
+            self._ndim = n
 
     coords = property(BaseGeometry._get_coords, _set_coords)
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -46,7 +46,9 @@ class MultiLineString(BaseMultipartGeometry):
             # allow creation of empty multilinestrings, to support unpickling
             pass
         else:
-            self._geom, self._ndim = geos_multilinestring_from_py(lines)
+            geom, n = geos_multilinestring_from_py(lines)
+            self._set_geom(geom)
+            self._ndim = n
 
     def shape_factory(self, *args):
         return linestring.LineString(*args)

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -52,7 +52,9 @@ class MultiPoint(BaseMultipartGeometry):
             # allow creation of empty multipoints, to support unpickling
             pass
         else:
-            self._geom, self._ndim = geos_multipoint_from_py(points)
+            geom, n = geos_multipoint_from_py(points)
+            self._set_geom(geom)
+            self._ndim = n
 
     def shape_factory(self, *args):
         return point.Point(*args)

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -55,11 +55,13 @@ class MultiPolygon(BaseMultipartGeometry):
 
         if not polygons:
             # allow creation of empty multipolygons, to support unpickling
-            pass
+            return
         elif context_type == 'polygons':
-            self._geom, self._ndim = geos_multipolygon_from_polygons(polygons)
+            geom, n = geos_multipolygon_from_polygons(polygons)
         elif context_type == 'geojson':
-            self._geom, self._ndim = geos_multipolygon_from_py(polygons)
+            geom, n = geos_multipolygon_from_py(polygons)
+        self._set_geom(geom)
+        self._ndim = n
 
     def shape_factory(self, *args):
         return polygon.Polygon(*args)

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -47,13 +47,15 @@ class Point(BaseGeometry):
         BaseGeometry.__init__(self)
         if len(args) > 0:
             if len(args) == 1:
-                self._geom, self._ndim = geos_point_from_py(args[0])
+                geom, n = geos_point_from_py(args[0])
             elif len(args) > 3:
                 raise TypeError(
                     "Point() takes at most 3 arguments ({} given)".format(len(args))
                 )
             else:
-                self._geom, self._ndim = geos_point_from_py(tuple(args))
+                geom, n = geos_point_from_py(tuple(args))
+            self._set_geom(geom)
+            self._ndim = n
 
     # Coordinate getters and setters
 
@@ -157,11 +159,13 @@ class Point(BaseGeometry):
             ShapelyDeprecationWarning, stacklevel=2)
         self.empty()
         if len(args) == 1:
-            self._geom, self._ndim = geos_point_from_py(args[0])
+            geom, n = geos_point_from_py(args[0])
         elif len(args) > 3:
             raise TypeError("Point() takes at most 3 arguments ({} given)".format(len(args)))
         else:
-            self._geom, self._ndim = geos_point_from_py(tuple(args))
+            geom, n = geos_point_from_py(tuple(args))
+        self._set_geom(geom)
+        self._ndim = n
 
     coords = property(BaseGeometry._get_coords, _set_coords)
 

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -52,7 +52,9 @@ class LinearRing(LineString):
         if coordinates is not None:
             ret = geos_linearring_from_py(coordinates)
             if ret is not None:
-                self._geom, self._ndim = ret
+                geom, n = ret
+                self._set_geom(geom)
+                self._ndim = n
 
     @property
     def __geo_interface__(self):
@@ -73,7 +75,9 @@ class LinearRing(LineString):
         self.empty()
         ret = geos_linearring_from_py(coordinates)
         if ret is not None:
-            self._geom, self._ndim = ret
+            geom, n = ret
+            self._set_geom(geom)
+            self._ndim = n
 
     coords = property(_get_coords, _set_coords)
 
@@ -196,7 +200,7 @@ class InteriorRingSequence(object):
         if i not in self.__rings__:
             g = lgeos.GEOSGetInteriorRingN(self._geom, i)
             ring = LinearRing()
-            ring._geom = g
+            ring._set_geom(g)
             ring.__p__ = self
             ring._other_owned = True
             ring._ndim = self._ndim
@@ -249,7 +253,9 @@ class Polygon(BaseGeometry):
         if shell is not None:
             ret = geos_polygon_from_py(shell, holes)
             if ret is not None:
-                self._geom, self._ndim = ret
+                geom, n = ret
+                self._set_geom(geom)
+                self._ndim = n
             else:
                 self.empty()
 
@@ -260,7 +266,7 @@ class Polygon(BaseGeometry):
         elif self._exterior is None or self._exterior() is None:
             g = lgeos.GEOSGetExteriorRing(self._geom)
             ring = LinearRing()
-            ring._geom = g
+            ring._set_geom(g)
             ring.__p__ = self
             ring._other_owned = True
             ring._ndim = self._ndim

--- a/tests/test_emptiness.py
+++ b/tests/test_emptiness.py
@@ -1,4 +1,4 @@
-from . import unittest
+from . import unittest, shapely20_deprecated
 
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry.base import BaseGeometry, EmptyGeometry
@@ -28,6 +28,7 @@ class EmptinessTestCase(unittest.TestCase):
         p.empty()
         self.assertTrue(p._is_empty)
 
+    @shapely20_deprecated
     def test_none_geom(self):
         p = BaseGeometry()
         p._geom = None


### PR DESCRIPTION
Related to https://github.com/Toblerity/Shapely/issues/999, but regardless the naming discussion / which properties we keep, the ability to *set* them from python is something that will go away in Shapely 2.0, so this PR is explicitly deprecating that.