### PR TITLE
MAINT: aliases of builtin types is deprecated with numpy>=1.20

### DIFF
--- a/shapely/vectorized/_vectorized.pyx
+++ b/shapely/vectorized/_vectorized.pyx
@@ -121,4 +121,4 @@ cdef _predicated_1d(geometry, np.double_t[:] x, np.double_t[:] y, predicate fn):
             result[idx] = <np.uint8_t> fn(geos_h, geos_geom, p)
             GEOSGeom_destroy_r(geos_h, p)
 
-    return result.view(dtype=np.bool)
+    return result.view(dtype=bool)

--- a/tests/test_vectorized.py
+++ b/tests/test_vectorized.py
@@ -18,7 +18,7 @@ class VectorizedContainsTestCase(unittest.TestCase):
         y = np.asanyarray(y) 
 
         self.assertIsInstance(result, np.ndarray)
-        self.assertEqual(result.dtype, np.bool)
+        self.assertEqual(result.dtype, bool)
 
         result_flat = result.flat
         x_flat, y_flat = x.flat, y.flat


### PR DESCRIPTION
With [numpy 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated), aliases of builtin types like `np.bool` is deprecated. This should clear up some warnings in the test suite.