### PR TITLE
Remove the DeprecationWarning from STRtree constructor

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -22,9 +22,7 @@ import ctypes
 import logging
 from typing import Any, ItemsView, Iterable, Iterator, Sequence, Tuple, Union
 import sys
-from warnings import warn
 
-from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry.base import BaseGeometry
 from shapely.geos import lgeos
 
@@ -99,11 +97,6 @@ class STRtree:
         items: Iterable[Any] = None,
         node_capacity: int = 10,
     ):
-        warn(
-            "STRtree will be changed in 2.0.0. The exact API is not yet decided, but will be documented before 1.8.0",
-            ShapelyDeprecationWarning,
-            stacklevel=2,
-        )
         self._tree = None
         self.node_capacity = node_capacity
         self._rev = {

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -6,7 +6,6 @@ import sys
 
 import pytest
 
-from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import Point, Polygon
 from shapely.geos import geos_version
 from shapely import strtree
@@ -22,8 +21,7 @@ from .conftest import requires_geos_342
     [(Point(2, 2).buffer(0.99), 1), (Point(2, 2).buffer(1.0), 3)],
 )
 def test_query(geoms, query_geom, num_results):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms)
+    tree = STRtree(geoms)
     results = tree.query(query_geom)
     assert len(results) == num_results
 
@@ -36,8 +34,7 @@ def test_query(geoms, query_geom, num_results):
 )
 def test_query_enumeration_idx(geoms, query_geom, expected):
     """Store enumeration idx"""
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree((g, i) for i, g in enumerate(geoms))
+    tree = STRtree((g, i) for i, g in enumerate(geoms))
     results = tree.query_items(query_geom)
     assert sorted(results) == sorted(expected)
 
@@ -50,8 +47,7 @@ def test_insert_empty_geometry():
     """
     empty = Polygon()
     geoms = [empty]
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms)
+    tree = STRtree(geoms)
     query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
     results = tree.query(query)
     assert len(results) == 0
@@ -66,8 +62,7 @@ def test_query_empty_geometry():
     empty = Polygon()
     point = Point(1, 0.5)
     geoms = [empty, point]
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms)
+    tree = STRtree(geoms)
     query = Polygon([(0, 0), (1, 1), (2, 0), (0, 0)])
     results = tree.query(query)
     assert len(results) == 1
@@ -80,8 +75,7 @@ def test_references():
     empty = Polygon()
     point = Point(1, 0.5)
     geoms = [empty, point]
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms)
+    tree = STRtree(geoms)
 
     empty = None
     point = None
@@ -95,8 +89,7 @@ def test_references():
 
 @requires_geos_342
 def test_safe_delete():
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree([])
+    tree = STRtree([])
 
     _lgeos = strtree.lgeos
     strtree.lgeos = None
@@ -111,8 +104,7 @@ def test_pickle_persistence():
     """
     Don't crash trying to use unpickled GEOS handle.
     """
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree([(Point(i, i).buffer(0.1), i) for i in range(3)])
+    tree = STRtree([(Point(i, i).buffer(0.1), i) for i in range(3)])
 
     pickled_strtree = pickle.dumps(tree)
     unpickle_script_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "unpickle-strtree.py")
@@ -138,8 +130,7 @@ def test_pickle_persistence():
 )
 @pytest.mark.parametrize("query_geom", [Point(0, 0.4)])
 def test_nearest_geom(geoms, query_geom):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms)
+    tree = STRtree(geoms)
     result = tree.nearest(query_geom)
     assert result.geom_type == "Point"
     assert result.x == 0.0
@@ -160,22 +151,19 @@ def test_nearest_geom(geoms, query_geom):
 @pytest.mark.parametrize("items", [list(range(1, 4)), list("abc")])
 @pytest.mark.parametrize("query_geom", [Point(0, 0.4)])
 def test_nearest_item(geoms, items, query_geom):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms, items)
+    tree = STRtree(geoms, items)
     assert tree.nearest_item(query_geom) == items[0]
 
 
 @pytest.mark.parametrize(["geoms", "items"], [(None, None), ([], None)])
 def test_nearest_empty(geoms, items):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms, items)
+    tree = STRtree(geoms, items)
     assert tree.nearest_item(None) is None
 
 
 @pytest.mark.parametrize(["geoms", "items"], [(None, None), ([], None)])
 def test_nearest_items(geoms, items):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms, items)
+    tree = STRtree(geoms, items)
     assert tree.nearest_item(None) is None
 
 
@@ -193,6 +181,5 @@ def test_nearest_items(geoms, items):
 @pytest.mark.parametrize("items", [list(range(1, 4)), list("abc")])
 @pytest.mark.parametrize("query_geom", [Point(0, 0.5)])
 def test_nearest_item_exclusive(geoms, items, query_geom):
-    with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree(geoms, items)
+    tree = STRtree(geoms, items)
     assert tree.nearest_item(query_geom, exclusive=True) != items[0]


### PR DESCRIPTION
As a follow-up on https://github.com/Toblerity/Shapely/pull/1112, if we don't have concrete plans to change the API, we shouldn't raising a warning in the constructor every time?