### PR TITLE
docs: Fix a few typos

### DIFF
--- a/_vendor/packaging/specifiers.py
+++ b/_vendor/packaging/specifiers.py
@@ -503,7 +503,7 @@ class Specifier(_IndividualSpecifier):
                 return False
 
         # Ensure that we do not allow a local version of the version mentioned
-        # in the specifier, which is techincally greater than, to match.
+        # in the specifier, which is technically greater than, to match.
         if prospective.local is not None:
             if Version(prospective.base_version) == Version(spec.base_version):
                 return False
@@ -589,7 +589,7 @@ def _pad_version(left, right):
 class SpecifierSet(BaseSpecifier):
 
     def __init__(self, specifiers="", prereleases=None):
-        # Split on , to break each indidivual specifier into it's own item, and
+        # Split on , to break each individual specifier into it's own item, and
         # strip each item to remove leading/trailing whitespace.
         specifiers = [s.strip() for s in specifiers.split(",") if s.strip()]
 

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -3,7 +3,7 @@ Design Notes
 ============
 
 Shapely provides classes that implement, more or less, the interfaces in the
-OGC's simple feature acess specification [1]_. The classes are defined in
+OGC's simple feature access specification [1]_. The classes are defined in
 similarly named modules under ``shapely.geometry``: ``Point`` is in
 ``shapely.geometry.point``, ``MultiPolygon`` is in
 ``shapely.geometry.multipolygon``. These classes derive from

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -101,7 +101,7 @@ def deserialize_wkb(data):
 def geos_geom_from_py(ob, create_func=None):
     """Helper function for geos_*_from_py functions in each geom type.
 
-    If a create_func is specified the coodinate sequence is cloned and a new
+    If a create_func is specified the coordinate sequence is cloned and a new
     geometry is created with it, otherwise the geometry is cloned directly.
     This behaviour is useful for converting between LineString and LinearRing
     objects.

--- a/shapely/ops.py
+++ b/shapely/ops.py
@@ -145,7 +145,7 @@ class CollectionOperator:
         """Returns the union of a sequence of geometries
 
         This method replaces :meth:`cascaded_union` as the
-        prefered method for dissolving many polygons.
+        preferred method for dissolving many polygons.
         """
         try:
             if isinstance(geoms, BaseMultipartGeometry):

--- a/shapely/speedups/__init__.py
+++ b/shapely/speedups/__init__.py
@@ -33,7 +33,7 @@ def enable():
     """Enable Cython speedups
 
     The shapely.speedups module contains performance enhancements written in C.
-    They are automaticaly installed when Python has access to a compiler and
+    They are automatically installed when Python has access to a compiler and
     GEOS development headers during installation, and are enabled by default.
 
     You can check if speedups are installed with the `available` attribute, and


### PR DESCRIPTION
There are small typos in:
- _vendor/packaging/specifiers.py
- docs/design.rst
- shapely/geometry/base.py
- shapely/ops.py
- shapely/speedups/__init__.py

Fixes:
- Should read `technically` rather than `techincally`.
- Should read `preferred` rather than `prefered`.
- Should read `individual` rather than `indidivual`.
- Should read `coordinate` rather than `coodinate`.
- Should read `automatically` rather than `automaticaly`.
- Should read `access` rather than `acess`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md