### PR TITLE
[2.0] Disallow setting custom attributes on geometry objects

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -99,7 +99,7 @@ class BaseGeometry(pygeos.Geometry):
     # _ndim : int
     #     Number of dimensions (2 or 3, generally)
 
-    _coords = None
+    __slots__ = []
 
     def __new__(self):
         # TODO create empty geometry - should we deprecate this constructor?
@@ -182,10 +182,8 @@ class BaseGeometry(pygeos.Geometry):
     @property
     def coords(self):
         """Access to geometry's coordinates (CoordinateSequence)"""
-        if self._coords is None:
-            coords_array = pygeos.get_coordinates(self, include_z=self.has_z)
-            self._coords = CoordinateSequence(coords_array)
-        return self._coords
+        coords_array = pygeos.get_coordinates(self, include_z=self.has_z)
+        return CoordinateSequence(coords_array)
 
     @property
     def xy(self):
@@ -663,6 +661,8 @@ class BaseGeometry(pygeos.Geometry):
 
 
 class BaseMultipartGeometry(BaseGeometry):
+
+    __slots__ = []
 
     def shape_factory(self, *args):
         # Factory for part instances, usually a geometry class

--- a/shapely/geometry/collection.py
+++ b/shapely/geometry/collection.py
@@ -20,6 +20,8 @@ class GeometryCollection(BaseMultipartGeometry):
         A sequence of Shapely geometry instances
     """
 
+    __slots__ = []
+
     def __new__(self, geoms=None):
         """
         Parameters

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -21,6 +21,8 @@ class LineString(BaseGeometry):
     and need not be straight. Unlike a LinearRing, a LineString is not closed.
     """
 
+    __slots__ = []
+
     def __new__(self, coordinates=None):
         """
         Parameters

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -26,6 +26,8 @@ class MultiLineString(BaseMultipartGeometry):
         A sequence of LineStrings
     """
 
+    __slots__ = []
+
     def __new__(self, lines=None):
         """
         Parameters

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -26,6 +26,8 @@ class MultiPoint(BaseMultipartGeometry):
         A sequence of Points
     """
 
+    __slots__ = []
+
     def __new__(self, points=None):
         """
         Parameters

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -26,6 +26,8 @@ class MultiPolygon(BaseMultipartGeometry):
         A sequence of `Polygon` instances
     """
 
+    __slots__ = []
+
     def __new__(self, polygons=None):
         """
         Parameters

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -35,6 +35,8 @@ class Point(BaseGeometry):
       1.0
     """
 
+    __slots__ = []
+
     def __new__(self, *args):
         """
         Parameters

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -34,6 +34,8 @@ class LinearRing(LineString):
     invalid and operations on it may fail.
     """
 
+    __slots__ = []
+
     def __new__(self, coordinates=None):
         """
         Parameters
@@ -197,6 +199,8 @@ class Polygon(BaseGeometry):
     interiors : sequence
         A sequence of rings which bound all existing holes.
     """
+
+    __slots__ = []
 
     def __new__(self, shell=None, holes=None):
         """

--- a/tests/test_geometry_base.py
+++ b/tests/test_geometry_base.py
@@ -1,8 +1,6 @@
 from shapely import geometry
-from shapely.errors import ShapelyDeprecationWarning
 
 import pytest
-
 
 def test_polygon():
     assert bool(geometry.Polygon()) is False
@@ -31,6 +29,5 @@ def test_geometry_collection():
     geometry.GeometryCollection([geometry.Point(1, 1)]),
 ])
 def test_setattr_disallowed(geom):
-    with pytest.warns(ShapelyDeprecationWarning, match="Setting custom attributes"):
+    with pytest.raises(AttributeError):
         geom.name = "test"
-    assert geom.name == "test"


### PR DESCRIPTION
xref https://github.com/Toblerity/Shapely/pull/1180/files#r693378882

PyGEOS geometries are "immutable", not only regarding the coordinates of the geometry, but also the python object: you can't assign random attributes as you can do with a normal class defined in python (this is because they are C extension types):

```python
>>> import pygeos
>>> p = pygeos.Geometry("POINT(1 1)")
>>> p
<pygeos.Geometry POINT (1 1)>
>>> p.name = "test"
...
AttributeError: 'pygeos.lib.Geometry' object has no attribute 'name'
```

However, because in Shapely we still create a Python-defined subclass for each of the geometry types (and register this, so the C code will actually instantiate those subclasses), we get the typical behaviour of standard python classes still being "mutable" objects:

```python
# using shapely-2.0 branch
>>> p = pygeos.Geometry("POINT(1 1)")
>>> p
<shapely.geometry.Point POINT (1 1)>
>>> p.name = "test"
>>> p.name
'test'
```

It's however relatively easy to keep the "can't set custom attribute" behaviour of the base C class (*if* we want this), by adding an empty `__slots__` to each of the python subclasses. (which is what this PR is doing)

---

Personally, I liked the fact that pygeos Geometries were completely immutable, so I would be in favor of preserving this characteristic in Shapely as well. 
(for example, we will generally re-use objects (eg when broadcasting) because they are immutable, and for such cases, setting attributes might give surprising behaviour)

_If_ we would want to disallow setting attributes in Shapely 2.0, following PyGEOS behaviour, that's of course a breaking change compared to Shapely 1.x, but I think it should be relatively easy to add a deprecation warning for this change as well (adding a warning in `__setattr__`).

cc @sgillies @caspervdw


