### PR TITLE
Only load conda GEOS dll if it exists (on Windows)

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -156,9 +156,10 @@ elif sys.platform == 'darwin':
     free.restype = None
 
 elif sys.platform == 'win32':
-    if exists_conda_env():
+    _conda_dll_path = os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll')
+    if exists_conda_env() and os.path.exists(_conda_dll_path):
         # conda package.
-        _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
+        _lgeos = CDLL(_conda_dll_path)
     else:
         try:
             egg_dlls = os.path.abspath(


### PR DESCRIPTION
@sgillies I know you have said multiple times that you don't want to fix this .., but 1) it's a small change, 2) we basically do this for Linux/Mac as well (by first checking the wheel path) and 3) solves troubling import issues that can easily be avoided. 
So therefore I don't see much reason to *not* do this for Shapely 1.8 (it will still take a while until 2.0 is fully stabilized and released)

Related discussion in https://github.com/Toblerity/Shapely/pull/843#discussion_r386275247 (and also #1105, #924)