### PR TITLE
[documentation] add `covers` and `covered_by`

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1184,6 +1184,20 @@ A line's endpoints are part of its `boundary` and are therefore not contained.
   >>> [p.wkt for p in contained]
   ['POINT (0.5000000000000000 0.5000000000000000)']
 
+.. method:: object.covers(other)
+
+  Returns ``True`` if every point of `other` is a point on the interior or
+  boundary of `object`. This is similar to ``object.contains(other)`` except
+  that this does not require any interior points of `other` to lie in the 
+  interior of `object`.
+
+.. method:: object.covered_by(other)
+
+  Returns ``True`` if every point of `object` is a point on the interior or
+  boundary of `other`. This is equivalent to ``other.covers(object)``.
+  
+  `New in version 1.8`.
+
 .. method:: object.crosses(other)
 
   Returns ``True`` if the `interior` of the object intersects the `interior` of


### PR DESCRIPTION
The `.covers()` binary predicate was [added 6 years ago](https://github.com/Toblerity/Shapely/commit/0090e5de2bedfeeaeae4061cf5fd20ef88d03c88#diff-0cfd418bbccae3cd182953f575a205d0bc8bde442f40041187b6016668cbefdeR619-R621), and the `.covered_by()` binary predicate was [added last year](https://github.com/Toblerity/Shapely/commit/0ecc21c0aaef478dbfdc55bcf3b6e90a039e4b64#diff-0cfd418bbccae3cd182953f575a205d0bc8bde442f40041187b6016668cbefdeR735-R738), but neither are included in the documentation. The only way someone would know to use this is by being familiar with the DE-9IM named predicates or perusing the source code. Let's fix that.