### PR TITLE
TST: make the WKB test robust for flavour of NaN

### DIFF
--- a/tests/test_wkb.py
+++ b/tests/test_wkb.py
@@ -99,8 +99,9 @@ requires_geos_380 = pytest.mark.xfail(
 @requires_geos_380
 def test_point_empty():
     g = wkt.loads("POINT EMPTY")
-    assert g.wkb_hex == hostorder(
-        "BIdd", "0101000000000000000000F87F000000000000F87F")
+    NAN = struct.pack("<d", float("nan")).hex()
+    POINT_EMPTY_WKB = "0101000000" + (NAN * 2)
+    assert g.wkb_hex == hostorder("BIdd", POINT_EMPTY_WKB)
 
 
 @pytest.mark.xfail(reason="Fails with latest pygeos")


### PR DESCRIPTION
This `test_wkb.py::test_point_empty` test is failing on the shapely-2.0 branch with the latest pygeos. I *think* this is because pygeos is using `Py_NAN` to write the WKB with NaN values for empty geometries, and `Py_NAN` might be platform-dependent (the error on appveyor indicates the WKB includes a negative quiet NaN (`-float(NaN)`) instead of a plain quiet NaN, by checking on my linux laptop). 

So this PR tries to make the test more robust, by using the default NaN representation from the system on which the test is running (which *should* match with the NaN value that pygeos is using, I think).