### PR TITLE
Add vectorized covers and intersects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ Python version support:
 
 Shapely 1.8 will support only Python versions >= 3.6.
 
+New features:
+
+- Add `covers` and `intersects` to the vectorized methods (#1144).
+
 Bug fixes:
 
 - GEOS error messages printed when GEOS_getCoordSeq() is passed an empty

--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -72,6 +72,7 @@ Shapely is written by:
 * Morris Tweed <tweed.morris@gmail.com>
 * Naveen Michaud-Agrawal <naveen.michaudagrawal@gmail.com>
 * Oliver Tonnhofer <olt@bogosoft.com>
+* Pascal Bourgault <pascal.bourgaulty@gmail.com
 * Paveł Tyślacki <tbicr@users.noreply.github.com>
 * Peter Sagerson <psagers.github@ignorare.net>
 * Phil Elson <pelson.pub@gmail.com>

--- a/shapely/vectorized/__init__.py
+++ b/shapely/vectorized/__init__.py
@@ -1,3 +1,3 @@
 """Provides multi-point element-wise operations such as ``contains``."""
 
-from ._vectorized import (contains, touches)
+from ._vectorized import (contains, covers, intersects, touches)

--- a/shapely/vectorized/_vectorized.pyx
+++ b/shapely/vectorized/_vectorized.pyx
@@ -41,6 +41,54 @@ def contains(geometry, x, y):
     return _predicated_elementwise(geometry, x, y, GEOSPreparedContains_r)
 
 
+def covers(geometry, x, y):
+    """
+    Vectorized (element-wise) version of `covers` which checks whether
+    multiple points are covered by the exterior of a single geometry.
+
+    Parameters
+    ----------
+    geometry : PreparedGeometry or subclass of BaseGeometry
+        The geometry which is to be checked to see whether each point is
+        covered. The geometry will be "prepared" if it is not already
+        a PreparedGeometry instance.
+    x : array
+        The x coordinates of the points to check. 
+    y : array
+        The y coordinates of the points to check.
+
+    Returns
+    -------
+    Mask of points covered by the exterior of the given `geometry`.
+
+    """
+    return _predicated_elementwise(geometry, x, y, GEOSPreparedCovers_r)
+
+
+def intersects(geometry, x, y):
+    """
+    Vectorized (element-wise) version of `intersects` which checks whether
+    multiple points are share any portion of space with a single geometry.
+
+    Parameters
+    ----------
+    geometry : PreparedGeometry or subclass of BaseGeometry
+        The geometry which is to be checked to see whether each point share any
+        portion of space with. The geometry will be "prepared" if it is not already
+        a PreparedGeometry instance.
+    x : array
+        The x coordinates of the points to check. 
+    y : array
+        The y coordinates of the points to check.
+
+    Returns
+    -------
+    Mask of points sharing space with the given `geometry`.
+
+    """
+    return _predicated_elementwise(geometry, x, y, GEOSPreparedIntersects_r)
+
+
 def touches(geometry, x, y):
     """
     Vectorized (element-wise) version of `touches` which checks whether


### PR DESCRIPTION
This PR goes in the direction of #501 and adds `covers` and `intersects` to the vectorized methods.

In `clisops`, we are constructing integer masks from xarray DataArrays and GeoDataframes. The code currently uses `vectorized.contains` and `vectorized.touches`. The latter is extremely slow. I'm not sure why, but see issue roocs/clisops#160.

What we are looking for is in fact `covers`, but as it wasn't available, we went with a logical OR of the two other results. This PR adds `covers` and `intersects`, the two remaining unimplemented predicates that make sense with points. 

I did try `PyGEOS`, but while I might be doing something wrong, the performance are orders of magnitude better with `vectorized.covers`.  Also, it seemed a low-effort high-reward PR to do for us.