### PR TITLE
Upgrade cython==0.29.24 to work with Python 3.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ environment:
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
       GEOS_VERSION: "3.9.1"
+    - PYTHON: "C:\\Python310"
+      ARCH: x86
+      GEOS_VERSION: "3.10.1"
 
 
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cython==0.29.21
+cython==0.29.24
 descartes==1.0.1
 matplotlib
 numpy>=1.4.1


### PR DESCRIPTION
[Attempts](https://github.com/shapely/shapely-wheels/pull/10/commits/d8700bbee937d515a197353452b0651783abc23c) to build Shapely for Python 3.10 on Windows [flopped with an error](https://ci.appveyor.com/project/frsci/shapely-wheels/builds/41413927/job/q8r6r6w36ae35527#L2172):
> _speedups.obj : error LNK2001: unresolved external symbol _PyGen_Send

which is described at https://github.com/cython/cython/issues/3876

This was resolved as of cython version 0.29.22, but this PR uses the latest cython update in the 0.29.x series.

Xref #1215 and https://github.com/shapely/shapely-wheels/pull/10