### PR TITLE
Python3 classes does not need to inherit from object

### DIFF
--- a/_vendor/packaging/_structures.py
+++ b/_vendor/packaging/_structures.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-class Infinity(object):
+class Infinity:
 
     def __repr__(self):
         return "Infinity"
@@ -36,7 +36,7 @@ class Infinity(object):
 Infinity = Infinity()
 
 
-class NegativeInfinity(object):
+class NegativeInfinity:
 
     def __repr__(self):
         return "-Infinity"

--- a/_vendor/packaging/markers.py
+++ b/_vendor/packaging/markers.py
@@ -40,7 +40,7 @@ class UndefinedEnvironmentName(ValueError):
     """
 
 
-class Node(object):
+class Node:
 
     def __init__(self, value):
         self.value = value
@@ -254,7 +254,7 @@ def default_environment():
     }
 
 
-class Marker(object):
+class Marker:
 
     def __init__(self, marker):
         try:

--- a/_vendor/packaging/requirements.py
+++ b/_vendor/packaging/requirements.py
@@ -72,7 +72,7 @@ NAMED_REQUIREMENT = \
 REQUIREMENT = stringStart + NAMED_REQUIREMENT + stringEnd
 
 
-class Requirement(object):
+class Requirement:
     """Parse a requirement.
 
     Parse a given requirement string into its parts, such as name, specifier,

--- a/_vendor/packaging/version.py
+++ b/_vendor/packaging/version.py
@@ -39,7 +39,7 @@ class InvalidVersion(ValueError):
     """
 
 
-class _BaseVersion(object):
+class _BaseVersion:
 
     def __hash__(self):
         return hash(self._key)

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1290,7 +1290,7 @@ Shapely's binary :meth:`within` predicate.
 
 .. code-block:: python
 
-  class Within(object):
+  class Within:
       def __init__(self, o):
           self.o = o
       def __lt__(self, other):
@@ -2857,7 +2857,7 @@ Or a simple placemark-type object:
 
 .. code-block:: pycon
 
-  >>> class GeoThing(object):
+  >>> class GeoThing:
   ...     def __init__(self, d):
   ...         self.__geo_interface__ = d
   >>> thing = GeoThing({"type": "Point", "coordinates": (0.0, 0.0)})

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if 'all' in sys.warnoptions:
     log.level = logging.DEBUG
 
 
-class GEOSConfig(object):
+class GEOSConfig:
     """Interface to config options from the `geos-config` utility
     """
 

--- a/shapely/algorithms/polylabel.py
+++ b/shapely/algorithms/polylabel.py
@@ -3,7 +3,7 @@ from ..geos import TopologicalError
 from heapq import heappush, heappop
 
 
-class Cell(object):
+class Cell:
     """A `Cell`'s centroid property is a potential solution to finding the pole
     of inaccessibility for a given polygon. Rich comparison operators are used
     for sorting `Cell` objects in a priority queue based on the potential

--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -11,7 +11,7 @@ from shapely.geos import lgeos
 from shapely.topology import Validating
 
 
-class CoordinateSequence(object):
+class CoordinateSequence:
     """
     Iterative access to coordinate tuples from the parent geometry's coordinate
     sequence.

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -128,13 +128,13 @@ def exceptNull(func):
     return wrapper
 
 
-class CAP_STYLE(object):
+class CAP_STYLE:
     round = 1
     flat = 2
     square = 3
 
 
-class JOIN_STYLE(object):
+class JOIN_STYLE:
     round = 1
     mitre = 2
     bevel = 3
@@ -142,7 +142,7 @@ class JOIN_STYLE(object):
 EMPTY = deserialize_wkb(a2b_hex(b'010700000000000000'))
 
 
-class BaseGeometry(object):
+class BaseGeometry:
     """
     Provides GEOS spatial predicates and topological operations.
 
@@ -949,7 +949,7 @@ class BaseMultipartGeometry(BaseGeometry):
             '</g>'
 
 
-class GeometrySequence(object):
+class GeometrySequence:
     """
     Iterative access to members of a homogeneous multipart geometry.
     """

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -131,7 +131,7 @@ def asLinearRing(context):
     return LinearRingAdapter(context)
 
 
-class InteriorRingSequence(object):
+class InteriorRingSequence:
 
     _factory = None
     _geom = None

--- a/shapely/geometry/proxy.py
+++ b/shapely/geometry/proxy.py
@@ -5,7 +5,7 @@ from shapely.geometry.base import EMPTY
 from shapely.geos import lgeos
 
 
-class CachingGeometryProxy(object):
+class CachingGeometryProxy:
 
     context = None
     factory = None

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -269,7 +269,7 @@ error_h = EXCEPTION_HANDLER_FUNCTYPE(error_handler)
 notice_h = EXCEPTION_HANDLER_FUNCTYPE(notice_handler)
 
 
-class WKTReader(object):
+class WKTReader:
 
     _lgeos = None
     _reader = None
@@ -302,7 +302,7 @@ class WKTReader(object):
         return geom_factory(geom)
 
 
-class WKTWriter(object):
+class WKTWriter:
 
     _lgeos = None
     _writer = None
@@ -402,7 +402,7 @@ class WKTWriter(object):
         return text.decode('ascii')
 
 
-class WKBReader(object):
+class WKBReader:
 
     _lgeos = None
     _reader = None
@@ -445,7 +445,7 @@ class WKBReader(object):
         return geometry.base.geom_factory(geom)
 
 
-class WKBWriter(object):
+class WKBWriter:
 
     _lgeos = None
     _writer = None

--- a/shapely/impl.py
+++ b/shapely/impl.py
@@ -44,7 +44,7 @@ def delegated(func):
 # Map geometry methods to their GEOS delegates
 
 
-class BaseImpl(object):
+class BaseImpl:
     """Base class for registrable implementations."""
 
     def __init__(self, values):

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -20,7 +20,7 @@ __all__ = ['cascaded_union', 'linemerge', 'operator', 'polygonize',
            'shared_paths', 'clip_by_rect', 'orient', 'substring']
 
 
-class CollectionOperator(object):
+class CollectionOperator:
 
     def shapeup(self, ob):
         if isinstance(ob, BaseGeometry):
@@ -245,7 +245,7 @@ def voronoi_diagram(geom, envelope=None, tolerance=0.0, edges=False):
     return result
 
 
-class ValidateOp(object):
+class ValidateOp:
     def __call__(self, this):
         return lgeos.GEOSisValidReason(this._geom)
 
@@ -397,7 +397,7 @@ def shared_paths(g1, g2):
     return(geom_factory(lgeos.methods['shared_paths'](g1._geom, g2._geom)))
 
 
-class SplitOp(object):
+class SplitOp:
 
     @staticmethod
     def _split_polygon_with_line(poly, splitter):

--- a/shapely/prepared.py
+++ b/shapely/prepared.py
@@ -7,7 +7,7 @@ from shapely.impl import DefaultImplementation, delegated
 from pickle import PicklingError
 
 
-class PreparedGeometry(object):
+class PreparedGeometry:
     """
     A geometry prepared for efficient comparison to a set of other geometries.
 

--- a/shapely/topology.py
+++ b/shapely/topology.py
@@ -11,7 +11,7 @@ from ctypes import byref, c_double
 from shapely.geos import TopologicalError, lgeos
 
 
-class Validating(object):
+class Validating:
 
     def _validate(self, ob, stop_prepared=False):
         if ob is None or ob._geom is None:

--- a/tests/test_delegated.py
+++ b/tests/test_delegated.py
@@ -4,7 +4,7 @@ from shapely.impl import BaseImpl
 from shapely.geometry.base import delegated
 
 
-class Geometry(object):
+class Geometry:
 
     impl = BaseImpl({})
 

--- a/tests/test_geointerface.py
+++ b/tests/test_geointerface.py
@@ -11,7 +11,7 @@ from shapely.geometry.multipolygon import MultiPolygon, MultiPolygonAdapter
 from shapely import wkt
 
 
-class GeoThing(object):
+class GeoThing:
     def __init__(self, d):
         self.__geo_interface__ = d
 


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3 (and the docs don't use that style [here](https://docs.python.org/3/tutorial/classes.html) or [here](https://docs.python.org/3/howto/descriptor.html)). This PR keeps the base classes a bit tidier and quicker to identify.

Edits were automated using:

    git ls-files -z | xargs -0 sed -i -re 's/class (.*)\(object\):/class \1:/g'

Matching files in `docs/sphinxext/*py` were ignored, as these appear to be Python2!