### PR TITLE
ops.split: Split the line when the boundary of a splitter LineString touches the interior of the line

### DIFF
--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -122,6 +122,11 @@ class TestSplitLine(TestSplitGeometry):
 		self.assertTrue(splitter.touches(self.ls))
 		self.helper(self.ls, splitter, 1)
 
+		# splitter boundary touches interior of line --> return 2 segments
+		splitter = LineString([(0, 1), (1, 1)])  # touches at (1, 1)
+		self.assertTrue(splitter.touches(self.ls))
+		self.helper(self.ls, splitter, 2)
+
 	def test_split_line_with_multiline(self):
 		# crosses at one point --> return 2 segments
 		splitter = MultiLineString([[(0, 1), (1, 0)], [(0, 0), (2, -2)]])


### PR DESCRIPTION
See #701 for background. 

I thought about using `splitter.relate_pattern(line, '...')` several times. But I'm not sure how much if any of that operation is cached, so I'm calculating one relation string and using it directly for the three checks. Fortunately the checks are all straightforward, each involving only one character.

Ping to @snorfalorpagus, just in case you would want to take a look since you have been heavily involved with the split function in the past.