### PR TITLE
Fix loading geos_c library on Linux.

### DIFF
--- a/shapely/geos.py
+++ b/shapely/geos.py
@@ -96,7 +96,7 @@ if sys.platform.startswith('linux'):
             'libgeos_c.so.1',
             'libgeos_c.so',
         ]
-        _lgeos = load_dll('libgeos_c', fallbacks=alt_paths)
+        _lgeos = load_dll('geos_c', fallbacks=alt_paths)
 
     # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
     # manpage says, "If filename is NULL, then the returned handle is for the


### PR DESCRIPTION
The Debian package build for 1.8rc1 failed due to not finding geos_c:
```
FileNotFoundError: [Errno 2] No such file or directory: b'liblibgeos_c.a'
```
This is fixed by [reverting the `load_dll` change from `geos_c` to `libgeos_c` on Linux](https://github.com/Toblerity/Shapely/commit/611a0b3b2047bf8a49db32dc4b30684a10f5b6eb#diff-449c80fbb0cac229a562aa3662da054b7ccdd3533e46d7e66cdf623fba6dd507).

