### PR TITLE
TST: fix GEOS 3.10.0dev by simplifying a normalized geometry

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -29,8 +29,8 @@ class OperationsTestCase(unittest.TestCase):
         self.assertIsInstance(point.buffer(10.0, 32), Polygon)
 
         # Simplify
-        p = loads('POLYGON ((120 120, 121 121, 122 122, 220 120, 180 199, '
-                  '160 200, 140 199, 120 120))')
+        p = loads('POLYGON ((120 120, 140 199, 160 200, 180 199, 220 120, '
+                  '122 122, 121 121, 120 120))')
         expected = loads('POLYGON ((120 120, 140 199, 160 200, 180 199, '
                          '220 120, 120 120))')
         s = p.simplify(10.0, preserve_topology=False)


### PR DESCRIPTION
The input geometry is re-ordered to have a clockwise exterior linearring i.e. is normalized.

An alternative patch is to add `.normalized()` to the result(s) of `simplify(...)`:
```diff
diff --git a/tests/test_operations.py b/tests/test_operations.py
index 23dfd08..b1d9d18 100644
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -34,5 +34,5 @@ class OperationsTestCase(unittest.TestCase):
         expected = loads('POLYGON ((120 120, 140 199, 160 200, 180 199, '
                          '220 120, 120 120))')
-        s = p.simplify(10.0, preserve_topology=False)
+        s = p.simplify(10.0, preserve_topology=False).normalize()
         self.assertTrue(s.equals_exact(expected, 0.001))
```

Closes #1113