### PR TITLE
Added /opt/homebrew/lib for GEOS shared library

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,8 @@ Bug fixes:
   geometry are avoided by never passing an empty geometry (#1134).
 - Python's builtin super() is now used only as described in PEP 3135 (#1109).
 - Only load conda GEOS dll if it exists (on Windows) (#1108).
+- Add /opt/homebrew/lib to the list of directories to be searched for the GEOS
+  shared library.
 
 1.8a1 (2021-03-03)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,7 @@ Bug fixes:
 - Only load conda GEOS dll if it exists (on Windows) (#1108).
 - Add /opt/homebrew/lib to the list of directories to be searched for the GEOS
   shared library.
+- Added new library search path to assist app creation with cx_Freeze.
 
 1.8a1 (2021-03-03)
 ------------------

--- a/shapely/_buildcfg.py
+++ b/shapely/_buildcfg.py
@@ -181,8 +181,10 @@ elif sys.platform == 'darwin':
                 "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
                 # macports
                 '/opt/local/lib/libgeos_c.dylib',
-                # homebrew
+                # homebrew Intel
                 '/usr/local/lib/libgeos_c.dylib',
+                # homebrew Apple Silicon
+                '/opt/homebrew/lib/libgeos_c.dylib',
             ]
         lgeos = load_dll('geos_c', fallbacks=alt_paths)
 

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -131,9 +131,11 @@ elif sys.platform == 'darwin':
                     os.environ['RESOURCEPATH'], '..', 'Frameworks',
                     'libgeos_c.dylib')]
             except KeyError:
-                # binary from pyinstaller
                 alt_paths = [
-                    os.path.join(sys.executable, 'libgeos_c.dylib')]
+                    # binary from pyinstaller
+                    os.path.join(sys.executable, 'libgeos_c.dylib'),
+                    # .app from cx_Freeze
+                    os.path.join(os.path.dirname(sys.executable), 'libgeos_c.1.dylib')]
                 if hasattr(sys, '_MEIPASS'):
                     alt_paths.append(
                         os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))

--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -143,8 +143,10 @@ elif sys.platform == 'darwin':
                 "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
                 # macports
                 '/opt/local/lib/libgeos_c.dylib',
-                # homebrew
+                # homebrew Intel
                 '/usr/local/lib/libgeos_c.dylib',
+                # homebrew Apple Silicon
+                '/opt/homebrew/lib/libgeos_c.dylib',
             ]
         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 

--- a/tests/test_dlls.py
+++ b/tests/test_dlls.py
@@ -13,8 +13,9 @@ class LoadingTestCase(unittest.TestCase):
     def test_fallbacks(self):
         load_dll('geos_c', fallbacks=[
             os.path.join(sys.prefix, "lib", "libgeos_c.dylib"), # anaconda (Mac OS X)
-            '/opt/local/lib/libgeos_c.dylib',  # MacPorts
-            '/usr/local/lib/libgeos_c.dylib',  # homebrew (Mac OS X)
+            '/opt/local/lib/libgeos_c.dylib',     # MacPorts
+            '/usr/local/lib/libgeos_c.dylib',     # homebrew (Mac OS X)
+            '/opt/homebrew/lib/libgeos_c.dylib',  # homebrew (macOS)
             os.path.join(sys.prefix, "lib", "libgeos_c.so"), # anaconda (Linux)
             'libgeos_c.so.1',
             'libgeos_c.so'])


### PR DESCRIPTION
I added the directory /opt/homebrew/lib to the list of directories to be searched for the GEOS
  shared library. Homebrew installs into /opt/homebrew rather than /usr/local on systems with the new Apple Silicon (M1) chip.

## Expected behavior and actual behavior.

Actual behaviour of
`python -c "from shapely.geos import lgeos"`

is

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/cuntz/.pyenv/versions/3.9.6/envs/test-cartopy/lib/python3.9/site-packages/shapely/geos.py", line 136, in <module>
    _lgeos = load_dll('geos_c', fallbacks=alt_paths)
  File "/Users/cuntz/.pyenv/versions/3.9.6/envs/test-cartopy/lib/python3.9/site-packages/shapely/geos.py", line 60, in load_dll
    raise OSError(
OSError: Could not find lib geos_c or load any of its variants ['/Library/Frameworks/GEOS.framework/Versions/Current/GEOS', '/opt/local/lib/libgeos_c.dylib', '/usr/local/lib/libgeos_c.dylib'].
```

## Operating system

macOS Big Sur (Version 11.5.1) on Mac mini (M1, 2020).
Python 3.9.6

## Shapely version and provenance

Current master on Github.
