### PR TITLE
Deprecate setting of custom attributes on geometry objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -53,6 +53,7 @@ version 2.0.0.
 - geometry .to_wkb() and .to_wkt()
 - geometry .ctypes and .__array_interface__
 - multi-part geometry .__len__
+- setting custom attributes on geometry objects
 
 Geometry objects will become immutable in version 2.0.0.
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -66,9 +66,13 @@ Currently you can do::
     >>> line.name
     'my_geometry'
 
-This doesn't raise a warning in Shapely 1.8, but will start raising an
+In Shapely 1.8, this will start raising a warning, and will raise an
 AttributeError in Shapely 2.0.
 
+**How do I update my code?** There is no direct alternative for adding custom
+attributes to geometry objects. You can use other Python data structures such as
+(GeoJSON-like) dictionaries or GeoPandas' GeoDataFrames to store attributes
+alongside geometry features. 
 
 Multi-part geometries will no longer be "sequences" (length, iterable, indexable)
 =================================================================================

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -20,6 +20,8 @@ For more background, see
 `RFC 1: Roadmap for Shapely 2.0 <https://github.com/shapely/shapely-rfc/pull/1>`__.
 
 .. contents:: Table of Contents
+  :backlinks: none
+  :local:
 
 
 Geometry objects will become immutable

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -14,6 +14,7 @@ import math
 import sys
 from warnings import warn
 from functools import wraps
+import warnings
 
 from shapely.affinity import affine_transform
 from shapely.coords import CoordinateSequence
@@ -240,6 +241,24 @@ class BaseGeometry:
         self._empty()
         self._is_empty = val in [EMPTY, None]
         self.__geom__ = val
+
+    def __setattr__(self, name, value):
+        # first try regular attribute access via __getattribute__, so that
+        # our own (existing) attributes don't raise a warning
+        try:
+            object.__getattribute__(self, name)
+            super().__setattr__(name, value)
+            return
+        except AttributeError:
+            pass
+
+        # if custom atribute, raise the warning
+        warn(
+            "Setting custom attributes on geometry objects is deprecated, "
+            "and will raise an AttributeError in Shapely 2.0",
+            ShapelyDeprecationWarning, stacklevel=2
+        )
+        super().__setattr__(name, value)
 
     # Operators
     # ---------

--- a/shapely/geometry/proxy.py
+++ b/shapely/geometry/proxy.py
@@ -38,6 +38,11 @@ class CachingGeometryProxy:
     def gtag(self):
         return hash(repr(self.context))
 
+    def __setattr__(self, name, value):
+        # to override the custom one in BaseGeometry, so we don't warn
+        # for the proxy classes, which are already deprecated itself
+        object.__setattr__(self, name, value)
+
 
 class PolygonProxy(CachingGeometryProxy):
 

--- a/tests/test_geometry_base.py
+++ b/tests/test_geometry_base.py
@@ -1,4 +1,7 @@
 from shapely import geometry
+from shapely.errors import ShapelyDeprecationWarning
+
+import pytest
 
 
 def test_polygon():
@@ -15,3 +18,19 @@ def test_point():
 
 def test_geometry_collection():
     assert bool(geometry.GeometryCollection()) is False
+
+
+@pytest.mark.parametrize("geom", [
+    geometry.Point(1, 1),
+    geometry.LinearRing([(0, 0), (1, 1), (0, 1), (0, 0)]),
+    geometry.LineString([(0, 0), (1, 1), (0, 1), (0, 0)]),
+    geometry.Polygon([(0, 0), (1, 1), (0, 1), (0, 0)]),
+    geometry.MultiPoint([(1, 1)]),
+    geometry.MultiLineString([[(0, 0), (1, 1), (0, 1), (0, 0)]]),
+    geometry.MultiPolygon([geometry.Polygon([(0, 0), (1, 1), (0, 1), (0, 0)])]),
+    geometry.GeometryCollection([geometry.Point(1, 1)]),
+])
+def test_setattr_disallowed(geom):
+    with pytest.warns(ShapelyDeprecationWarning, match="Setting custom attributes"):
+        geom.name = "test"
+    assert geom.name == "test"


### PR DESCRIPTION
See https://github.com/Toblerity/Shapely/pull/1181 (and https://github.com/Toblerity/Shapely/pull/1180/files#r693378882). _If_ we want to disallow it for Shapely 2.0, this is adding a deprecation warning for it for 1.8