### PR TITLE
Support LinearRing objects in the shape() function

### DIFF
--- a/shapely/geometry/geo.py
+++ b/shapely/geometry/geo.py
@@ -8,7 +8,7 @@ from shapely.errors import ShapelyDeprecationWarning
 
 from .point import Point, asPoint
 from .linestring import LineString, asLineString
-from .polygon import Polygon, asPolygon
+from .polygon import LinearRing, Polygon, asPolygon
 from .multipoint import MultiPoint, asMultiPoint
 from .multilinestring import MultiLineString, asMultiLineString
 from .multipolygon import MultiPolygon, MultiPolygonAdapter
@@ -106,6 +106,8 @@ def shape(context):
         return Point(ob["coordinates"])
     elif geom_type == "linestring":
         return LineString(ob["coordinates"])
+    elif geom_type == "linearring":
+        return LinearRing(ob["coordinates"])
     elif geom_type == "polygon":
         return Polygon(ob["coordinates"][0], ob["coordinates"][1:])
     elif geom_type == "multipoint":

--- a/tests/test_geointerface.py
+++ b/tests/test_geointerface.py
@@ -6,7 +6,7 @@ from shapely.geometry import asShape, shape
 from shapely.geometry.multipoint import MultiPoint, MultiPointAdapter
 from shapely.geometry.linestring import LineString, LineStringAdapter
 from shapely.geometry.multilinestring import MultiLineString, MultiLineStringAdapter
-from shapely.geometry.polygon import Polygon, PolygonAdapter
+from shapely.geometry.polygon import LinearRing, Polygon, PolygonAdapter
 from shapely.geometry.multipolygon import MultiPolygon, MultiPolygonAdapter
 from shapely import wkt
 
@@ -93,6 +93,17 @@ class GeoInterfaceTestCase(unittest.TestCase):
             {'type': 'LineString', 'coordinates': ((-1.0, -1.0), (1.0, 1.0))})
         self.assertIsInstance(geom, LineString)
         self.assertEqual(tuple(geom.coords), ((-1.0, -1.0), (1.0, 1.0)))
+
+        # Check linearring
+        geom = shape(
+            {'type': 'LinearRing', 
+             'coordinates': 
+                 ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (2.0, -1.0), (0.0, 0.0))}
+        )
+        self.assertIsInstance(geom, LinearRing)
+        self.assertEqual(
+            tuple(geom.coords),
+            ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (2.0, -1.0), (0.0, 0.0)))
 
         # polygon
         geom = shape(


### PR DESCRIPTION
Closes #1179

Note that LinearRing type geometry is not actually supported in the GeoJSON spec, and the `__geo_interface__` spec doesn't explicitly mention it (https://gist.github.com/sgillies/2217756). 

But since we create python dicts with "LinearRing" type in `mapping(linearring)` or `linearring.__geo_interface__`, it seems most logical to indeed support the roundtrip in `shape(..)` as well.