### PR TITLE
[2.0] Remove len() (__len__) for multi-part geometries

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -16,7 +16,6 @@ import pygeos
 
 from shapely.affinity import affine_transform
 from shapely.coords import CoordinateSequence
-from shapely.errors import ShapelyDeprecationWarning
 
 log = logging.getLogger(__name__)
 
@@ -662,17 +661,6 @@ class BaseMultipartGeometry(BaseGeometry):
 
     def __bool__(self):
         return self.is_empty is False
-
-    def __len__(self):
-        warn(
-            "__len__ for multi-part geometries is deprecated and will be removed in "
-            "Shapely 2.0. Check the length of the `geoms` property instead to get the "
-            " number of parts of a multi-part geometry.",
-            ShapelyDeprecationWarning, stacklevel=2)
-        if not self.is_empty:
-            return len(self.geoms)
-        else:
-            return 0
 
     __hash__ = None
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -64,21 +64,7 @@ def test_geointerface(geometrycollection_geojson):
     assert geom.__geo_interface__ == geometrycollection_geojson
 
 
-@pytest.mark.parametrize('geom', [
-    GeometryCollection(),
-    shape({"type": "GeometryCollection", "geometries": []}),
-    shape({"type": "GeometryCollection", "geometries": [
-        {"type": "Point", "coordinates": ()},
-        {"type": "LineString", "coordinates": (())}
-    ]}),
-    wkt.loads('GEOMETRYCOLLECTION EMPTY'),
-])
-def test_len_empty_deprecated(geom):
-    with pytest.warns(ShapelyDeprecationWarning, match="__len__"):
-        assert len(geom) == 0
-
-
-def test_len_deprecated(geometrycollection_geojson):
+def test_len_raises(geometrycollection_geojson):
     geom = shape(geometrycollection_geojson)
-    with pytest.warns(ShapelyDeprecationWarning, match="__len__"):
-        assert len(geom) == 2
+    with pytest.raises(TypeError):
+        len(geom)

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -3,7 +3,7 @@ from .test_multi import MultiGeometryTestCase
 
 import pytest
 
-from shapely.errors import EmptyPartError, ShapelyDeprecationWarning
+from shapely.errors import EmptyPartError
 from shapely.geometry import Point, MultiPoint
 from shapely.geometry.base import dump_coords
 
@@ -75,7 +75,7 @@ def test_multipoint_array_coercion():
     assert arr.item() == geom
 
 
-def test_len_deprecated():
+def test_len_raises():
     geom = MultiPoint([[5.0, 6.0], [7.0, 8.0]])
-    with pytest.warns(ShapelyDeprecationWarning, match="__len__"):
-        assert len(geom) == 2
+    with pytest.raises(TypeError):
+        len(geom)


### PR DESCRIPTION
This deprecation in Shapely 1.8 was not yet removed in the shapely-2.0 branch