### PR TITLE
CI: bump versions to latest GEOS-3.9.1 (maint-1.7 branch)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,15 +73,15 @@ jobs:
             speedups: 0
           # 2020
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             numpy: 1.19.5
             speedups: 1
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             numpy: 1.19.5
             speedups: 0
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             speedups: 0
           # dev
           - python: 3.9
@@ -118,7 +118,7 @@ jobs:
       - name: Install python dependencies
         shell: bash
         run: |
-          use_pip_lt_21=`python3 -c "import sys; print(sys.version_info[:2] < (3, 6))"`
+          use_pip_lt_21=`python -c "import sys; print(sys.version_info[:2] < (3, 6))"`
           if [ $use_pip_lt_21 = "True" ]; then
             pip="pip < 21.0"
           else


### PR DESCRIPTION
Update the `maint-1.7` branch with the latest GEOS version for testing with GitHub Actions. Also tidy a minor component of the "Install python dependencies" step.