### PR TITLE
Only support separate geoms, items sequences in STRtree constructor

### DIFF
--- a/shapely/strtree.py
+++ b/shapely/strtree.py
@@ -20,7 +20,7 @@ References
 
 import ctypes
 import logging
-from typing import Any, ItemsView, Iterable, Iterator, Sequence, Tuple, Union
+from typing import Any, ItemsView, Iterable, Iterator, Optional, Sequence, Tuple, Union
 import sys
 from warnings import warn
 
@@ -108,27 +108,24 @@ class STRtree:
         self.node_capacity = node_capacity
         self._rev = {
             item: geom
-            for geom, item in self._iterinitdata(
-                zip(geoms, items) if items is not None else geoms
-            )
+            for geom, item in self._iterinitdata(geoms, items)
             if not geom.is_empty
         }
-
         if self._rev:
             self._init_tree(self._rev.items())
 
     def _iterinitdata(
         self,
-        initdata: Union[Iterable[Tuple[BaseGeometry, Any]], Iterable[BaseGeometry]],
+        geoms: Iterable[BaseGeometry], items: Optional[Iterable[BaseGeometry]],
     ) -> Iterator[Tuple[BaseGeometry, Any]]:
-        if not initdata:
-            return
-
-        for enum_idx, item in enumerate(initdata):
-            if isinstance(item, tuple):
-                yield item[0], item[1]
-            elif isinstance(item, BaseGeometry):
-                yield (item, enum_idx)
+        if items is not None:
+            for geom, item in zip(geoms, items):
+                if isinstance(geom, BaseGeometry):
+                    yield (geom, item)
+        else:
+            for enum_idx, geom in enumerate(geoms):
+                if isinstance(geom, BaseGeometry):
+                    yield (geom, enum_idx)
 
     def _init_tree(self, rev_initdata: ItemsView[Any, BaseGeometry]):
         if rev_initdata:

--- a/tests/test_strtree.py
+++ b/tests/test_strtree.py
@@ -37,7 +37,7 @@ def test_query(geoms, query_geom, num_results):
 def test_query_enumeration_idx(geoms, query_geom, expected):
     """Store enumeration idx"""
     with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree((g, i) for i, g in enumerate(geoms))
+        tree = STRtree(geoms, range(len(geoms)))
     results = tree.query_items(query_geom)
     assert sorted(results) == sorted(expected)
 
@@ -112,7 +112,7 @@ def test_pickle_persistence():
     Don't crash trying to use unpickled GEOS handle.
     """
     with pytest.warns(ShapelyDeprecationWarning):
-        tree = STRtree([(Point(i, i).buffer(0.1), i) for i in range(3)])
+        tree = STRtree([Point(i, i).buffer(0.1) for i in range(3)], range(3))
 
     pickled_strtree = pickle.dumps(tree)
     unpickle_script_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "unpickle-strtree.py")
@@ -165,14 +165,14 @@ def test_nearest_item(geoms, items, query_geom):
     assert tree.nearest_item(query_geom) == items[0]
 
 
-@pytest.mark.parametrize(["geoms", "items"], [(None, None), ([], None)])
+@pytest.mark.parametrize(["geoms", "items"], [([], None), ([], [])])
 def test_nearest_empty(geoms, items):
     with pytest.warns(ShapelyDeprecationWarning):
         tree = STRtree(geoms, items)
     assert tree.nearest_item(None) is None
 
 
-@pytest.mark.parametrize(["geoms", "items"], [(None, None), ([], None)])
+@pytest.mark.parametrize(["geoms", "items"], [([], None), ([], [])])
 def test_nearest_items(geoms, items):
     with pytest.warns(ShapelyDeprecationWarning):
         tree = STRtree(geoms, items)


### PR DESCRIPTION
Another follow-up on #1112. See my comment at https://github.com/Toblerity/Shapely/pull/1112#discussion_r671652931 about supporting zipped geoms/items sequence vs only supporting separate sequences. 

Assuming the zipped sequences in #1112 were a left-over from the initial version of that PR, this PR updates the STRtree constructor (and tests) to:

- only support separate sequences as `STRtree(geoms, items)`, and thus no longer supports `STRtree(zip(geoms, items))`
- also removed support for `STRtree(None)`. This didn't work before in released versions, and IMO it's cleaner to keep requiring `geoms` to be a sequence (it can still be an empty sequence)

If the intention is to mainly support the separate sequences, I would personally not support the zipped sequences (i.e. sequence tuples) to keep the interface simple and explicit.