### PR TITLE
Fix linux path to wheel for libgeos

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -65,7 +65,11 @@ if sys.platform.startswith('linux'):
     # Test to see if we have a wheel repaired by auditwheel which contains its
     # own libgeos_c. Note: auditwheel 3.1 changed the location of libs.
     geos_whl_so = glob.glob(
-        os.path.abspath(os.path.join(os.path.dirname(__file__), ".libs/libgeos*.so*"))
+        os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), ".libs", "libgeos*.so*"
+            )
+        )
     ) or glob.glob(
         os.path.abspath(
             os.path.join(
@@ -73,14 +77,16 @@ if sys.platform.startswith('linux'):
             )
         )
     )
+    geos_whl_so = sorted(geos_whl_so)
+    LOG.debug("globs found libgeos wheels: %s", geos_whl_so)
 
     if len(geos_whl_so) > 0:
         # We have observed problems with CDLL of libgeos_c not automatically
         # loading the sibling c++ library since the change made by auditwheel
         # 3.1, so we explicitly load them both.
-        geos_whl_so = sorted(geos_whl_so)
         CDLL(geos_whl_so[0])
-        _lgeos = CDLL(geos_whl_so[-1])
+        libgeos_whl_so = [so for so in geos_whl_so if "libgeos_c" in so]
+        _lgeos = CDLL(libgeos_whl_so[0])
         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
 
     elif hasattr(sys, 'frozen'):


### PR DESCRIPTION
On linux, the binary wheel bundled with shapely is not found correctly.  This PR aims to fix it.

```
$ ls -alh /opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/
total 2.5M
drwxrwxr-x 2 joe joe 4.0K Apr 21 13:19 .
drwxrwxr-x 9 joe joe 4.0K Apr 21 13:19 ..
-rwxrwxr-x 1 joe joe 346K Apr 21 13:19 libgeos_c-a68605fd.so.1.13.1
-rwxrwxr-x 1 joe joe 2.2M Apr 21 13:19 libgeos--no-undefined-b94097bf.so


$ ldd /opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos_c-a68605fd.so.1.13.1 
	linux-vdso.so.1 (0x00007ffc06125000)
	libgeos--no-undefined-b94097bf.so => /opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/./libgeos--no-undefined-b94097bf.so (0x00007fab621c9000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fab61e40000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fab61aa2000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fab616b1000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fab61499000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fab62843000)

```

On Python 3.7.10 
```python
>>> import shapely.geos
>>> shapely.geos.__file__
'/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/geos.py'
>>> import glob, os

# this glob pattern finds 2 files:

>>> glob.glob(os.path.abspath(os.path.join(os.path.dirname(shapely.geos.__file__),  ".libs", "libgeos*.so*")))
['/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos--no-undefined-b94097bf.so', '/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos_c-a68605fd.so.1.13.1']

# this glob pattern finds only a libgeos_c file:

>>> glob.glob(os.path.abspath(os.path.join(os.path.dirname(shapely.geos.__file__),  ".libs", "libgeos_c-*.so.*")))
['/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos_c-a68605fd.so.1.13.1']

# the linux code sorts the 'so' files and chooses the last one, might be better to explicitly select a libgeos_c file:

>>> geos_whl_so = glob.glob(os.path.abspath(os.path.join(os.path.dirname(shapely.geos.__file__), ".libs", "libgeos*.so*")))
>>> sorted(geos_whl_so)
['/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos--no-undefined-b94097bf.so', '/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos_c-a68605fd.so.1.13.1']

# curious note: the linux file system sort order (above) is different from the python sort order

>>> geos_whl_so = sorted(geos_whl_so)
>>> libgeos_whl_so = [so for so in geos_whl_so if "libgeos_c" in so]
>>> libgeos_whl_so[0]
'/opt/conda/envs/gis/lib/python3.7/site-packages/shapely/.libs/libgeos_c-a68605fd.so.1.13.1'
```

#### Aside: geopandas vs. shapely GEOS version

https://github.com/geopandas/geopandas/issues/1912
