### PR TITLE
Deprecate ops.cascaded_union, as it was superseded by ops.unary_union

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import shapely
 
 # For pyplots in code/, load functions here first, so they are visible
 from shapely import geometry, affinity, wkt, wkb
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -137,7 +137,7 @@ described in a following section of the manual.
 Coordinate Systems
 ------------------
 
-Even though the Earth is not flat – and for that matter not exactly spherical –
+Even though the Earth is not flat – and for that matter not exactly spherical –
 there are many analytic problems that can be approached by transforming Earth
 features to a Cartesian plane, applying tried and true algorithms, and then
 transforming the results back to geographic coordinates.  This practice is as
@@ -2220,10 +2220,8 @@ efficient than accumulating with :meth:`union`.
 
   .. note::
 
-     In 1.2.16 :func:`shapely.ops.cascaded_union` was transparently superseded by
-     :func:`shapely.ops.unary_union` if GEOS 3.3+ is used. The unary union
-     function can operate on different geometry types, not only polygons as is
-     the case for the older cascaded union.
+     In 1.8.0 :func:`shapely.ops.cascaded_union` is deprecated, as it was
+     superseded by :func:`shapely.ops.unary_union`.
 
 Delaunay triangulation
 ----------------------

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -2,7 +2,9 @@
 """
 
 from ctypes import byref, c_void_p, c_double
+from warnings import warn
 
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.prepared import prep
 from shapely.geos import lgeos
 from shapely.geometry.base import geom_factory, BaseGeometry, BaseMultipartGeometry
@@ -119,8 +121,13 @@ class CollectionOperator(object):
     def cascaded_union(self, geoms):
         """Returns the union of a sequence of geometries
 
-        This method was superseded by :meth:`unary_union`.
+        This function is deprecated, as it was superseded by
+        :meth:`unary_union`.
         """
+        warn(
+            "The 'cascaded_union()' function is deprecated. "
+            "Use 'unary_union()' instead.",
+            ShapelyDeprecationWarning, stacklevel=2)
         try:
             L = len(geoms)
             if isinstance(geoms, BaseMultipartGeometry):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -3,7 +3,7 @@ from shapely.ops import split
 from . import unittest
 
 from shapely.geometry import Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection
-from shapely.ops import cascaded_union, linemerge
+from shapely.ops import linemerge, unary_union
 
 class TestSplitGeometry(unittest.TestCase):
 	# helper class for testing below
@@ -16,7 +16,7 @@ class TestSplitGeometry(unittest.TestCase):
 			if s.geoms[0].type == 'LineString':
 				self.assertTrue(linemerge(s).simplify(0.000001).equals(geom))
 			elif s.geoms[0].type == 'Polygon':
-				union = cascaded_union(s).simplify(0.000001)
+				union = unary_union(s).simplify(0.000001)
 				self.assertTrue(union.equals(geom))
 				self.assertEqual(union.area, geom.area)
 			else:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,7 +1,9 @@
 from . import unittest
+import pytest
 import random
 from itertools import islice
 from functools import partial
+from shapely.errors import ShapelyDeprecationWarning
 from shapely.geos import geos_version
 from shapely.geometry import Point, MultiPolygon
 from shapely.ops import cascaded_union, unary_union
@@ -27,6 +29,7 @@ def halton(base):
 class UnionTestCase(unittest.TestCase):
 
     def test_cascaded_union(self):
+        # cascaded_union is deprecated, as it was superseded by unary_union
 
         # Use a partial function to make 100 points uniformly distributed
         # in a 40x40 box centered on 0,0.
@@ -39,7 +42,8 @@ class UnionTestCase(unittest.TestCase):
 
         # Perform a cascaded union of the polygon spots, dissolving them
         # into a collection of polygon patches
-        u = cascaded_union(spots)
+        with pytest.warns(ShapelyDeprecationWarning, match="is deprecated"):
+            u = cascaded_union(spots)
         self.assertTrue(u.geom_type in ('Polygon', 'MultiPolygon'))
 
     def setUp(self):


### PR DESCRIPTION
Resolves #1001 to deprecate `ops.cascaded_union` for Shapely 1.8.