### PR TITLE
Add tests to WKT and WKB conversion to increase coverage

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -24,6 +24,7 @@ Shapely is written by:
 * David Swinkels <davidswinkelss@gmail.com>
 * Denis Rykov <rykovd@gmail.com>
 * Erwin Sterrenburg <e.w.sterrenburg@gmail.com>
+* Felix Divo <4403130+felixdivo@users.noreply.github.com>
 * Felix Yan <felixonmars@archlinux.org>
 * Filipe Fernandes <ocefpaf@gmail.com>
 * Frédéric Junod <frederic.junod@camptocamp.com>

--- a/shapely/errors.py
+++ b/shapely/errors.py
@@ -39,5 +39,6 @@ class ShapelyDeprecationWarning(FutureWarning):
     changed in a future release.
     """
 
+
 class EmptyPartError(ShapelyError):
     """An error signifying an empty part was encountered when creating a multi-part."""

--- a/shapely/wkb.py
+++ b/shapely/wkb.py
@@ -10,6 +10,11 @@ from shapely.geometry.base import geom_factory
 def loads(data, hex=False):
     """Load a geometry from a WKB byte string, or hex-encoded string if
     ``hex=True``.
+
+    Raises
+    ------
+    WKBReadingError, UnicodeDecodeError
+        If ``data`` contains an invalid geometry.
     """
     reader = WKBReader(lgeos)
     if hex:
@@ -19,7 +24,13 @@ def loads(data, hex=False):
 
 
 def load(fp, hex=False):
-    """Load a geometry from an open file."""
+    """Load a geometry from an open file.
+
+    Raises
+    ------
+    WKBReadingError, UnicodeDecodeError
+        If the given file contains an invalid geometry.
+    """
     data = fp.read()
     return loads(data, hex=hex)
 

--- a/shapely/wkb.py
+++ b/shapely/wkb.py
@@ -1,10 +1,11 @@
-"""Load/dump geometries using the well-known binary (WKB) format
+"""Load/dump geometries using the well-known binary (WKB) format.
+
+Also provides pickle-like convenience functions.
 """
 
 from shapely.geos import WKBReader, WKBWriter, lgeos
 from shapely.geometry.base import geom_factory
 
-# Pickle-like convenience functions
 
 def loads(data, hex=False):
     """Load a geometry from a WKB byte string, or hex-encoded string if
@@ -16,10 +17,12 @@ def loads(data, hex=False):
     else:
         return reader.read(data)
 
+
 def load(fp, hex=False):
     """Load a geometry from an open file."""
     data = fp.read()
     return loads(data, hex=hex)
+
 
 def dumps(ob, hex=False, srid=None, **kw):
     """Dump a WKB representation of a geometry to a byte string, or a
@@ -30,13 +33,14 @@ def dumps(ob, hex=False, srid=None, **kw):
     ob : geometry
         The geometry to export to well-known binary (WKB) representation
     hex : bool
-        If true, export the WKB as a hexidecimal string. The default is to
+        If true, export the WKB as a hexadecimal string. The default is to
         return a binary string/bytes object.
     srid : int
         Spatial reference system ID to include in the output. The default value
         means no SRID is included.
     **kw : kwargs
-        See available keyword output settings in ``shapely.geos.WKBWriter``."""
+        See available keyword output settings in ``shapely.geos.WKBWriter``.
+    """
     if srid is not None:
         # clone the object and set the SRID before dumping
         geom = lgeos.GEOSGeom_clone(ob._geom)

--- a/shapely/wkt.py
+++ b/shapely/wkt.py
@@ -1,9 +1,9 @@
 """Load/dump geometries using the well-known text (WKT) format
+
+Also provides pickle-like convenience functions.
 """
 
 from shapely import geos
-
-# Pickle-like convenience functions
 
 
 def loads(data):

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -97,7 +97,7 @@ def test_loads_srid():
 
 
 def test_loads_hex(some_point):
-    assert loads(dumps(some_point, hex=True), hex=True), some_point
+    assert loads(dumps(some_point, hex=True), hex=True) == some_point
 
 
 def test_dump_load_binary(some_point):

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -1,14 +1,21 @@
 import binascii
 import struct
 import sys
+from tempfile import TemporaryDirectory
+from os.path import join
 
 import pytest
 
 from shapely import wkt
-from shapely.wkb import dumps, loads
+from shapely.errors import WKBReadingError
 from shapely.geometry import Point
 from shapely.geos import geos_version
+from shapely.wkb import dumps, loads, dump, load
 
+
+@pytest.fixture(scope="module")
+def some_point():
+    return Point(1.2, 3.4)
 
 
 def bin2hex(value):
@@ -45,30 +52,27 @@ def hostorder(fmt, value):
         *struct.unpack(hexorder + fmt, hex2bin(value))[1:]))
 
 
-def test_dumps_srid():
-    p1 = Point(1.2, 3.4)
-    result = dumps(p1)
+def test_dumps_srid(some_point):
+    result = dumps(some_point)
     assert bin2hex(result) == hostorder(
         "BIdd", "0101000000333333333333F33F3333333333330B40")
-    result = dumps(p1, srid=4326)
+    result = dumps(some_point, srid=4326)
     assert bin2hex(result) == hostorder(
         "BIIdd", "0101000020E6100000333333333333F33F3333333333330B40")
 
 
-def test_dumps_endianness():
-    p1 = Point(1.2, 3.4)
-    result = dumps(p1)
+def test_dumps_endianness(some_point):
+    result = dumps(some_point)
     assert bin2hex(result) == hostorder(
         "BIdd", "0101000000333333333333F33F3333333333330B40")
-    result = dumps(p1, big_endian=False)
+    result = dumps(some_point, big_endian=False)
     assert bin2hex(result) == "0101000000333333333333F33F3333333333330B40"
-    result = dumps(p1, big_endian=True)
+    result = dumps(some_point, big_endian=True)
     assert bin2hex(result) == "00000000013FF3333333333333400B333333333333"
 
 
-def test_dumps_hex():
-    p1 = Point(1.2, 3.4)
-    result = dumps(p1, hex=True)
+def test_dumps_hex(some_point):
+    result = dumps(some_point, hex=True)
     assert result == hostorder(
         "BIdd", "0101000000333333333333F33F3333333333330B40")
 
@@ -90,6 +94,64 @@ def test_loads_srid():
     result = dumps(geom, srid=27700)
     assert bin2hex(result) == hostorder(
         "BIIdd", "0101000020346C0000333333333333F33F3333333333330B40")
+
+
+def test_loads_hex(some_point):
+    assert loads(dumps(some_point, hex=True), hex=True), some_point
+
+
+def test_dump_load_binary(some_point):
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkb")
+        with open(file, "wb") as file_pointer:
+            dump(some_point, file_pointer)
+        with open(file, "rb") as file_pointer:
+            restored = load(file_pointer)
+
+    assert some_point == restored
+
+
+def test_dump_load_hex(some_point):
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkb")
+        with open(file, "w") as file_pointer:
+            dump(some_point, file_pointer, hex=True)
+        with open(file, "r") as file_pointer:
+            restored = load(file_pointer, hex=True)
+
+    assert some_point == restored
+
+
+def test_dump_hex_load_binary(some_point):
+    """Asserts that reading a binary file as text (hex mode) fails."""
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkb")
+        with open(file, "w") as file_pointer:
+            dump(some_point, file_pointer, hex=True)
+
+        try:
+            with open(file, "rb") as file_pointer:
+                load(file_pointer)
+        except WKBReadingError:
+            pass
+        else:
+            raise AssertionError("Reading a text file as binary should fail")
+
+
+def test_dump_binary_load_hex(some_point):
+    """Asserts that reading a text file (hex mode) as binary fails."""
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkb")
+        with open(file, "wb") as file_pointer:
+            dump(some_point, file_pointer)
+
+        try:
+            with open(file, "r") as file_pointer:
+                load(file_pointer, hex=True)
+        except (WKBReadingError, UnicodeDecodeError):
+            pass
+        else:
+            raise AssertionError("Reading a text file as binary should fail")
 
 
 requires_geos_39 = pytest.mark.xfail(

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -1,8 +1,6 @@
 import binascii
 import struct
 import sys
-from tempfile import TemporaryDirectory
-from os.path import join
 
 import pytest
 
@@ -100,54 +98,46 @@ def test_loads_hex(some_point):
     assert loads(dumps(some_point, hex=True), hex=True) == some_point
 
 
-def test_dump_load_binary(some_point):
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkb")
-        with open(file, "wb") as file_pointer:
-            dump(some_point, file_pointer)
-        with open(file, "rb") as file_pointer:
-            restored = load(file_pointer)
+def test_dump_load_binary(some_point, tmpdir):
+    file = tmpdir.join("test.wkb")
+    with open(file, "wb") as file_pointer:
+        dump(some_point, file_pointer)
+    with open(file, "rb") as file_pointer:
+        restored = load(file_pointer)
 
     assert some_point == restored
 
 
-def test_dump_load_hex(some_point):
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkb")
-        with open(file, "w") as file_pointer:
-            dump(some_point, file_pointer, hex=True)
-        with open(file, "r") as file_pointer:
-            restored = load(file_pointer, hex=True)
+def test_dump_load_hex(some_point, tmpdir):
+    file = tmpdir.join("test.wkb")
+    with open(file, "w") as file_pointer:
+        dump(some_point, file_pointer, hex=True)
+    with open(file, "r") as file_pointer:
+        restored = load(file_pointer, hex=True)
 
     assert some_point == restored
 
 
-def test_dump_hex_load_binary(some_point):
+def test_dump_hex_load_binary(some_point, tmpdir):
     """Asserts that reading a binary file as text (hex mode) fails."""
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkb")
-        with open(file, "w") as file_pointer:
-            dump(some_point, file_pointer, hex=True)
+    file = tmpdir.join("test.wkb")
+    with open(file, "w") as file_pointer:
+        dump(some_point, file_pointer, hex=True)
 
-        with pytest.raises(WKBReadingError):
-            with open(file, "rb") as file_pointer:
-                load(file_pointer)
+    with pytest.raises(WKBReadingError):
+        with open(file, "rb") as file_pointer:
+            load(file_pointer)
 
 
-def test_dump_binary_load_hex(some_point):
+def test_dump_binary_load_hex(some_point, tmpdir):
     """Asserts that reading a text file (hex mode) as binary fails."""
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkb")
-        with open(file, "wb") as file_pointer:
-            dump(some_point, file_pointer)
+    file = tmpdir.join("test.wkb")
+    with open(file, "wb") as file_pointer:
+        dump(some_point, file_pointer)
 
-        try:
-            with open(file, "r") as file_pointer:
-                load(file_pointer, hex=True)
-        except (WKBReadingError, UnicodeEncodeError, UnicodeDecodeError):
-            pass
-        else:
-            raise AssertionError("Reading a text file as binary should fail")
+    with pytest.raises((WKBReadingError, UnicodeEncodeError, UnicodeDecodeError)):
+        with open(file, "r") as file_pointer:
+            load(file_pointer, hex=True)
 
 
 requires_geos_39 = pytest.mark.xfail(

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -148,7 +148,7 @@ def test_dump_binary_load_hex(some_point):
         try:
             with open(file, "r") as file_pointer:
                 load(file_pointer, hex=True)
-        except (WKBReadingError, UnicodeDecodeError):
+        except (WKBReadingError, UnicodeEncodeError, UnicodeDecodeError):
             pass
         else:
             raise AssertionError("Reading a text file as binary should fail")

--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -129,13 +129,9 @@ def test_dump_hex_load_binary(some_point):
         with open(file, "w") as file_pointer:
             dump(some_point, file_pointer, hex=True)
 
-        try:
+        with pytest.raises(WKBReadingError):
             with open(file, "rb") as file_pointer:
                 load(file_pointer)
-        except WKBReadingError:
-            pass
-        else:
-            raise AssertionError("Reading a text file as binary should fail")
 
 
 def test_dump_binary_load_hex(some_point):

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -21,8 +21,8 @@ def test_wkt(some_point):
     assert some_point.wkt == "POINT ({0:.15f} {1:.15f})".format(pi, -pi)
 
 
-def test_wkt_null(null_geometry):
-    assert null_geometry.wkt == "GEOMETRYCOLLECTION EMPTY"
+def test_wkt_null(empty_geometry):
+    assert empty_geometry.wkt == "GEOMETRYCOLLECTION EMPTY"
 
 
 def test_dump_load(some_point, tmpdir):
@@ -35,15 +35,15 @@ def test_dump_load(some_point, tmpdir):
     assert some_point == restored
 
 
-def test_dump_load_null_geometry(null_geometry, tmpdir):
+def test_dump_load_null_geometry(empty_geometry, tmpdir):
     file = tmpdir.join("test.wkt")
     with open(file, "w") as file_pointer:
-        dump(null_geometry, file_pointer)
+        dump(empty_geometry, file_pointer)
     with open(file, "r") as file_pointer:
         restored = load(file_pointer)
 
     # This is does not work with __eq__():
-    assert null_geometry.equals(restored)
+    assert empty_geometry.equals(restored)
 
 
 def test_dumps_loads(some_point):
@@ -51,10 +51,10 @@ def test_dumps_loads(some_point):
     assert loads(dumps(some_point)) == some_point
 
 
-def test_dumps_loads_null_geometry(null_geometry):
-    assert dumps(null_geometry) == "GEOMETRYCOLLECTION EMPTY"
+def test_dumps_loads_null_geometry(empty_geometry):
+    assert dumps(empty_geometry) == "GEOMETRYCOLLECTION EMPTY"
     # This is does not work with __eq__():
-    assert loads(dumps(null_geometry)).equals(null_geometry)
+    assert loads(dumps(empty_geometry)).equals(empty_geometry)
 
 
 def test_dumps_precision(some_point):

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -1,6 +1,4 @@
 from math import pi
-from tempfile import TemporaryDirectory
-from os.path import join
 
 import pytest
 
@@ -10,7 +8,7 @@ from shapely.wkt import dumps, dump, load, loads
 
 @pytest.fixture(scope="module")
 def some_point():
-    return Point((pi, -pi))
+    return Point(pi, -pi)
 
 
 @pytest.fixture(scope="module")
@@ -27,24 +25,22 @@ def test_wkt_null(null_geometry):
     assert null_geometry.wkt == "GEOMETRYCOLLECTION EMPTY"
 
 
-def test_dump_load(some_point):
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkt")
-        with open(file, "w") as file_pointer:
-            dump(some_point, file_pointer)
-        with open(file, "r") as file_pointer:
-            restored = load(file_pointer)
+def test_dump_load(some_point, tmpdir):
+    file = tmpdir.join("test.wkt")
+    with open(file, "w") as file_pointer:
+        dump(some_point, file_pointer)
+    with open(file, "r") as file_pointer:
+        restored = load(file_pointer)
 
     assert some_point == restored
 
 
-def test_dump_load_null_geometry(null_geometry):
-    with TemporaryDirectory() as directory_path:
-        file = join(directory_path, "test.wkt")
-        with open(file, "w") as file_pointer:
-            dump(null_geometry, file_pointer)
-        with open(file, "r") as file_pointer:
-            restored = load(file_pointer)
+def test_dump_load_null_geometry(null_geometry, tmpdir):
+    file = tmpdir.join("test.wkt")
+    with open(file, "w") as file_pointer:
+        dump(null_geometry, file_pointer)
+    with open(file, "r") as file_pointer:
+        restored = load(file_pointer)
 
     # This is does not work with __eq__():
     assert null_geometry.equals(restored)

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -1,9 +1,11 @@
 from math import pi
+from tempfile import TemporaryDirectory
+from os.path import join
 
 import pytest
 
-from shapely.geometry import LineString, Point
-from shapely.wkt import dumps
+from shapely.geometry import Point
+from shapely.wkt import dumps, dump, load, loads
 
 
 @pytest.fixture(scope="module")
@@ -16,7 +18,12 @@ def pipi4():
     return Point((pi*4, -pi*4))
 
 
-def test_wkt(pipi):
+@pytest.fixture(scope="module")
+def null_geometry():
+    return Point()
+
+
+def test_wkt_simple(pipi):
     """.wkt and wkt.dumps() both do not trim by default."""
     assert pipi.wkt == "POINT ({0:.15f} {1:.15f})".format(pi, -pi)
 
@@ -26,8 +33,42 @@ def test_wkt(pipi4):
     assert pipi4.wkt == "POINT ({0:.14f} {1:.14f})".format(pi*4, -pi*4)
 
 
-def test_dumps(pipi4):
+def test_wkt_null(null_geometry):
+    assert null_geometry.wkt == "GEOMETRYCOLLECTION EMPTY"
+
+
+def test_dump_load(pipi4):
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkt")
+        with open(file, "w") as file_pointer:
+            dump(pipi4, file_pointer)
+        with open(file, "r") as file_pointer:
+            restored = load(file_pointer)
+
+    assert pipi4 == restored
+
+
+def test_dump_load_null_geometry(null_geometry):
+    with TemporaryDirectory() as directory_path:
+        file = join(directory_path, "test.wkt")
+        with open(file, "w") as file_pointer:
+            dump(null_geometry, file_pointer)
+        with open(file, "r") as file_pointer:
+            restored = load(file_pointer)
+
+    # This is does not work with __eq__():
+    assert null_geometry.equals(restored)
+
+
+def test_dumps_loads(pipi4):
     assert dumps(pipi4) == "POINT ({0:.16f} {1:.16f})".format(pi*4, -pi*4)
+    assert loads(dumps(pipi4)) == pipi4
+
+
+def test_dumps_loads_null_geometry(null_geometry):
+    assert dumps(null_geometry) == "GEOMETRYCOLLECTION EMPTY"
+    # This is does not work with __eq__():
+    assert loads(dumps(null_geometry)).equals(null_geometry)
 
 
 def test_dumps_precision(pipi4):

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -9,13 +9,8 @@ from shapely.wkt import dumps, dump, load, loads
 
 
 @pytest.fixture(scope="module")
-def pipi():
+def some_point():
     return Point((pi, -pi))
-
-
-@pytest.fixture(scope="module")
-def pipi4():
-    return Point((pi*4, -pi*4))
 
 
 @pytest.fixture(scope="module")
@@ -23,29 +18,24 @@ def null_geometry():
     return Point()
 
 
-def test_wkt_simple(pipi):
+def test_wkt(some_point):
     """.wkt and wkt.dumps() both do not trim by default."""
-    assert pipi.wkt == "POINT ({0:.15f} {1:.15f})".format(pi, -pi)
-
-
-def test_wkt(pipi4):
-    """.wkt and wkt.dumps() both do not trim by default."""
-    assert pipi4.wkt == "POINT ({0:.14f} {1:.14f})".format(pi*4, -pi*4)
+    assert some_point.wkt == "POINT ({0:.15f} {1:.15f})".format(pi, -pi)
 
 
 def test_wkt_null(null_geometry):
     assert null_geometry.wkt == "GEOMETRYCOLLECTION EMPTY"
 
 
-def test_dump_load(pipi4):
+def test_dump_load(some_point):
     with TemporaryDirectory() as directory_path:
         file = join(directory_path, "test.wkt")
         with open(file, "w") as file_pointer:
-            dump(pipi4, file_pointer)
+            dump(some_point, file_pointer)
         with open(file, "r") as file_pointer:
             restored = load(file_pointer)
 
-    assert pipi4 == restored
+    assert some_point == restored
 
 
 def test_dump_load_null_geometry(null_geometry):
@@ -60,9 +50,9 @@ def test_dump_load_null_geometry(null_geometry):
     assert null_geometry.equals(restored)
 
 
-def test_dumps_loads(pipi4):
-    assert dumps(pipi4) == "POINT ({0:.16f} {1:.16f})".format(pi*4, -pi*4)
-    assert loads(dumps(pipi4)) == pipi4
+def test_dumps_loads(some_point):
+    assert dumps(some_point) == "POINT ({0:.16f} {1:.16f})".format(pi, -pi)
+    assert loads(dumps(some_point)) == some_point
 
 
 def test_dumps_loads_null_geometry(null_geometry):
@@ -71,5 +61,6 @@ def test_dumps_loads_null_geometry(null_geometry):
     assert loads(dumps(null_geometry)).equals(null_geometry)
 
 
-def test_dumps_precision(pipi4):
-    assert dumps(pipi4, rounding_precision=4) == "POINT ({0:.4f} {1:.4f})".format(pi*4, -pi*4)
+def test_dumps_precision(some_point):
+    assert dumps(some_point, rounding_precision=4) == \
+           "POINT ({0:.4f} {1:.4f})".format(pi, -pi)


### PR DESCRIPTION
Adds more meaningful tests for `shapely.wkt` and `shapely.wkb`. They are now covered completely.