### PR TITLE
Get free from global symbol table on Linux as we do for macos.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ New features:
 
 Bug fixes:
 
+- We no longer attempt to load libc to get the free function on Linux, but get
+  it from the global symbol table.
 - GEOS error messages printed when GEOS_getCoordSeq() is passed an empty
   geometry are avoided by never passing an empty geometry (#1134).
 - Python's builtin super() is now used only as described in PEP 3135 (#1109).

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -97,11 +97,11 @@ if sys.platform.startswith('linux'):
             'libgeos_c.so',
         ]
         _lgeos = load_dll('libgeos_c', fallbacks=alt_paths)
-    # Necessary for environments with only libc.musl
-    c_alt_paths = [
-        'libc.musl-x86_64.so.1'
-    ]
-    # free = load_dll('c', fallbacks=c_alt_paths).free
+
+    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
+    # manpage says, "If filename is NULL, then the returned handle is for the
+    # main program". This way we can let the linker do the work to figure out
+    # which libc Python is actually using.
     free = CDLL(None).free
     free.argtypes = [c_void_p]
     free.restype = None
@@ -148,10 +148,6 @@ elif sys.platform == 'darwin':
             ]
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 
-    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
-    # manpage says, "If filename is NULL, then the returned handle is for the
-    # main program". This way we can let the linker do the work to figure out
-    # which libc Python is actually using.
     free = CDLL(None).free
     free.argtypes = [c_void_p]
     free.restype = None
@@ -188,12 +184,13 @@ elif sys.platform == 'win32':
 
 elif sys.platform == 'sunos5':
     _lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
-    free = CDLL('libc.so.1').free
+    free.restype = None
     free.argtypes = [c_void_p]
     free.restype = None
+
 else:  # other *nix systems
     _lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])
-    free = load_dll('c', fallbacks=['libc.so.6']).free
+    free = CDLL(None).free
     free.argtypes = [c_void_p]
     free.restype = None
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -101,7 +101,8 @@ if sys.platform.startswith('linux'):
     c_alt_paths = [
         'libc.musl-x86_64.so.1'
     ]
-    free = load_dll('c', fallbacks=c_alt_paths).free
+    # free = load_dll('c', fallbacks=c_alt_paths).free
+    free = CDLL(None).free
     free.argtypes = [c_void_p]
     free.restype = None
 


### PR DESCRIPTION
I saw some errors like `OSError: Could not find lib c or load any of its variants` in production at work. I suspect that the instances I'm using were in a very bad state, but we don't need to load libc (or its equivalent) on a *nix platform: Python has already loaded it and `free` will be found in the global symbol table.