### PR TITLE
Add migration guide with explanation how to update your code for Shapely 1.8 / 2.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,7 +37,9 @@ Bug fixes:
 
 Shapely 1.8.0 will be a transitional version. There are a few bug fixes and new
 features, but it is mainly about warning of the upcoming changes in 2.0.0.
-Several more pre-releases before 1.8.0 are expected.
+Several more pre-releases before 1.8.0 are expected. See the migration guide
+to Shapely 1.8 / 2.0 for more details on how to update your code
+(https://shapely.readthedocs.io/en/latest/migration.html).
 
 Python version support:
 
@@ -50,7 +52,6 @@ version 2.0.0.
 
 - ops.cascaded_union
 - geometry .empty()
-- geometry .to_wkb() and .to_wkt()
 - geometry .ctypes and .__array_interface__
 - multi-part geometry .__len__
 
@@ -61,6 +62,9 @@ not yet decided, but will be decided before 1.8.0 is released.
 
 Deprecation warnings will be emitted in 1.8a1 when any of these features are
 used.
+
+The deprecated .to_wkb() and .to_wkt() methods on the geometry objects have
+been removed.
 
 New features:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ from shapely.ops import unary_union
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'matplotlib.sphinxext.plot_directive',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.autodoc',
     #'sphinx.ext.pngmath', # <----- pick one, not both
     'sphinx.ext.mathjax', # <--/
@@ -209,3 +210,11 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_use_modindex = True
+
+
+#  --Options for sphinx extensions -----------------------------------------------
+
+# connect docs in other projects
+intersphinx_mapping = {
+    'numpy': ('https://numpy.org/doc/stable/', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Documentation Contents
    The Project <project>
    User Manual <manual>
    API Documentation <modules>
+   migration
 
 Indices and tables
 ==================

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2787,6 +2787,8 @@ All of Shapely's geometry types are supported by these functions.
   >>> wkt.dumps(pt, trim=True)
   'POINT (0 0)'
 
+.. _array-interface:
+
 Numpy and Python Arrays
 -----------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -194,9 +194,8 @@ convert the ``.coords`` attribute instead::
 The ``array_interface()`` method and ``ctypes`` attribute will be removed in
 Shapely 2.0, but since Shapely will start requiring NumPy as a dependency,
 you can use NumPy or its array interface directly. Check the NumPy docs on
-the `ctypes attribute <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.ctypes.html>`__
-or the `array interface <https://numpy.org/doc/stable/reference/arrays.interface.html>`__
-for more details.
+the :py:attr:`ctypes <numpy:numpy.ndarray.ctypes>` attribute
+or the :ref:`array interface <numpy:arrays.interface>` for more details.
 
 Creating NumPy arrays of geometry objects
 -----------------------------------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -273,8 +273,8 @@ manager that can be copied into your project::
         def ignore_shapely2_warnings():
             yield
 
-This can then be used when creating NumPy arrays (be careful to *only* for
-this specific purpose, and not generally suppress those warnings)::
+This can then be used when creating NumPy arrays (be careful to *only* use it
+for this specific purpose, and not generally suppress those warnings)::
 
     geoms = [...]
     arr = np.empty(len(geoms), dtype="object")

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -46,7 +46,7 @@ In Shapely 1.8, this will start raising a warning::
     in place is deprecated, and will not be possible any more in Shapely 2.0
 
 and starting with version 2.0.0, all geometry objects will become immutable
-(as a consequence, they will also become hashable and thefore usable as, for
+(as a consequence, they will also become hashable and therefore usable as, for
 example, dictionary keys).
 
 **How do I update my code?** There is no direct alternative for mutating the
@@ -137,11 +137,11 @@ support those features, and for those classes there is no change in behaviour
 for this aspect.
 
 
-The array interface and conversion to numpy
+The array interface and conversion to NumPy
 ===========================================
 
 Shapely provides an array interface to have easy access to the coordinates as,
-for example, numpy arrays (:ref:`manual section <array-interface>`).
+for example, NumPy arrays (:ref:`manual section <array-interface>`).
 
 A small example::
 
@@ -165,20 +165,20 @@ In addition, there are also the explicit ``array_interface()`` method and
 
 This functionality is available for Point, LineString, LinearRing and MultiPoint.
 
-For more robust interoperability with numpy, this array interface will be removed
+For more robust interoperability with NumPy, this array interface will be removed
 from those geometry classes, and limited to the ``coords``. 
 
-Starting with Shapely 1.8, converting a geometry object to a numpy array
+Starting with Shapely 1.8, converting a geometry object to a NumPy array
 directly will start raising a warning::
 
     >>> np.asarray(line)
     ShapelyDeprecationWarning: The array interface is deprecated and will no longer
-    work in Shapely 2.0. Convert the '.coords' to a numpy array instead.
+    work in Shapely 2.0. Convert the '.coords' to a NumPy array instead.
     array([[0., 0.],
            [1., 1.],
            [2., 2.]])
 
-**How do I update my code?** To convert a geometry to a numpy array, you can
+**How do I update my code?** To convert a geometry to a NumPy array, you can
 convert the ``.coords`` attribute instead::
 
     >>> line.coords

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -335,4 +335,4 @@ as well:
 - The ``empty()`` method on a geometry object is deprecated.
 
 - The ``shapely.ops.cascaded_union`` function is deprecated. Use
-  ``shapely.ops.unary_union`` instead.
+  ``shapely.ops.unary_union`` instead, which internally already uses a cascaded union operation for better performance.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -45,9 +45,9 @@ In Shapely 1.8, this will start raising a warning::
     ShapelyDeprecationWarning: Setting the 'coords' to mutate a Geometry
     in place is deprecated, and will not be possible any more in Shapely 2.0
 
-and starting with version 2.0.0, all geometry objects will become immutable
-.  As a consequence, they will also become hashable and therefore usable as, for
-example, dictionary keys).
+and starting with version 2.0.0, all geometry objects will become immutable.
+As a consequence, they will also become hashable and therefore usable as, for
+example, dictionary keys.
 
 **How do I update my code?** There is no direct alternative for mutating the
 coordinates of an existing geometry, except for creating a new geometry

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -193,7 +193,10 @@ convert the ``.coords`` attribute instead::
 
 The ``array_interface()`` method and ``ctypes`` attribute will be removed in
 Shapely 2.0, but since Shapely will start requiring NumPy as a dependency,
-you can use NumPy or its array interface directly.
+you can use NumPy or its array interface directly. Check the NumPy docs on
+the `ctypes attribute <https://numpy.org/doc/stable/reference/generated/numpy.ndarray.ctypes.html>`__
+or the `array interface <https://numpy.org/doc/stable/reference/arrays.interface.html>`__
+for more details.
 
 Creating NumPy arrays of geometry objects
 -----------------------------------------

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,249 @@
+.. _migration:
+
+==============================
+Migrating to Shapely 1.8 / 2.0
+==============================
+
+Shapely 1.8.0 is a transitional version introducing several warnings in
+preparation of the upcoming changes in 2.0.0.
+
+Shapely 2.0.0 will be a major release with a refactor of the internals with
+considerable performance improvements (based on the developments in the
+`PyGEOS <https://github.com/pygeos/pygeos>`__ package), along with several
+breaking changes.
+
+This guide gives an overview of the most important changes with details
+on what will change in 2.0.0, how we warn for this in 1.8.0, and how
+you can update your code to be future-proof.
+
+For more background, see
+`RFC 1: Roadmap for Shapely 2.0 <https://github.com/shapely/shapely-rfc/pull/1>`__.
+
+.. contents:: Table of Contents
+
+
+Geometry objects will become immutable
+======================================
+
+Geometry objects will become immutable in version 2.0.0.
+
+In Shapely 1.x, some of the geometry classes are mutable, meaning that you
+can change their coordinates in-place. Illustrative code::
+
+    >>> from shapely.geometry import LineString
+    >>> line = LineString([(0,0), (2, 2)])
+    >>> print(line)
+    LINESTRING (0 0, 2 2)
+
+    >>> line.coords = [(0, 0), (10, 0), (10, 10)]
+    >>> print(line)
+    LINESTRING (0 0, 10 0, 10 10)
+
+In Shapely 1.8, this will start raising a warning::
+
+    >>> line.coords = [(0, 0), (10, 0), (10, 10)]
+    ShapelyDeprecationWarning: Setting the 'coords' to mutate a Geometry
+    in place is deprecated, and will not be possible any more in Shapely 2.0
+
+and starting with version 2.0.0, all geometry objects will become immutable
+(as a consequence, they will also become hashable and thefore usable as, for
+example, dictionary keys).
+
+**How do I update my code?** There is no direct alternative for mutating the
+coordinates of an existing geometry, except for creating a new geometry
+object with the new coordinates.
+
+
+Setting custom attributes
+-------------------------
+
+Another consequence of the geometry objects becoming immutable is that
+assigning custom attributes, which currently works, will no longer be possible.
+
+Currently you can do::
+
+    >>> line.name = "my_geometry"
+    >>> line.name
+    'my_geometry'
+
+This doesn't raise a warning in Shapely 1.8, but will start raising an
+AttributeError in Shapely 2.0.
+
+
+Multi-part geometries will no longer be "sequences" (length, iterable, indexable)
+=================================================================================
+
+In Shapely 1.x, multi-part geometries (MultiPoint, MultiLineString,
+MultiPolygon and GeometryCollection) implement a part of the "sequence"
+python interface (making them list-like). This means you can iterate through
+the object to get the parts, index into the object to get a specific part,
+and ask for the number of parts with the ``len()`` method.
+
+Some examples of this with Shapely 1.x:
+
+    >>> from shapely.geometry import Point, MultiPoint
+    >>> mp = MultiPoint([(1, 1), (2, 2), (3, 3)])
+    >>> print(mp)
+    MULTIPOINT (1 1, 2 2, 3 3)
+    >>> for part in mp:
+    ...     print(part)
+    POINT (1 1)
+    POINT (2 2)
+    POINT (3 3)
+    >>> print(mp[1])
+    POINT (2 2)
+    >>> len(mp)
+    3
+    >>> list(mp)
+    [<shapely.geometry.point.Point at 0x7f2e0912bf10>,
+     <shapely.geometry.point.Point at 0x7f2e09fed820>,
+     <shapely.geometry.point.Point at 0x7f2e09fed4c0>]
+
+Starting with Shapely 1.8, all the examples above will start raising a
+deprecation warning. For example:
+
+    >>> for part in mp:
+    ...     print(part)
+    ShapelyDeprecationWarning: Iteration over multi-part geometries is deprecated
+    and will be removed in Shapely 2.0. Use the `geoms` property to access the
+    constituent parts of a multi-part geometry.
+    POINT (1 1)
+    POINT (2 2)
+    POINT (3 3)
+
+In Shapely 2.0, all those examples will raise an error.
+
+**How do I update my code?** To access the geometry parts of a multi-part
+geometry, you can use the ``.geoms`` attribute, as the warning indicates.
+
+The examples above can be updated to::
+
+    >>> for part in mp.geoms:
+    ...     print(part)
+    POINT (1 1)
+    POINT (2 2)
+    POINT (3 3)
+    >>> print(mp.geoms[1])
+    POINT (2 2)
+    >>> len(mp.geoms)
+    3
+    >>> list(mp.geoms)
+    [<shapely.geometry.point.Point at 0x7f2e0912bf10>,
+     <shapely.geometry.point.Point at 0x7f2e09fed820>,
+     <shapely.geometry.point.Point at 0x7f2e09fed4c0>]
+
+The single-part geometries (Point, LineString, Polygon) already didn't
+support those features, and for those classes there is no change in behaviour
+for this aspect.
+
+
+The array interface and conversion to numpy
+===========================================
+
+Shapely provides an array interface to have easy access to the coordinates as,
+for example, numpy arrays (:ref:`manual section <array-interface>`).
+
+A small example::
+
+    >>> line = LineString([(0, 0), (1, 1), (2, 2)])
+    >>> import numpy as np
+    >>> np.asarray(line)
+    array([[0., 0.],
+           [1., 1.],
+           [2., 2.]])
+
+In addition, there are also the explicit ``array_interface()`` method and
+``ctypes`` attribute to get access to the coordinates as array data:
+
+    >>> line.ctypes
+    <shapely.geometry.linestring.c_double_Array_6 at 0x7f75261eb740>
+    >>> line.array_interface()
+    {'version': 3,
+     'typestr': '<f8',
+     'data': <shapely.geometry.linestring.c_double_Array_6 at 0x7f752664ae40>,
+     'shape': (3, 2)}
+
+This functionality is available for Point, LineString, LinearRing and MultiPoint.
+
+For more robust interoperability with numpy, this array interface will be removed
+from those geometry classes, and limited to the ``coords``. 
+
+Starting with Shapely 1.8, converting a geometry object to a numpy array
+directly will start raising a warning::
+
+    >>> np.asarray(line)
+    ShapelyDeprecationWarning: The array interface is deprecated and will no longer
+    work in Shapely 2.0. Convert the '.coords' to a numpy array instead.
+    array([[0., 0.],
+           [1., 1.],
+           [2., 2.]])
+
+**How do I update my code?** To convert a geometry to a numpy array, you can
+convert the ``.coords`` attribute instead::
+
+    >>> line.coords
+    <shapely.coords.CoordinateSequence at 0x7f2e09e88d60>
+    >>> np.array(line.coords)
+    array([[0., 0.],
+           [1., 1.],
+           [2., 2.]])
+
+The ``array_interface()`` method and ``ctypes`` attribute will be removed in
+Shapely 2.0, but since Shapely will start requiring NumPy as a dependency,
+you can use NumPy or its array interface directly.
+
+
+Consistent creation of empty geometries
+=======================================
+
+Shapely 1.x is inconsistent in creating empty geometries between various
+creation methods. A small example for an empty Polygon geometry::
+
+    # Using an empty constructor results in a GeometryCollection
+    >>> from shapely.geometry import Polygon
+    >>> g1 = Polygon()
+    >>> type(g1)
+    <class 'shapely.geometry.polygon.Polygon'>
+    >>> g1.wkt
+    GEOMETRYCOLLECTION EMPTY
+
+    # Converting from WKT gives a correct empty polygon
+    >>> from shapely import wkt
+    >>> g2 = wkt.loads("POLYGON EMPTY")
+    >>> type(g2)
+    <class 'shapely.geometry.polygon.Polygon'>
+    >>> g2.wkt
+    POLYGON EMPTY
+
+Shapely 1.8 does not yet change this inconsistent behaviour, but starting
+with Shapely 2.0, the different methods will always consistently give an
+empty geometry object of the correct type, instead of using an empty
+GeometryCollection as "generic" empty geometry object.
+
+**How do I update my code?** Those cases that will change don't raise a
+warning, but you will need to update your code if you rely on the fact that
+empty geometry objects are of the GeometryCollection type. Use the
+``.is_empty`` attribute for robustly checking if a geometry object is an
+empty geometry.
+
+In addition, the WKB serialization methods will start supporting empty
+Points (using ``"POINT (NaN NaN)"`` to represent an empty point).
+
+
+Other deprecated functionality
+==============================
+
+There are some other various functions and methods deprecated in Shapely 1.8
+as well:
+
+- The adapters to create geometry-like proxy objects with coordinates stored
+  outside Shapely geometries are deprecated and will be removed in Shapely
+  2.0 (e.g. created using ``asShape()``). They have little to no benefit
+  compared to the normal geometry classes, as thus you can convert to your
+  data to a normal geometry object instead. Use the ``shape()`` function
+  instead to convert a GeoJSON-like dict to a Shapely geometry.
+
+- The ``empty()`` method on a geometry object is deprecated.
+
+- The ``shapely.ops.cascaded_union`` function is deprecated. Use
+  ``shapely.ops.unary_union`` instead.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -46,7 +46,7 @@ In Shapely 1.8, this will start raising a warning::
     in place is deprecated, and will not be possible any more in Shapely 2.0
 
 and starting with version 2.0.0, all geometry objects will become immutable
-(as a consequence, they will also become hashable and therefore usable as, for
+.  As a consequence, they will also become hashable and therefore usable as, for
 example, dictionary keys).
 
 **How do I update my code?** There is no direct alternative for mutating the


### PR DESCRIPTION
In preparation of a next (final?) Shapely 1.8 release, I wrote up a more detailed page on the warnings included in Shapely 1.8 (and upcoming changes in 2.0), and how to update your code to get rid of the warnings / prepare it for Shapely 2.0.
