### PR TITLE
Refactor shapely.ops to not use lgeos

### DIFF
--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -46,16 +46,8 @@ class CollectionOperator:
             source = [source]
         finally:
             obs = [self.shapeup(l) for l in source]
-        geom_array_type = c_void_p * len(obs)
-        geom_array = geom_array_type()
-        for i, line in enumerate(obs):
-            geom_array[i] = line._geom
-        product = lgeos.GEOSPolygonize(byref(geom_array), len(obs))
-        collection = geom_factory(product)
-        for g in collection.geoms:
-            clone = lgeos.GEOSGeom_clone(g._geom)
-            g = geom_factory(clone)
-            yield g
+        collection = pygeos.polygonize(obs)
+        return collection.geoms
 
     def polygonize_full(self, lines):
         """Creates polygons from a source of lines, returning the polygons
@@ -79,22 +71,7 @@ class CollectionOperator:
             source = [source]
         finally:
             obs = [self.shapeup(l) for l in source]
-        L = len(obs)
-        subs = (c_void_p * L)()
-        for i, g in enumerate(obs):
-            subs[i] = g._geom
-        collection = lgeos.GEOSGeom_createCollection(5, subs, L)
-        dangles = c_void_p()
-        cuts = c_void_p()
-        invalids = c_void_p()
-        product = lgeos.GEOSPolygonize_full(
-            collection, byref(dangles), byref(cuts), byref(invalids))
-        return (
-            geom_factory(product),
-            geom_factory(dangles.value),
-            geom_factory(cuts.value),
-            geom_factory(invalids.value)
-            )
+        return pygeos.polygonize_full(obs)
 
     def linemerge(self, lines):
         """Merges all connected lines from a source

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -192,7 +192,7 @@ def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
         errstr += "({}).".format(str(err))
         if tolerance:
             errstr += " Try running again with default tolerance value."
-        raise pygeos.GEOSException(errstr) from err
+        raise ValueError(errstr) from err
 
     if result.type != 'GeometryCollection':
         return GeometryCollection([result])

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -1,13 +1,11 @@
 """Support for various GEOS geometry operations
 """
 
-from ctypes import byref, c_void_p, c_double
 from warnings import warn
 
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.prepared import prep
-from shapely.geos import lgeos
-from shapely.geometry.base import geom_factory, BaseGeometry, BaseMultipartGeometry
+from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
 from shapely.geometry import (
     shape, Point, MultiPoint, LineString, MultiLineString, Polygon, GeometryCollection)
 from shapely.geometry.polygon import orient as orient_

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -224,11 +224,8 @@ def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
     return result
 
 
-class ValidateOp:
-    def __call__(self, this):
-        return lgeos.GEOSisValidReason(this._geom)
-
-validate = ValidateOp()
+def validate(geom):
+    return pygeos.is_valid_reason(geom)
 
 
 def transform(func, geom):
@@ -327,6 +324,7 @@ def nearest_points(g1, g2):
     p2 = Point(x2.value, y2.value)
     return (p1, p2)
 
+
 def snap(g1, g2, tolerance):
     """Snap one geometry to another with a given tolerance
 
@@ -351,7 +349,8 @@ def snap(g1, g2, tolerance):
     >>> result.wkt
     'LINESTRING (0 0, 1 1, 2 1, 2.6 0.5)'
     """
-    return(geom_factory(lgeos.methods['snap'](g1._geom, g2._geom, tolerance)))
+    return pygeos.snap(g1, g2, tolerance)
+
 
 def shared_paths(g1, g2):
     """Find paths shared between the two given lineal geometries
@@ -373,7 +372,7 @@ def shared_paths(g1, g2):
         raise TypeError("First geometry must be a LineString")
     if not isinstance(g2, LineString):
         raise TypeError("Second geometry must be a LineString")
-    return(geom_factory(lgeos.methods['shared_paths'](g1._geom, g2._geom)))
+    return pygeos.shared_paths(g1, g2)
 
 
 class SplitOp:

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -694,8 +694,7 @@ def clip_by_rect(geom, xmin, ymin, xmax, ymax):
     """
     if geom.is_empty:
         return geom
-    result = geom_factory(lgeos.methods['clip_by_rect'](geom._geom, xmin, ymin, xmax, ymax))
-    return result
+    return pygeos.clip_by_rect(geom, xmin, ymin, xmax, ymax)
 
 
 def orient(geom, sign=1.0):

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -283,22 +283,15 @@ def nearest_points(g1, g2):
 
     The points are returned in the same order as the input geometries.
     """
-    seq = lgeos.methods['nearest_points'](g1._geom, g2._geom)
+    seq = pygeos.shortest_line(g1, g2)
     if seq is None:
         if g1.is_empty:
             raise ValueError('The first input geometry is empty')
         else:
             raise ValueError('The second input geometry is empty')
-    x1 = c_double()
-    y1 = c_double()
-    x2 = c_double()
-    y2 = c_double()
-    lgeos.GEOSCoordSeq_getX(seq, 0, byref(x1))
-    lgeos.GEOSCoordSeq_getY(seq, 0, byref(y1))
-    lgeos.GEOSCoordSeq_getX(seq, 1, byref(x2))
-    lgeos.GEOSCoordSeq_getY(seq, 1, byref(y2))
-    p1 = Point(x1.value, y1.value)
-    p2 = Point(x2.value, y2.value)
+
+    p1 = pygeos.get_point(seq, 0)
+    p2 = pygeos.get_point(seq, 1)
     return (p1, p2)
 
 

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -8,6 +8,8 @@ that we return a sane result without error or raise a useful one.
 
 import pytest
 
+import pygeos
+
 from shapely.geos import geos_version
 from shapely.geometry import MultiPoint
 from shapely.wkt import loads as load_wkt
@@ -86,21 +88,21 @@ def test_from_polygon_with_enough_tolerance():
 @requires_geos_35
 def test_from_polygon_without_enough_tolerance():
     poly = load_wkt('POLYGON ((0 0, 0.5 0, 0.5 0.5, 0 0.5, 0 0))')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(pygeos.GEOSException) as exc:
         voronoi_diagram(poly, tolerance=0.6)
 
-    assert exc.match("Could not create Voronoi Diagram with the specified inputs. "
-                     "Try running again with default tolerance value.")
+    assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
+    assert "Try running again with default tolerance value." in str(exc.value)
 
 
 @requires_geos_35
 def test_from_polygon_without_floating_point_coordinates():
     poly = load_wkt('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(pygeos.GEOSException) as exc:
         voronoi_diagram(poly, tolerance=0.1)
 
-    assert exc.match("Could not create Voronoi Diagram with the specified inputs. "
-                     "Try running again with default tolerance value")
+    assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
+    assert "Try running again with default tolerance value." in str(exc.value)
 
 
 @requires_geos_35
@@ -108,22 +110,22 @@ def test_from_multipoint_without_floating_point_coordinates():
     """A Multipoint with the same "shape" as the above Polygon raises the same error..."""
     mp = load_wkt('MULTIPOINT (0 0, 1 0, 1 1, 0 1)')
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(pygeos.GEOSException) as exc:
         voronoi_diagram(mp, tolerance=0.1)
 
-    assert exc.match("Could not create Voronoi Diagram with the specified inputs. "
-                     "Try running again with default tolerance value")
+    assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
+    assert "Try running again with default tolerance value." in str(exc.value)
 
 
 @requires_geos_35
 def test_from_multipoint_with_tolerace_without_floating_point_coordinates():
     """This multipoint will not work with a tolerance value."""
     mp = load_wkt('MULTIPOINT (0 0, 1 0, 1 2, 0 1)')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(pygeos.GEOSException) as exc:
         voronoi_diagram(mp, tolerance=0.1)
 
-    assert exc.match("Could not create Voronoi Diagram with the specified inputs. "
-                     "Try running again with default tolerance value")
+    assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
+    assert "Try running again with default tolerance value." in str(exc.value)
 
 
 @requires_geos_35

--- a/tests/test_voronoi_diagram.py
+++ b/tests/test_voronoi_diagram.py
@@ -8,8 +8,6 @@ that we return a sane result without error or raise a useful one.
 
 import pytest
 
-import pygeos
-
 from shapely.geos import geos_version
 from shapely.geometry import MultiPoint
 from shapely.wkt import loads as load_wkt
@@ -88,7 +86,7 @@ def test_from_polygon_with_enough_tolerance():
 @requires_geos_35
 def test_from_polygon_without_enough_tolerance():
     poly = load_wkt('POLYGON ((0 0, 0.5 0, 0.5 0.5, 0 0.5, 0 0))')
-    with pytest.raises(pygeos.GEOSException) as exc:
+    with pytest.raises(ValueError) as exc:
         voronoi_diagram(poly, tolerance=0.6)
 
     assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
@@ -98,7 +96,7 @@ def test_from_polygon_without_enough_tolerance():
 @requires_geos_35
 def test_from_polygon_without_floating_point_coordinates():
     poly = load_wkt('POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))')
-    with pytest.raises(pygeos.GEOSException) as exc:
+    with pytest.raises(ValueError) as exc:
         voronoi_diagram(poly, tolerance=0.1)
 
     assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
@@ -110,7 +108,7 @@ def test_from_multipoint_without_floating_point_coordinates():
     """A Multipoint with the same "shape" as the above Polygon raises the same error..."""
     mp = load_wkt('MULTIPOINT (0 0, 1 0, 1 1, 0 1)')
 
-    with pytest.raises(pygeos.GEOSException) as exc:
+    with pytest.raises(ValueError) as exc:
         voronoi_diagram(mp, tolerance=0.1)
 
     assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)
@@ -121,7 +119,7 @@ def test_from_multipoint_without_floating_point_coordinates():
 def test_from_multipoint_with_tolerace_without_floating_point_coordinates():
     """This multipoint will not work with a tolerance value."""
     mp = load_wkt('MULTIPOINT (0 0, 1 0, 1 2, 0 1)')
-    with pytest.raises(pygeos.GEOSException) as exc:
+    with pytest.raises(ValueError) as exc:
         voronoi_diagram(mp, tolerance=0.1)
 
     assert "Could not create Voronoi Diagram with the specified inputs" in str(exc.value)


### PR DESCRIPTION
Replacing direct `lgeos` calls with pygeos python functions in the `shapely.ops` module.

The remaining ones to do are `polygonize`, `polygonize_full` and `nearest_points`. For `polygonize` I already have a PR in pygeos, the others still need to be added there.