### PR TITLE
A general purpose STRtree which can store any Python object

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -238,6 +238,9 @@ class STRtree:
         None
 
         """
+        if not self._initdata:
+            return
+
         lgeos.GEOSSTRtree_query(
             self._tree_handle, geom._geom, lgeos.GEOSQueryCallback(callback), None
         )

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -39,7 +39,7 @@ def nearest_callback(func):
             dist.contents.value = func(value, geom)
             return 1
         except Exception:
-            log.exception()
+            log.exception("Caught exception")
             return 0
     return wrapper
 

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -21,6 +21,7 @@ References
 from shapely.geos import lgeos
 import ctypes
 
+
 class STRtree:
     """
     An STRtree is a spatial index; specifically, an R-tree created
@@ -172,6 +173,11 @@ class STRtree:
 
         return result
 
+    def query_cb(self, geom, callback):
+        lgeos.GEOSSTRtree_query(
+            self._tree_handle, geom._geom, lgeos.GEOSQueryCallback(callback), None
+        )
+
     def nearest(self, geom):
         """
         Get the nearest object in the index to a geometry object.
@@ -217,11 +223,16 @@ class STRtree:
                 dist = ctypes.cast(distance, ctypes.POINTER(ctypes.c_double))
                 lgeos.GEOSDistance(geom1._geom, geom2._geom, dist)
                 return 1
-            except:
+            except Exception:
                 return 0
 
-        item = lgeos.GEOSSTRtree_nearest_generic(self._tree_handle, ctypes.py_object(geom), envelope._geom, \
-            lgeos.GEOSDistanceCallback(callback), None)
+        item = lgeos.GEOSSTRtree_nearest_generic(
+            self._tree_handle,
+            ctypes.py_object(geom),
+            envelope._geom,
+            lgeos.GEOSDistanceCallback(callback),
+            None,
+        )
         result = ctypes.cast(item, ctypes.py_object).value
 
         return result

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -275,7 +275,7 @@ class STRtree:
 
         # In a future version of shapely, geometries will be hashable
         # and we won't need to reindex like this.
-        geoms = {id(v): g for g, v in self._initdata}
+        geoms = {id(v): g for v, g in self._initdata}
 
         @nearest_callback
         def callback(value, geom):

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -266,6 +266,9 @@ class STRtree:
         'POINT (0 0)'
 
         """
+        if not self._initdata:
+            return None
+
         envelope = geom.envelope
         try:
             geoms, values = zip(*self._initdata)

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -133,15 +133,15 @@ class STRtree:
                 geom = obj
                 value = obj
             else:
-                geom, value = obj
+                value, geom = obj
             if not geom.is_empty:
-                yield geom, value
+                yield value, geom
 
     def _init_tree(self, initdata):
         if initdata:
             node_capacity = 10
             self._tree = lgeos.GEOSSTRtree_create(node_capacity)
-            for geom, value in self._iteritems(initdata):
+            for value, geom in self._iteritems(initdata):
                 lgeos.GEOSSTRtree_insert(
                     self._tree, geom._geom, ctypes.py_object(value)
                 )

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -18,8 +18,9 @@ References
      https://www.cs.odu.edu/~mln/ltrs-pdfs/icase-1997-14.pdf
 """
 
-from shapely.geos import lgeos
 import ctypes
+
+from shapely.geos import lgeos
 
 
 class STRtree:

--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -107,8 +107,18 @@ class STRtree:
     def __init__(self, initdata=None):
         self._initdata = None
         self._tree_handle = None
+
         if initdata is not None:
-            self._initdata = list(initdata)
+            self._initdata = []
+            for obj in initdata:
+                if not isinstance(obj, tuple):
+                    geom = obj
+                    value = obj
+                else:
+                    geom, value = obj
+                if not geom.is_empty:
+                    self._initdata.append(obj)
+
         self._init_tree_handle(self._initdata)
 
     def _init_tree_handle(self, initdata):

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -38,9 +38,9 @@ def test_query_cb(geoms, query_geom, num_results):
 
     results = []
 
-    def callback(item, userdata):
-        obj = ctypes.cast(item, ctypes.py_object).value
-        results.append(obj)
+    @query_callback
+    def callback(value):
+        results.append(value)
 
     tree.query_cb(query_geom, callback=callback)
 
@@ -60,7 +60,7 @@ def test_query_cb_str(geoms, values, query_geom, num_results):
     results = []
 
     @query_callback
-    def callback(value, userdata):
+    def callback(value):
         results.append(value)
 
     tree.query_cb(query_geom, callback=callback)
@@ -81,7 +81,7 @@ def test_query_cb_dict(geoms, values, query_geom, num_results):
     results = []
 
     @query_callback
-    def callback(value, userdata):
+    def callback(value):
         results.append(value)
 
     tree.query_cb(query_geom, callback=callback)

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -9,28 +9,29 @@ import pytest
 
 from shapely.geometry import Point, Polygon
 from shapely import strtree
-from shapely.strtree import STRtree
+from shapely.strtree import STRtree, query_callback
 
 from .conftest import requires_geos_342
 
 
 @requires_geos_342
-def test_query():
-    points = [Point(i, i) for i in range(10)]
-    tree = STRtree(points)
-    results = tree.query(Point(2, 2).buffer(0.99))
-    assert len(results) == 1
-    results = tree.query(Point(2, 2).buffer(1.0))
-    assert len(results) == 3
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
+@pytest.mark.parametrize(
+    "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
+)
+def test_query(geoms, query_geom, num_results):
+    tree = STRtree(geoms)
+    results = tree.query(query_geom)
+    assert len(results) == num_results
 
 
 @requires_geos_342
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
 @pytest.mark.parametrize(
-    "q_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
+    "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
-def test_query_cb(q_geom, num_results):
-    points = [Point(i, i) for i in range(10)]
-    tree = STRtree(points)
+def test_query_cb(geoms, query_geom, num_results):
+    tree = STRtree(geoms)
 
     results = []
 
@@ -38,9 +39,49 @@ def test_query_cb(q_geom, num_results):
         obj = ctypes.cast(item, ctypes.py_object).value
         results.append(obj)
 
-    tree.query_cb(q_geom, callback=callback)
+    tree.query_cb(query_geom, callback=callback)
 
     assert len(results) == num_results
+
+
+@requires_geos_342
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
+@pytest.mark.parametrize("values", [["Hi!" for i in range(10)]])
+@pytest.mark.parametrize(
+    "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
+)
+def test_query_cb_str(geoms, values, query_geom, num_results):
+    tree = STRtree(zip(geoms, values))
+
+    results = []
+
+    @query_callback
+    def callback(value, userdata):
+        results.append(value)
+
+    tree.query_cb(query_geom, callback=callback)
+
+    assert list(results) == ["Hi!"] * num_results
+
+
+@requires_geos_342
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
+@pytest.mark.parametrize("values", [[{"a": 1, "b": 2} for i in range(10)]])
+@pytest.mark.parametrize(
+    "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
+)
+def test_query_cb_dict(geoms, values, query_geom, num_results):
+    tree = STRtree(zip(geoms, values))
+
+    results = []
+
+    @query_callback
+    def callback(value, userdata):
+        results.append(value)
+
+    tree.query_cb(query_geom, callback=callback)
+
+    assert list(results) == [{"a": 1, "b": 2}] * num_results
 
 
 @requires_geos_342
@@ -52,7 +93,6 @@ def test_insert_empty_geometry():
     empty = Polygon()
     geoms = [empty]
     tree = STRtree(geoms)
-    assert tree._n_geoms == 0
     query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
     results = tree.query(query)
     assert len(results) == 0
@@ -68,7 +108,6 @@ def test_query_empty_geometry():
     point = Point(1, 0.5)
     geoms = [empty, point]
     tree = STRtree(geoms)
-    assert tree._n_geoms == 1
     query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
     results = tree.query(query)
     assert len(results) == 1
@@ -82,7 +121,6 @@ def test_references():
     point = Point(1, 0.5)
     geoms = [empty, point]
     tree = STRtree(geoms)
-    assert tree._n_geoms == 1
 
     empty = None
     point = None
@@ -111,7 +149,7 @@ def test_pickle_persistence():
     """
     Don't crash trying to use unpickled GEOS handle.
     """
-    tree = STRtree([Point(i, i).buffer(0.1) for i in range(3)])
+    tree = STRtree([(Point(i, i).buffer(0.1), "Hi!") for i in range(3)])
     pickled_strtree = pickle.dumps(tree)
     unpickle_script_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "unpickle-strtree.py")
     proc = subprocess.Popen(

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -21,7 +21,8 @@ from .conftest import requires_geos_342
     "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
 def test_query(geoms, query_geom, num_results):
-    tree = STRtree(geoms)
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(geoms)
     results = tree.query(query_geom)
     assert len(results) == num_results
 
@@ -32,7 +33,8 @@ def test_query(geoms, query_geom, num_results):
     "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
 def test_query_cb(geoms, query_geom, num_results):
-    tree = STRtree(geoms)
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(geoms)
 
     results = []
 
@@ -52,7 +54,8 @@ def test_query_cb(geoms, query_geom, num_results):
     "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
 def test_query_cb_str(geoms, values, query_geom, num_results):
-    tree = STRtree(zip(geoms, values))
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(zip(geoms, values))
 
     results = []
 
@@ -72,7 +75,8 @@ def test_query_cb_str(geoms, values, query_geom, num_results):
     "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
 def test_query_cb_dict(geoms, values, query_geom, num_results):
-    tree = STRtree(zip(geoms, values))
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(zip(geoms, values))
 
     results = []
 

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -30,6 +30,19 @@ def test_query(geoms, query_geom, num_results):
 @requires_geos_342
 @pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
 @pytest.mark.parametrize(
+    "query_geom,expected",
+    [(Point(2, 2).buffer(0.99), [2]), (Point(2, 2).buffer(1.0), [1, 2, 3])],
+)
+def test_query_idx_values(geoms, query_geom, expected):
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(enumerate(geoms))
+    results = tree.query(query_geom)
+    assert sorted(results) == sorted(expected)
+
+
+@requires_geos_342
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
+@pytest.mark.parametrize(
     "query_geom,num_results", [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)]
 )
 def test_query_cb(geoms, query_geom, num_results):
@@ -55,7 +68,7 @@ def test_query_cb(geoms, query_geom, num_results):
 )
 def test_query_cb_str(geoms, values, query_geom, num_results):
     with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(zip(geoms, values))
+        tree = STRtree(zip(values, geoms))
 
     results = []
 
@@ -76,7 +89,7 @@ def test_query_cb_str(geoms, values, query_geom, num_results):
 )
 def test_query_cb_dict(geoms, values, query_geom, num_results):
     with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(zip(geoms, values))
+        tree = STRtree(zip(values, geoms))
 
     results = []
 
@@ -159,7 +172,7 @@ def test_pickle_persistence():
     Don't crash trying to use unpickled GEOS handle.
     """
     with pytest.warns(ShapelyDeprecationWarning):
-      tree = STRtree([(Point(i, i).buffer(0.1), "Hi!") for i in range(3)])
+        tree = STRtree([("Hi!", Point(i, i).buffer(0.1)) for i in range(3)])
 
     pickled_strtree = pickle.dumps(tree)
     unpickle_script_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "unpickle-strtree.py")

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -33,11 +33,26 @@ def test_query(geoms, query_geom, num_results):
     "query_geom,expected",
     [(Point(2, 2).buffer(0.99), [2]), (Point(2, 2).buffer(1.0), [1, 2, 3])],
 )
-def test_query_idx_values(geoms, query_geom, expected):
+def test_query_enumeration_idx(geoms, query_geom, expected):
+    """Store enumeration idx"""
     with pytest.warns(ShapelyDeprecationWarning):
         tree = STRtree(enumerate(geoms))
     results = tree.query(query_geom)
     assert sorted(results) == sorted(expected)
+
+
+@requires_geos_342
+@pytest.mark.parametrize("geoms", [[Point(i, i) for i in range(10)]])
+@pytest.mark.parametrize(
+    "query_geom,expected",
+    [(Point(2, 2).buffer(0.99), [2]), (Point(2, 2).buffer(1.0), [1, 2, 3])],
+)
+def test_query_enumeration(geoms, query_geom, expected):
+    """Store enumeration"""
+    with pytest.warns(ShapelyDeprecationWarning):
+        tree = STRtree(zip(enumerate(geoms), geoms))
+    results = tree.query(query_geom)
+    assert sorted(results) == sorted([(idx, geoms[idx]) for idx in expected])
 
 
 @requires_geos_342

--- a/tests/test_strtree_nearest.py
+++ b/tests/test_strtree_nearest.py
@@ -44,5 +44,5 @@ def test_nearest_geom(geoms, query_geom):
 @pytest.mark.parametrize("query_geom", [Point(0, 0.4)])
 def test_nearest_value(geoms, values, query_geom):
     with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(zip(geoms, values))
+        tree = STRtree(zip(values, geoms))
     tree.nearest(query_geom) == "Ahoy!"

--- a/tests/test_strtree_nearest.py
+++ b/tests/test_strtree_nearest.py
@@ -1,19 +1,43 @@
-from . import unittest
+import pytest
 
 from shapely.geometry import Point, Polygon
 from shapely.geos import geos_version
 from shapely.strtree import STRtree
 
-@unittest.skipIf(geos_version < (3, 6, 0), 'GEOS 3.6.0 required')
-class STRTreeNearest(unittest.TestCase):
-    def test_nearest(self):
-        tree = STRtree([
-            Polygon([(1,0),(2,0),(2,1),(1,1)]),
-            Polygon([(0,2),(1,2),(1,3),(0,3)]),
-            Point(0,0.5)])
-        result = tree.nearest(Point(0,0))
-        self.assertEqual(result, Point(0,0.5))
-        result = tree.nearest(Point(0,4))
-        self.assertEqual(result, Polygon([(0,2),(1,2),(1,3),(0,3)]))
-        result = tree.nearest(Polygon([(-0.5,-0.5),(0.5,-0.5),(0.5,0.5),(-0.5,0.5)]))
-        self.assertEqual(result, Point(0,0.5))
+
+@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS 3.6.0 required")
+@pytest.mark.parametrize(
+    "geoms",
+    [
+        [
+            Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+            Polygon([(0, 2), (1, 2), (1, 3), (0, 3)]),
+            Point(0, 0.5),
+        ]
+    ],
+)
+@pytest.mark.parametrize("query_geom", [Point(0, 0.4)])
+def test_nearest_geom(geoms, query_geom):
+    tree = STRtree(geoms)
+    result = tree.nearest(query_geom)
+    assert result.geom_type == "Point"
+    assert result.x == 0.0
+    assert result.y == 0.5
+
+
+@pytest.mark.skipif(geos_version < (3, 6, 0), reason="GEOS 3.6.0 required")
+@pytest.mark.parametrize(
+    "geoms",
+    [
+        [
+            Point(0, 0.5),
+            Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+            Polygon([(0, 2), (1, 2), (1, 3), (0, 3)]),
+        ]
+    ],
+)
+@pytest.mark.parametrize("values", [["Ahoy!", "Hi!", "Hi!"]])
+@pytest.mark.parametrize("query_geom", [Point(0, 0.4)])
+def test_nearest_value(geoms, values, query_geom):
+    tree = STRtree(zip(geoms, values))
+    tree.nearest(query_geom) == "Ahoy!"

--- a/tests/unpickle-strtree.py
+++ b/tests/unpickle-strtree.py
@@ -10,12 +10,7 @@ from shapely.geos import geos_version
 
 
 if __name__ == "__main__":
-    try:
-        pickled_strtree = sys.stdin.buffer.read()
-    except AttributeError:
-        # Python 2.7
-        pickled_strtree = sys.stdin.read()
-
+    pickled_strtree = sys.stdin.buffer.read()
     print("received pickled strtree:", repr(pickled_strtree))
     strtree = pickle.loads(pickled_strtree)
     # Exercise API.


### PR DESCRIPTION
This STRtree can store almost anything and is backwards compatible with the one in 1.7. If initialized with a sequence of geometry objects, these are stored, and query and nearest return a list of geometries or a single geometry. If initialized with a sequence of `(value, geom)` pairs, the values are stored, and query and nearest return lists of these values or a single value. The values could be any Python object and don't need to be the same type.

In #1064 we have an STRtree that takes a sequence of geometry objects and stores their enumeration indices. Query returns a list of indices or a list of geometries (found by index from an internal list) depending on a flag.

The STRtree in #1064 and in this PR each have internal lists maintaining references to the initial data.

My understanding of the STRtree in #1064 is that it is designed to take a sequence of geometry objects (a DataSeries, yes?) from GeoPandas and store their enumeration indices. Syncronization of state between the enumeration indices in the tree and the DataFrame row indices would be required. The way GeoPandas would use the #1094 STRtree is to store DataFrame row indices directly. I believe this would make synchronization less fragile.