### PR TITLE
CI: bump versions to latest GEOS-3.9.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,15 +61,15 @@ jobs:
             speedups: 0
           # 2020
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             numpy: 1.19.5
             speedups: 1
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             numpy: 1.19.5
             speedups: 0
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             speedups: 0
           # dev
           - python: 3.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       GEOS_VERSION: "3.8.1"
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
-      GEOS_VERSION: "3.9.0beta2"
+      GEOS_VERSION: "3.9.1"
 
 
 install:

--- a/ci/install_geos.cmd
+++ b/ci/install_geos.cmd
@@ -21,7 +21,7 @@ if exist %GEOS_INSTALL% (
   cd build
   cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOS_INSTALL% .. || exit /B 2
   cmake --build . || exit /B 3
-  :: ctest . || exit /B 4
+  ctest . || exit /B 4
   ctest .
   cmake --install . || exit /B 5
   cd ..


### PR DESCRIPTION
GEOS 3.9.1 was recently [announced](https://lists.osgeo.org/pipermail/geos-devel/2021-February/010138.html). Bump the following GEOS versions:

- Github Actions: 3.9.0 -> 3.9.1
- AppVeyor: 3.9.0beta2 -> 3.9.1; also, resume `ctest` build check