### PR TITLE
Silence NumPy 1.21 DeprecationWarning by raising AttributeError

### DIFF
--- a/shapely/coords.py
+++ b/shapely/coords.py
@@ -116,7 +116,10 @@ class CoordinateSequence:
     def _ctypes(self):
         self._update()
         has_z = self._ndim == 3
-        n = self._ndim
+        n = self._ndim or 0
+        if n == 0:
+            # ignore with NumPy 1.21 __array_interface__
+            raise AttributeError("empty geometry sequence")
         m = self.__len__()
         array_type = c_double * (m * n)
         data = array_type()

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -849,8 +849,8 @@ class BaseMultipartGeometry(BaseGeometry):
     @property
     def __array_interface__(self):
         """Provide the Numpy array protocol."""
-        raise NotImplementedError("Multi-part geometries do not themselves "
-                                  "provide the array interface")
+        raise AttributeError("Multi-part geometries do not themselves "
+                             "provide the array interface")
 
     def _get_coords(self):
         raise NotImplementedError("Sub-geometries may have coordinate "

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -317,7 +317,7 @@ class Polygon(BaseGeometry):
 
     @property
     def __array_interface__(self):
-        raise NotImplementedError(
+        raise AttributeError(
         "A polygon does not itself provide the array interface. Its rings do.")
 
     def _get_coords(self):

--- a/shapely/speedups/_speedups.pyx
+++ b/shapely/speedups/_speedups.pyx
@@ -421,7 +421,10 @@ def coordseq_ctypes(self):
     cdef GEOSCoordSequence *cs
     cdef double *data_p
     self._update()
-    n = self._ndim
+    n = self._ndim or 0
+    if n == 0:
+        # ignore with NumPy 1.21 __array_interface__
+        raise AttributeError("empty geometry sequence")
     m = self.__len__()
     array_type = ctypes.c_double * (m * n)
     data = array_type()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -114,3 +114,14 @@ def test_len_deprecated(geometrycollection_geojson):
     geom = shape(geometrycollection_geojson)
     with pytest.warns(ShapelyDeprecationWarning, match="__len__"):
         assert len(geom) == 2
+
+
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = GeometryCollection([LineString([(0, 0), (1, 1)])])
+    ar = np.empty(1, object)
+    ar[:] = [geom]
+    assert ar[0] == geom

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -106,6 +106,7 @@ def test_numpy_object_array():
     geom = LineString([(0.0, 0.0), (0.0, 1.0)])
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom
 
 
 def test_from_invalid_dim():

--- a/tests/test_linestring.py
+++ b/tests/test_linestring.py
@@ -87,6 +87,7 @@ def test_from_numpy():
     assert line.coords[:] == [(1.0, 2.0), (3.0, 4.0)]
 
 
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_linestring_coords():
     np = pytest.importorskip("numpy")
 
@@ -95,6 +96,16 @@ def test_numpy_empty_linestring_coords():
     la = np.asarray(line.coords)
 
     assert la.shape == (0,)
+
+
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = LineString([(0.0, 0.0), (0.0, 1.0)])
+    ar = np.empty(1, object)
+    ar[:] = [geom]
 
 
 def test_from_invalid_dim():

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -117,3 +117,13 @@ def test_getitem_deprecated():
     geom = MultiLineString([[[5.0, 6.0], [7.0, 8.0]]])
     with pytest.warns(ShapelyDeprecationWarning, match="__getitem__"):
         part = geom[0]
+
+
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = MultiLineString([[[5.0, 6.0], [7.0, 8.0]]])
+    ar = np.empty(1, object)
+    ar[:] = [geom]

--- a/tests/test_multilinestring.py
+++ b/tests/test_multilinestring.py
@@ -127,3 +127,4 @@ def test_numpy_object_array():
     geom = MultiLineString([[[5.0, 6.0], [7.0, 8.0]]])
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -137,6 +137,7 @@ def test_numpy_object_array():
     geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom
 
 
 def test_iteration_deprecated():

--- a/tests/test_multipoint.py
+++ b/tests/test_multipoint.py
@@ -129,6 +129,16 @@ def test_multipoint_array_interface_numpy_deprecated():
         np.array(geom)
 
 
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = MultiPoint(((1.0, 2.0), (3.0, 4.0)))
+    ar = np.empty(1, object)
+    ar[:] = [geom]
+
+
 def test_iteration_deprecated():
     geom = MultiPoint([[5.0, 6.0], [7.0, 8.0]])
     with pytest.warns(ShapelyDeprecationWarning, match="Iteration"):

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -110,3 +110,15 @@ def test_getitem_deprecated():
           [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])])
     with pytest.warns(ShapelyDeprecationWarning, match="__getitem__"):
         part = geom[0]
+
+
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = MultiPolygon(
+        [(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)),
+          [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])])
+    ar = np.empty(1, object)
+    ar[:] = [geom]

--- a/tests/test_multipolygon.py
+++ b/tests/test_multipolygon.py
@@ -122,3 +122,4 @@ def test_numpy_object_array():
           [((0.25, 0.25), (0.25, 0.5), (0.5, 0.5), (0.5, 0.25))])])
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -281,3 +281,4 @@ def test_numpy_object_array():
     geom = Point(3.0, 4.0)
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -262,6 +262,7 @@ def test_point_array_interface_numpy_deprecated():
         np.array(p)
 
 
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_point_coords():
     np = pytest.importorskip("numpy")
 
@@ -270,3 +271,13 @@ def test_numpy_empty_point_coords():
     # Access the coords
     a = np.asarray(pe.coords)
     assert a.shape == (0,)
+
+
+@shapely20_deprecated
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = Point(3.0, 4.0)
+    ar = np.empty(1, object)
+    ar[:] = [geom]

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -124,6 +124,7 @@ def test_numpy_object_array():
     geom = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])
     ar = np.empty(1, object)
     ar[:] = [geom]
+    assert ar[0] == geom
 
 
 def test_polygon_from_coordinate_sequence():

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -109,11 +109,21 @@ def test_numpy_linearring_coords():
     assert_array_equal(ra, expected)
 
 
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
 def test_numpy_empty_linearring_coords():
     np = pytest.importorskip("numpy")
 
     ring = LinearRing()
     assert np.asarray(ring.coords).shape == (0,)
+
+
+@pytest.mark.filterwarnings("error:An exception was ignored")  # NumPy 1.21
+def test_numpy_object_array():
+    np = pytest.importorskip("numpy")
+
+    geom = Polygon([(0.0, 0.0), (0.0, 1.0), (1.0, 1.0)])
+    ar = np.empty(1, object)
+    ar[:] = [geom]
 
 
 def test_polygon_from_coordinate_sequence():


### PR DESCRIPTION
Possible fix for NumPy 1.21 DeprecationWarning for exceptions raised in `__array_interface__`.  Only `BaseGeometry.__array_interface__` still raise NotImplementedError, as it is an abstract class.

Tests for each geometry type (except GeometryCollection) are added, which creates/assigns an object array.

Comments/reviews are welcome!

Closes #1173