### PR TITLE
Refactor pickling of LinearRing to not use lgeos

### DIFF
--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -19,9 +19,6 @@ def test_pickle_round_trip(cls, coords):
     data = dumps(geom1, HIGHEST_PROTOCOL)
     geom2 = loads(data)
     assert geom2.has_z == geom1.has_z
-    # TODO(shapely-2.0) LinearRing type not preserved in roundtrip
-    if cls is LinearRing:
-        geom1 = LineString(coords)
     assert type(geom2) is type(geom1)
     assert geom2.type == geom1.type
     assert geom2.wkt == geom1.wkt


### PR DESCRIPTION
xref https://github.com/Toblerity/Shapely/issues/988

Together with https://github.com/Toblerity/Shapely/pull/1161, this is the last remaining usage of lgeos / ctypes in the shapely-2.0 branch.