### PR TITLE
fix the multi libgeos for pyinstaller

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -85,7 +85,7 @@ if sys.platform.startswith('linux'):
 
     elif hasattr(sys, 'frozen'):
         geos_pyinstaller_so = glob.glob(os.path.join(sys.prefix, 'libgeos_c-*.so.*'))
-        if len(geos_pyinstaller_so) == 1:
+        if len(geos_pyinstaller_so) >= 1:
             _lgeos = CDLL(geos_pyinstaller_so[0])
             LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
     elif exists_conda_env():


### PR DESCRIPTION
If we have installed the `finoa`, `shapely`, `rasterio`, and package them all use Pyinstaller. 

There are multi `libgeos_c-*.so.*`, not only one. 

So, we should check the length of geos_pyinstaller_so greater and equal to 1.

![image](https://user-images.githubusercontent.com/5787131/105569030-159d7a00-5d79-11eb-9575-23d1f12f5bbc.png)


![image](https://user-images.githubusercontent.com/5787131/105569013-fef72300-5d78-11eb-9422-087ea3893e13.png)
