### PR TITLE
CI: Upgrade GEOS versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
           python -m pytest --cov shapely --cov-report term-missing "${SPEEDUPS_FLAG}"
 
       - name: Run doctests
-        if: ${{ matrix.python == '3.8' && matrix.numpy && matrix.speedups == '1' }}
+        if: ${{ matrix.python == '3.9' && matrix.numpy && matrix.speedups == '1' }}
         shell: bash
         run: |
           python -m pytest shapely --doctest-modules

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,27 +48,27 @@ jobs:
             speedups: 0
           # 2020
           - python: 3.9
-            geos: 3.9.1
+            geos: 3.9.2
             numpy: 1.19.5
             speedups: 1
           - python: 3.9
-            geos: 3.9.1
+            geos: 3.9.2
             numpy: 1.19.5
             speedups: 0
           - python: 3.9
-            geos: 3.9.1
+            geos: 3.9.2
             speedups: 0
           # 2021
           - python: "3.10"
-            geos: 3.10.0
+            geos: 3.10.1
             numpy: 1.21.3
             speedups: 1
           - python: "3.10"
-            geos: 3.10.0
+            geos: 3.10.1
             numpy: 1.21.3
             speedups: 0
           - python: "3.10"
-            geos: 3.10.0
+            geos: 3.10.1
             speedups: 0
           # dev
           - python: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,15 @@ jobs:
         include:
           # 2017
           - python: 3.6
-            geos: 3.6.4
+            geos: 3.6.5
             numpy: 1.13.3
             speeedups: 1
           - python: 3.6
-            geos: 3.6.4
+            geos: 3.6.5
             numpy: 1.13.3
             speeedups: 0
           - python: 3.6
-            geos: 3.6.4
+            geos: 3.6.5
             speeedups: 0
           # 2018
           - python: 3.7
@@ -36,15 +36,15 @@ jobs:
             speedups: 0
           # 2019
           - python: 3.8
-            geos: 3.8.1
+            geos: 3.8.2
             numpy: 1.17.5
             speedups: 1
           - python: 3.8
-            geos: 3.8.1
+            geos: 3.8.2
             numpy: 1.17.5
             speedups: 0
           - python: 3.8
-            geos: 3.8.1
+            geos: 3.8.2
             speedups: 0
           # 2020
           - python: 3.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
       GEOS_VERSION: "3.8.1"
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
-      GEOS_VERSION: "3.9.1"
+      GEOS_VERSION: "3.9.2"
     - PYTHON: "C:\\Python310"
       ARCH: x86
       GEOS_VERSION: "3.10.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       GEOS_VERSION: "3.7.3"
     - PYTHON: "C:\\Python38"
       ARCH: x86
-      GEOS_VERSION: "3.8.2"
+      GEOS_VERSION: "3.8.1"
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
       GEOS_VERSION: "3.9.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,13 @@ environment:
     # Interleave PYTHON, ARCH and GEOS_VERSION
     - PYTHON: "C:\\Python36"
       ARCH: x86
-      GEOS_VERSION: "3.6.4"
+      GEOS_VERSION: "3.6.5"
     - PYTHON: "C:\\Python37-x64"
       ARCH: x64
       GEOS_VERSION: "3.7.3"
     - PYTHON: "C:\\Python38"
       ARCH: x86
-      GEOS_VERSION: "3.8.1"
+      GEOS_VERSION: "3.8.2"
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
       GEOS_VERSION: "3.9.2"

--- a/shapely/algorithms/polylabel.py
+++ b/shapely/algorithms/polylabel.py
@@ -80,11 +80,12 @@ def polylabel(polygon, tolerance=1.0):
 
     Example
     -------
+    >>> from shapely import wkt
     >>> polygon = LineString([(0, 0), (50, 200), (100, 100), (20, 50),
     ... (-100, -20), (-150, -200)]).buffer(100)
     >>> label = polylabel(polygon, tolerance=10)
-    >>> label.wkt
-    'POINT (59.35615556364569 121.8391962974644)'
+    >>> wkt.dumps(label, rounding_precision=12)
+    'POINT (59.356155563646 121.839196297464)'
     """
     if not polygon.is_valid:
         raise TopologicalError('Invalid polygon')

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -600,10 +600,10 @@ class BaseGeometry:
         >>> from shapely.wkt import loads
         >>> g = loads('POINT (0.0 0.0)')
         >>> g.buffer(1.0).area        # 16-gon approx of a unit radius circle
-        3.1365484905459384
+        3.1365484905459...
         >>> g.buffer(1.0, 128).area   # 128-gon approximation
-        3.141513801144299
-        >>> g.buffer(1.0, 3).area     # triangle approximation
+        3.141513801144...
+        >>> round(g.buffer(1.0, 3).area, 10)  # triangle approximation
         3.0
         >>> list(g.buffer(1.0, cap_style=CAP_STYLE.square).exterior.coords)
         [(1.0, 1.0), (1.0, -1.0), (-1.0, -1.0), (-1.0, 1.0), (1.0, 1.0)]


### PR DESCRIPTION
Another maintenance update for shapely-1.8, to use the latest versions of GEOS.

- GEOS 3.9.2 [announcement](https://lists.osgeo.org/pipermail/geos-devel/2021-November/010526.html)
- GEOS 3.10.1 [announcement](https://lists.osgeo.org/pipermail/geos-devel/2021-November/010556.html)

If we get around to shapely-1.8.1, the binary wheels should probably be packaged with GEOS 3.9.2.