### PR TITLE
auditwheel 2/3 compat

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -68,22 +68,20 @@ if sys.platform.startswith('linux'):
     # Test to see if we have a wheel repaired by auditwheel which contains its
     # own libgeos_c. Note: auditwheel 3 changed the location of libs.
     geos_whl_so = glob.glob(
-        os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__), ".libs/libgeos_c-*.so.*"
-            )
-        )
+        os.path.abspath(os.path.join(os.path.dirname(__file__), ".libs/libgeos*.so*"))
     ) or glob.glob(
         os.path.abspath(
             os.path.join(
-                os.path.dirname(__file__), "..", "Shapely.libs", "libgeos_c-*.so.*"
+                os.path.dirname(__file__), "..", "Shapely.libs", "libgeos*.so*"
             )
         )
     )
 
-    if len(geos_whl_so) == 1:
-        _lgeos = CDLL(geos_whl_so[0])
+    if len(geos_whl_so) > 0:
+        CDLL(geos_whl_so[0])
+        _lgeos = CDLL(geos_whl_so[-1])
         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+
     elif hasattr(sys, 'frozen'):
         geos_pyinstaller_so = glob.glob(os.path.join(sys.prefix, 'libgeos_c-*.so.*'))
         if len(geos_pyinstaller_so) == 1:

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -61,18 +61,26 @@ def load_dll(libname, fallbacks=None, mode=DEFAULT_MODE):
             "Could not find lib {} or load any of its variants {}.".format(
                 libname, fallbacks or []))
 
+
 _lgeos = None
 
 if sys.platform.startswith('linux'):
-    # Test to see if we have a wheel repaired by 'auditwheel' containing its
-    # own libgeos_c
+    # Test to see if we have a wheel repaired by auditwheel which contains its
+    # own libgeos_c. Note: auditwheel 3 changed the location of libs.
     geos_whl_so = glob.glob(
         os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__), ".libs/libgeos_c-*.so.*"
             )
         )
+    ) or glob.glob(
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "..", "Shapely.libs", "libgeos_c-*.so.*"
+            )
+        )
     )
+
     if len(geos_whl_so) == 1:
         _lgeos = CDLL(geos_whl_so[0])
         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -78,6 +78,7 @@ if sys.platform.startswith('linux'):
     )
 
     if len(geos_whl_so) > 0:
+        geos_whl_so = sorted(geos_whl_so)
         CDLL(geos_whl_so[0])
         _lgeos = CDLL(geos_whl_so[-1])
         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)


### PR DESCRIPTION
This is a "hotfix" with search path changes required by auditwheel versions > 3.0, which is required for Python 3.9.

We will not merge this into 1.7.x but we will need this for 1.8.