### PR TITLE
MAINT: use super() as described by PEP 3135

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -1032,7 +1032,7 @@ class HeterogeneousGeometrySequence(GeometrySequence):
     """
 
     def __init__(self, parent):
-        super(HeterogeneousGeometrySequence, self).__init__(parent, None)
+        super().__init__(parent, None)
 
     def _get_geom_item(self, i):
         sub = lgeos.GEOSGetGeometryN(self._geom, i)

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -40,7 +40,7 @@ class MultiLineString(BaseMultipartGeometry):
 
           >>> lines = MultiLineString( [[[0.0, 0.0], [1.0, 2.0]]] )
         """
-        super(MultiLineString, self).__init__()
+        super().__init__()
 
         if not lines:
             # allow creation of empty multilinestrings, to support unpickling

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -46,7 +46,7 @@ class MultiPoint(BaseMultipartGeometry):
           >>> type(ob.geoms[0]) == Point
           True
         """
-        super(MultiPoint, self).__init__()
+        super().__init__()
 
         if points is None or (not isinstance(points, MultiPoint) and len(points) == 0):
             # allow creation of empty multipoints, to support unpickling

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -51,7 +51,7 @@ class MultiPolygon(BaseMultipartGeometry):
           >>> type(ob.geoms[0]) == Polygon
           True
         """
-        super(MultiPolygon, self).__init__()
+        super().__init__()
 
         if not polygons:
             # allow creation of empty multipolygons, to support unpickling

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -84,7 +84,7 @@ class LinearRing(LineString):
     def __setstate__(self, state):
         """WKB doesn't differentiate between LineString and LinearRing so we
         need to move the coordinate sequence into the correct geometry type"""
-        super(LinearRing, self).__setstate__(state)
+        super().__setstate__(state)
         cs = lgeos.GEOSGeom_getCoordSeq(self.__geom__)
         cs_clone = lgeos.GEOSCoordSeq_clone(cs)
         lgeos.GEOSGeom_destroy(self.__geom__)

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -601,7 +601,7 @@ class LGEOS330(LGEOSBase):
     geos_capi_version = (1, 7, 0)
 
     def __init__(self, dll):
-        super(LGEOS330, self).__init__(dll)
+        super().__init__(dll)
         self.geos_handle = self._lgeos.initGEOS_r(notice_h, error_h)
         keys = list(self._lgeos.__dict__.keys())
         for key in [x for x in keys if not x.endswith('_r')]:
@@ -734,7 +734,7 @@ class LGEOS340(LGEOS330):
     geos_capi_version = (1, 8, 0)
 
     def __init__(self, dll):
-        super(LGEOS340, self).__init__(dll)
+        super().__init__(dll)
         self.methods['delaunay_triangulation'] = self.GEOSDelaunayTriangulation
         self.methods['nearest_points'] = self.GEOSNearestPoints
 
@@ -746,7 +746,7 @@ class LGEOS350(LGEOS340):
     geos_capi_version = (1, 9, 0)
 
     def __init__(self, dll):
-        super(LGEOS350, self).__init__(dll)
+        super().__init__(dll)
         self.methods['clip_by_rect'] = self.GEOSClipByRect
         self.methods['voronoi_diagram'] = self.GEOSVoronoiDiagram
 
@@ -758,7 +758,7 @@ class LGEOS360(LGEOS350):
     geos_capi_version = (1, 10, 0)
 
     def __init__(self, dll):
-        super(LGEOS360, self).__init__(dll)
+        super().__init__(dll)
         self.methods['minimum_clearance'] = self.GEOSMinimumClearance
 
 
@@ -769,7 +769,7 @@ class LGEOS380(LGEOS360):
     geos_capi_version = (1, 13, 0)
 
     def __init__(self, dll):
-        super(LGEOS380, self).__init__(dll)
+        super().__init__(dll)
         self.methods['make_valid'] = self.GEOSMakeValid
 
 

--- a/shapely/linref.py
+++ b/shapely/linref.py
@@ -6,7 +6,7 @@ from shapely.topology import Delegating
 
 class LinearRefBase(Delegating):
     def _validate_line(self, ob):
-        super(LinearRefBase, self)._validate(ob)
+        super()._validate(ob)
         if not ob.geom_type in ['LinearRing', 'LineString', 'MultiLineString']:
             raise TypeError("Only linear types support this operation")
 


### PR DESCRIPTION
This PR refactors `super()` to be simpler, as described by [PEP 3135](https://www.python.org/dev/peps/pep-3135/) and approved in 2007 for Python 3.0.

The "old" convention (e.g. `super(C, self)`) was only required to support Python 2.