### PR TITLE
Refactor shapely.prepared to use prepared base geometries

### DIFF
--- a/shapely/prepared.py
+++ b/shapely/prepared.py
@@ -1,9 +1,8 @@
 """
 Support for GEOS prepared geometry operations.
 """
+import pygeos
 
-from shapely.geos import lgeos
-from shapely.impl import DefaultImplementation, delegated
 from pickle import PicklingError
 
 
@@ -20,75 +19,53 @@ class PreparedGeometry(object):
       True
     """
 
-    impl = DefaultImplementation
-
     def __init__(self, context):
         if isinstance(context, PreparedGeometry):
             self.context = context.context
         else:
+            pygeos.prepare(context)
             self.context = context
-        self.__geom__ = lgeos.GEOSPrepare(self.context._geom)
         self.prepared = True
 
-    def __del__(self):
-        if self.__geom__ is not None:
-            try:
-                lgeos.GEOSPreparedGeom_destroy(self.__geom__)
-            except AttributeError:
-                pass  # lgeos might be empty on shutdown.
-
-        self.__geom__ = None
-        self.context = None
-        self.prepared = False
-
-    @property
-    def _geom(self):
-        return self.__geom__
-
-    @delegated
     def contains(self, other):
         """Returns True if the geometry contains the other, else False"""
-        return bool(self.impl['prepared_contains'](self, other))
+        return self.context.contains(other)
 
-    @delegated
     def contains_properly(self, other):
         """Returns True if the geometry properly contains the other, else False"""
-        return bool(self.impl['prepared_contains_properly'](self, other))
+        # TODO temporary hack until pygeos exposes contains properly as predicate function
+        from pygeos import STRtree
+        tree = STRtree([other])
+        idx = tree.query(self.context, predicate="contains_properly")
+        return bool(len(idx))
 
-    @delegated
     def covers(self, other):
         """Returns True if the geometry covers the other, else False"""
-        return bool(self.impl['prepared_covers'](self, other))
+        return self.context.covers(other)
 
-    @delegated
     def crosses(self, other):
         """Returns True if the geometries cross, else False"""
-        return bool(self.impl['prepared_crosses'](self, other))
+        return self.context.crosses(other)
 
-    @delegated
     def disjoint(self, other):
         """Returns True if geometries are disjoint, else False"""
-        return bool(self.impl['prepared_disjoint'](self, other))
+        return self.context.disjoint(other)
 
-    @delegated
     def intersects(self, other):
         """Returns True if geometries intersect, else False"""
-        return bool(self.impl['prepared_intersects'](self, other))
+        return self.context.intersects(other)
 
-    @delegated
     def overlaps(self, other):
         """Returns True if geometries overlap, else False"""
-        return bool(self.impl['prepared_overlaps'](self, other))
+        return self.context.overlaps(other)
 
-    @delegated
     def touches(self, other):
         """Returns True if geometries touch, else False"""
-        return bool(self.impl['prepared_touches'](self, other))
+        return self.context.touches(other)
 
-    @delegated
     def within(self, other):
         """Returns True if geometry is within the other, else False"""
-        return bool(self.impl['prepared_within'](self, other))
+        return self.context.within(other)
 
     def __reduce__(self):
         raise PicklingError("Prepared geometries cannot be pickled.")

--- a/shapely/vectorized/__init__.py
+++ b/shapely/vectorized/__init__.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pygeos
 
+from shapely.prepared import PreparedGeometry
+
 
 def _construct_points(x, y):
     x, y = np.asanyarray(x), np.asanyarray(y)
@@ -39,6 +41,8 @@ def contains(geometry, x, y):
 
     """
     points = _construct_points(x, y)
+    if isinstance(geometry, PreparedGeometry):
+        geometry = geometry.context
     pygeos.prepare(geometry)
     return pygeos.contains(geometry, points)
 
@@ -65,5 +69,7 @@ def touches(geometry, x, y):
 
     """
     points = _construct_points(x, y)
+    if isinstance(geometry, PreparedGeometry):
+        geometry = geometry.context
     pygeos.prepare(geometry)
     return pygeos.touches(geometry, points)


### PR DESCRIPTION
In PyGEOS, the GEOSPreparedGeometry is now stored on the same python extension type (C struct) as used for the base Geometry class (and there are functions to (un)prepare a geometry object "in place"). If an object is prepared, the predicate functions will automatically use it.

So in the future, we can make this interface in Shapely easier, but on the short term, I refactored the existing shapely PreparedGeometry to use the prepared functionality of PyGEOS. 
(since there is not yet an alternative for this in Shapely 1.8, so we can't deprecate this yet (if we would want that long term), and keep a working version initially in Shapely 2.0)