### PR TITLE
ENH: Add normalize() method

### DIFF
--- a/shapely/ctypes_declarations.py
+++ b/shapely/ctypes_declarations.py
@@ -388,6 +388,9 @@ def prototype(lgeos, geos_version):
     lgeos.GEOSGeom_getDimensions.restype = c_int
     lgeos.GEOSGeom_getDimensions.argtypes = [c_void_p]
 
+    lgeos.GEOSNormalize.restype = c_int
+    lgeos.GEOSNormalize.argtypes = [c_void_p]
+
     # Misc functions
 
     lgeos.GEOSArea.restype = c_double

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -649,7 +649,7 @@ class BaseGeometry(object):
         >>> from shapely.wkt import loads
         >>> p = loads("MULTILINESTRING((0 0, 1 1), (3 3, 2 2))")
         >>> p.normalize().wkt
-        "MULTILINESTRING ((2 2, 3 3), (0 0, 1 1))"
+        'MULTILINESTRING ((2 2, 3 3), (0 0, 1 1))'
         """
         # self.impl['normalize'](self)
         if self._geom is None:

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -637,6 +637,27 @@ class BaseGeometry(object):
             op = self.impl['simplify']
         return geom_factory(op(self, tolerance))
 
+    def normalize(self):
+        """Converts geometry to normal form (or canonical form).
+
+        This method orders the coordinates, rings of a polygon and parts of
+        multi geometries consistently. Typically useful for testing purposes
+        (for example in combination with `equals_exact`).
+
+        Examples
+        --------
+        >>> from shapely.wkt import loads
+        >>> p = loads("MULTILINESTRING((0 0, 1 1), (3 3, 2 2))")
+        >>> p.normalize().wkt
+        "MULTILINESTRING ((2 2, 3 3), (0 0, 1 1))"
+        """
+        # self.impl['normalize'](self)
+        if self._geom is None:
+            raise ValueError("Null geometry supports no operations")
+        geom_cloned = lgeos.GEOSGeom_clone(self._geom)
+        lgeos.GEOSNormalize(geom_cloned)
+        return geom_factory(geom_cloned)
+
     # Binary operations
     # -----------------
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -699,6 +699,7 @@ class LGEOS330(LGEOSBase):
         self.methods['simplify'] = self.GEOSSimplify
         self.methods['topology_preserve_simplify'] = \
             self.GEOSTopologyPreserveSimplify
+        self.methods['normalize'] = self.GEOSNormalize
         self.methods['cascaded_union'] = self.GEOSUnionCascaded
 
         def parallel_offset(geom, distance, resolution=16, join_style=1,

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -88,6 +88,7 @@ IMPL330 = {
     'simplify': (UnaryTopologicalOp, 'simplify'),
     'topology_preserve_simplify':
         (UnaryTopologicalOp, 'topology_preserve_simplify'),
+    'normalize': (UnaryTopologicalOp, 'normalize'),
     #
     'difference': (BinaryTopologicalOp, 'difference'),
     'intersection': (BinaryTopologicalOp, 'intersection'),

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -92,3 +92,13 @@ class OperationsTestCase(unittest.TestCase):
         assert(empty_line.is_empty)
         with pytest.raises(ValueError):
             empty_line.interpolate(.5, normalized=True)
+
+    def test_normalize(self):
+        point = Point(1, 1)
+        result = point.normalize()
+        assert result == point
+
+        line = loads("MULTILINESTRING ((1 1, 0 0), (1 1, 1 2))")
+        result = line.normalize()
+        expected = loads("MULTILINESTRING ((1 1, 1 2), (0 0, 1 1))")
+        assert result == expected


### PR DESCRIPTION
Closes #994

This exposes `GEOSNormalize` as a method on the geometry classes. In GEOS, this works in place, but to keep the Shapely interface consistent (other operations like simplify also return a new geometry), I made the `normalize()` method to return a new geometry (and thus first clone the geometry before normalizing it).

This seems to work for me for some simple cases. cc @tomplex @Lucidiot  

Especially given the overlay changes in GEOS 3.9.0 (where you often first need to normalize the geometry if you want to be able to compare it to an expected result across different GEOS versions), I think it would be useful to still include this in Shapely 1.8.