### PR TITLE
CI: test geos-3.9.0 release; show other debug information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,17 +70,17 @@ matrix:
         NUMPY=0
     - python: "3.9"
       env:
-        GEOS_VERSION="3.9.0beta2"
+        GEOS_VERSION="3.9.0"
         SPEEDUPS=1
         NUMPY=1
     - python: "3.9"
       env:
-        GEOS_VERSION="3.9.0beta2"
+        GEOS_VERSION="3.9.0"
         SPEEDUPS=0
         NUMPY=1
     - python: "3.9"
       env:
-        GEOS_VERSION="3.9.0beta2"
+        GEOS_VERSION="3.9.0"
         SPEEDUPS=0
         NUMPY=0
     - python: "3.9-dev"
@@ -106,7 +106,7 @@ before_install:
   - if [ "$NUMPY" == "0" ]; then pip uninstall --yes numpy; fi
   # convert SPEEDUPS to --with-speedups/--without-speedups
   - if [ "$SPEEDUPS" == "1" ]; then SPEEDUPS_FLAG=--with-speedups; else SPEEDUPS_FLAG=--without-speedups; fi
-  - pip install --upgrade coveralls pytest-cov pytest>=3.8
+  - pip install --upgrade coveralls pytest-cov pytest
 
 install:
   - export GEOS_CONFIG=$HOME/geosinstall/geos-$GEOS_VERSION/bin/geos-config
@@ -115,7 +115,8 @@ install:
 script:
   - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
   - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
-  - python -c "from shapely.geos import geos_version; print(geos_version)"
+  - python -c "from shapely import geos; print(geos.geos_version_string)"
+  - python -c "from shapely import speedups; print(speedups.enabled)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" && "$NUMPY" == "1" && "$SPEEDUPS" == "1" ]]; then python -m pytest shapely --doctest-modules; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,24 +101,33 @@ before_install:
   - pip install --disable-pip-version-check --upgrade pip
   - pip install --upgrade wheel
   # if building with speedups install cython
-  - if [ "$SPEEDUPS" == "1" ]; then pip install --install-option="--no-cython-compile" cython; fi
+  - if [ "$SPEEDUPS" == "1" ]; then
+      pip install --install-option="--no-cython-compile" cython;
+    fi
   # if testing without numpy explicitly remove it
-  - if [ "$NUMPY" == "0" ]; then pip uninstall --yes numpy; fi
+  - if [ "$NUMPY" == "0" ]; then
+      pip uninstall --yes numpy;
+    fi
   # convert SPEEDUPS to --with-speedups/--without-speedups
-  - if [ "$SPEEDUPS" == "1" ]; then SPEEDUPS_FLAG=--with-speedups; else SPEEDUPS_FLAG=--without-speedups; fi
+  - if [ "$SPEEDUPS" == "1" ]; then
+      SPEEDUPS_FLAG=--with-speedups;
+    else
+      SPEEDUPS_FLAG=--without-speedups;
+    fi
   - pip install --upgrade coveralls pytest-cov pytest
 
 install:
-  - export GEOS_CONFIG=$HOME/geosinstall/geos-$GEOS_VERSION/bin/geos-config
+  - export GEOS_CONFIG=$GEOS_INSTALL/bin/geos-config
+  - export LD_LIBRARY_PATH=$GEOS_INSTALL/lib
   - pip install -v -e .[all]
 
 script:
-  - export LD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
-  - export DYLD_LIBRARY_PATH=$HOME/geosinstall/geos-$GEOS_VERSION/lib
   - python -c "from shapely import geos; print(geos.geos_version_string)"
   - python -c "from shapely import speedups; print(speedups.enabled)"
   - python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" && "$NUMPY" == "1" && "$SPEEDUPS" == "1" ]]; then python -m pytest shapely --doctest-modules; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" && "$NUMPY" == "1" && "$SPEEDUPS" == "1" ]]; then
+      python -m pytest shapely --doctest-modules;
+    fi
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"


### PR DESCRIPTION
The final release of geos-3.9.0 was just released, so use this in the Travis CI test matrix. (We'll likely transition this to Github Actions at some point).

Other things:
- The `pytest>=3.8` command just redirect output to a `=3.8` file; the `--upgrade` flag should do the right thing.
- Testing with the GEOS master branch builds speedups, but they don't appear to work, so add a bit more debugging info. If it looks like an easy fix, then I'll add it here.
- No features from GEOS 3.9.0 are implemented yet, but are next up to investigate and discuss.