### PR TITLE
ENH: Added opacity option to polygon, point, linestring and their multiple variations

### DIFF
--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -56,7 +56,7 @@ class LineString(BaseGeometry):
             'coordinates': tuple(self.coords)
             }
 
-    def svg(self, scale_factor=1., stroke_color=None):
+    def svg(self, scale_factor=1., stroke_color=None, opacity=None):
         """Returns SVG polyline element for the LineString geometry.
 
         Parameters
@@ -66,16 +66,20 @@ class LineString(BaseGeometry):
         stroke_color : str, optional
             Hex string for stroke color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.8
         """
         if self.is_empty:
             return '<g />'
         if stroke_color is None:
             stroke_color = "#66cc99" if self.is_valid else "#ff3333"
+        if opacity is None:
+            opacity = 0.8
         pnt_format = " ".join(["{},{}".format(*c) for c in self.coords])
         return (
             '<polyline fill="none" stroke="{2}" stroke-width="{1}" '
-            'points="{0}" opacity="0.8" />'
-            ).format(pnt_format, 2. * scale_factor, stroke_color)
+            'points="{0}" opacity="{3}" />'
+            ).format(pnt_format, 2. * scale_factor, stroke_color,opacity)
 
     @property
     def _ctypes(self):

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -60,7 +60,7 @@ class MultiLineString(BaseMultipartGeometry):
             'coordinates': tuple(tuple(c for c in g.coords) for g in self.geoms)
             }
 
-    def svg(self, scale_factor=1., stroke_color=None):
+    def svg(self, scale_factor=1., stroke_color=None, opacity=None):
         """Returns a group of SVG polyline elements for the LineString geometry.
 
         Parameters
@@ -70,13 +70,15 @@ class MultiLineString(BaseMultipartGeometry):
         stroke_color : str, optional
             Hex string for stroke color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.8
         """
         if self.is_empty:
             return '<g />'
         if stroke_color is None:
             stroke_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, stroke_color) for p in self.geoms) + \
+            ''.join(p.svg(scale_factor, stroke_color, opacity) for p in self.geoms) + \
             '</g>'
 
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -66,7 +66,7 @@ class MultiPoint(BaseMultipartGeometry):
             'coordinates': tuple([g.coords[0] for g in self.geoms])
             }
 
-    def svg(self, scale_factor=1., fill_color=None):
+    def svg(self, scale_factor=1., fill_color=None, opacity=None):
         """Returns a group of SVG circle elements for the MultiPoint geometry.
 
         Parameters
@@ -76,13 +76,15 @@ class MultiPoint(BaseMultipartGeometry):
         fill_color : str, optional
             Hex string for fill color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.6
         """
         if self.is_empty:
             return '<g />'
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, fill_color) for p in self.geoms) + \
+            ''.join(p.svg(scale_factor, fill_color, opacity) for p in self.geoms) + \
             '</g>'
 
     @property

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -80,7 +80,7 @@ class MultiPolygon(BaseMultipartGeometry):
             'coordinates': allcoords
             }
 
-    def svg(self, scale_factor=1., fill_color=None):
+    def svg(self, scale_factor=1., fill_color=None, opacity=None):
         """Returns group of SVG path elements for the MultiPolygon geometry.
 
         Parameters
@@ -90,13 +90,15 @@ class MultiPolygon(BaseMultipartGeometry):
         fill_color : str, optional
             Hex string for fill color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.6
         """
         if self.is_empty:
             return '<g />'
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
         return '<g>' + \
-            ''.join(p.svg(scale_factor, fill_color) for p in self.geoms) + \
+            ''.join(p.svg(scale_factor, fill_color, opacity) for p in self.geoms) + \
             '</g>'
 
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -84,7 +84,7 @@ class Point(BaseGeometry):
             'coordinates': self.coords[0]
             }
 
-    def svg(self, scale_factor=1., fill_color=None):
+    def svg(self, scale_factor=1., fill_color=None, opacity=None):
         """Returns SVG circle element for the Point geometry.
 
         Parameters
@@ -94,15 +94,19 @@ class Point(BaseGeometry):
         fill_color : str, optional
             Hex string for fill color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.6
         """
         if self.is_empty:
             return '<g />'
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        if opacity is None:
+            opacity = 0.6 
         return (
             '<circle cx="{0.x}" cy="{0.y}" r="{1}" '
-            'stroke="#555555" stroke-width="{2}" fill="{3}" opacity="0.6" />'
-            ).format(self, 3. * scale_factor, 1. * scale_factor, fill_color)
+            'stroke="#555555" stroke-width="{2}" fill="{3}" opacity="{4}" />'
+            ).format(self, 3. * scale_factor, 1. * scale_factor, fill_color, opacity)
 
     @property
     def _ctypes(self):

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -345,7 +345,7 @@ class Polygon(BaseGeometry):
             'type': 'Polygon',
             'coordinates': tuple(coords)}
 
-    def svg(self, scale_factor=1., fill_color=None):
+    def svg(self, scale_factor=1., fill_color=None, opacity=None):
         """Returns SVG path element for the Polygon geometry.
 
         Parameters
@@ -355,11 +355,15 @@ class Polygon(BaseGeometry):
         fill_color : str, optional
             Hex string for fill color. Default is to use "#66cc99" if
             geometry is valid, and "#ff3333" if invalid.
+        opacity : float
+            Float number between 0 and 1 for color opacity. Defaul value is 0.6
         """
         if self.is_empty:
             return '<g />'
         if fill_color is None:
             fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        if opacity is None:
+            opacity = 0.6 
         exterior_coords = [
             ["{},{}".format(*c) for c in self.exterior.coords]]
         interior_coords = [
@@ -370,8 +374,8 @@ class Polygon(BaseGeometry):
             for coords in exterior_coords + interior_coords])
         return (
             '<path fill-rule="evenodd" fill="{2}" stroke="#555555" '
-            'stroke-width="{0}" opacity="0.6" d="{1}" />'
-            ).format(2. * scale_factor, path, fill_color)
+            'stroke-width="{0}" opacity="{3}" d="{1}" />'
+            ).format(2. * scale_factor, path, fill_color, opacity)
 
     @classmethod
     def from_bounds(cls, xmin, ymin, xmax, ymax):


### PR DESCRIPTION
Hello,
I've just edited your library a bit. I added to method svg option to change opacity for pylygons, points, linestrings and their multiple variations.
I hope you will accept it.