### PR TITLE
arm64 wheels: RFC

### DIFF
--- a/Dockerfile.arm64.wheels
+++ b/Dockerfile.arm64.wheels
@@ -1,0 +1,24 @@
+FROM quay.io/pypa/manylinux2014_aarch64
+
+ENV GEOS_VERSION 3.5.0
+
+# Install geos
+RUN mkdir -p /src \
+    && cd /src \
+    && curl -f -L -O http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 \
+    && tar jxf geos-$GEOS_VERSION.tar.bz2 \
+    && cd /src/geos-$GEOS_VERSION \
+    && ./configure \
+    && make \
+    && make install \
+    && ldconfig \
+    && rm -rf /src
+
+# Bake dev requirements into the Docker image for faster builds
+ADD requirements-dev.txt /tmp/requirements-dev.txt
+RUN for PYBIN in /opt/python/cp3[789]*/bin; do \
+        $PYBIN/pip install -r /tmp/requirements-dev.txt ; \
+    done
+
+WORKDIR /io
+CMD ["/io/build-linux-arm64-wheels.sh"]

--- a/build-linux-arm64-wheels.sh
+++ b/build-linux-arm64-wheels.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu
+
+# Checking for /.dockerenv is a hacky way to determine whether or not we're
+# already running in a Docker container. Note that this is not guaranteed to
+# exist in all versions and drivers and may need to be changed later.
+if [ ! -e /.dockerenv ]; then
+    docker build -f Dockerfile.arm64.wheels --pull -t shapely-wheelbuilder .
+    exec docker run -v `pwd`:/io shapely-wheelbuilder "$@"
+fi
+
+ORIGINAL_PATH=$PATH
+UNREPAIRED_WHEELS=/tmp/wheels
+
+# Compile wheels
+for PYBIN in /opt/python/cp3[789]*/bin; do
+    PATH=${PYBIN}:$ORIGINAL_PATH
+    python setup.py bdist_wheel -d ${UNREPAIRED_WHEELS}
+done
+
+# Bundle GEOS into the wheels
+for whl in ${UNREPAIRED_WHEELS}/*.whl; do
+    auditwheel repair ${whl} -w wheels
+done


### PR DESCRIPTION
This will create wheels usable by arm64 systems.

As arm64 system become more prevalent, many wheels are also published for arm64 systems. Would it be possible to also have shapely arm64 wheels?

The script could be used as-is on either arm64 systems (tested on Graviton2) or intel/amd systems with [qemu-docker](https://github.com/joshkunz/qemu-docker) (tested on intel MAC).

I would be happy to add / modify the script as needed to support your normal wheel-building process.

Differences between arm64 and x86 wheel generation:
* Using manylinux2014_aarch64
* Added a call to ldconfig after building libgeos
* Only generating wheels for cp3.7/8/9 - as matplotlib only publishes wheels for these versions (for both x86 and arm64).