### PR TITLE
DOC: update README to indicate Python 2.7 is not longer supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ See the manual for more examples and guidance.
 Requirements
 ============
 
-Shapely 1.7 requires
+Shapely 1.8 requires
 
 * Python >=3.5
 * GEOS >=3.3

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Requirements
 
 Shapely 1.7 requires
 
-* Python 2.7, >=3.5
+* Python >=3.5
 * GEOS >=3.3
 
 Installing Shapely


### PR DESCRIPTION
We dropped Python 2.7 support for Shapely 1.8