### PR TITLE
Fix failures in test_wkb on big-endian hosts (#1102)

### DIFF
--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -1,4 +1,6 @@
 import binascii
+import struct
+import sys
 
 import pytest
 
@@ -17,18 +19,47 @@ def hex2bin(value):
     return binascii.a2b_hex(value)
 
 
+def hostorder(fmt, value):
+    """Re-pack a hex WKB value to native endianness if needed
+
+    This routine does not understand WKB format, so it must be provided a
+    struct module format string, without initial indicator character ("@=<>!"),
+    which will be interpreted as big- or little-endian with standard sizes
+    depending on the endian flag in the first byte of the value.
+    """
+
+    if fmt and fmt[0] in "@=<>!":
+        raise ValueError("Initial indicator character, one of @=<>!, in fmt")
+    if not fmt or fmt[0] not in "cbB":
+        raise ValueError("Missing endian flag in fmt")
+
+    (hexendian,) = struct.unpack(fmt[0], hex2bin(value[:2]))
+    hexorder = {0: ">", 1: "<"}[hexendian]
+    sysorder = {"little": "<", "big": ">"}[sys.byteorder]
+    if hexorder == sysorder:
+        return value  # Nothing to do
+
+    return bin2hex(struct.pack(
+        sysorder + fmt,
+        {">": 0, "<": 1}[sysorder],
+        *struct.unpack(hexorder + fmt, hex2bin(value))[1:]))
+
+
 def test_dumps_srid():
     p1 = Point(1.2, 3.4)
     result = dumps(p1)
-    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIdd", "0101000000333333333333F33F3333333333330B40")
     result = dumps(p1, srid=4326)
-    assert bin2hex(result) == "0101000020E6100000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIIdd", "0101000020E6100000333333333333F33F3333333333330B40")
 
 
 def test_dumps_endianness():
     p1 = Point(1.2, 3.4)
     result = dumps(p1)
-    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIdd", "0101000000333333333333F33F3333333333330B40")
     result = dumps(p1, big_endian=False)
     assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
     result = dumps(p1, big_endian=True)
@@ -38,8 +69,9 @@ def test_dumps_endianness():
 def test_dumps_hex():
     p1 = Point(1.2, 3.4)
     result = dumps(p1, hex=True)
-    assert result == "0101000000333333333333F33F3333333333330B40"
-    
+    assert result == hostorder(
+        "BIdd", "0101000000333333333333F33F3333333333330B40")
+
 
 def test_loads_srid():
     # load a geometry which includes an srid
@@ -48,13 +80,16 @@ def test_loads_srid():
     assert geom.coords[:] == [(1.2, 3.4)]
     # by default srid is not exported
     result = dumps(geom)
-    assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIdd", "0101000000333333333333F33F3333333333330B40")
     # include the srid in the output
     result = dumps(geom, include_srid=True)
-    assert bin2hex(result) == "0101000020E6100000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIIdd", "0101000020E6100000333333333333F33F3333333333330B40")
     # replace geometry srid with another
     result = dumps(geom, srid=27700)
-    assert bin2hex(result) == "0101000020346C0000333333333333F33F3333333333330B40"
+    assert bin2hex(result) == hostorder(
+        "BIIdd", "0101000020346C0000333333333333F33F3333333333330B40")
 
 
 requires_geos_39 = pytest.mark.xfail(
@@ -64,11 +99,12 @@ requires_geos_39 = pytest.mark.xfail(
 @requires_geos_39
 def test_point_empty():
     g = wkt.loads("POINT EMPTY")
-    assert g.wkb_hex == "0101000000000000000000F87F000000000000F87F"
+    assert g.wkb_hex == hostorder(
+        "BIdd", "0101000000000000000000F87F000000000000F87F")
 
 
 @requires_geos_39
 def test_point_z_empty():
     g = wkt.loads("POINT Z EMPTY")
-    assert g.wkb_hex == \
-        "0101000080000000000000F87F000000000000F87F000000000000F87F"
+    assert g.wkb_hex == hostorder(
+        "BIddd", "0101000080000000000000F87F000000000000F87F000000000000F87F")


### PR DESCRIPTION
Fixes https://github.com/Toblerity/Shapely/issues/1102.

Adds a `hostorder()` function in the test module to re-pack expected outputs in host endianness.

An alternative solution would be to manually compute the corresponding big-endian vectors, and branch on `sys.byteorder` in each test to decide which one to compare against. There are probably other reasonable alternative solutions, too.

This fix is verified on s390x, a big-endian architecture.