### PR TITLE
TST: linearring closing logic was changed with pygeos

### DIFF
--- a/tests/test_singularity.py
+++ b/tests/test_singularity.py
@@ -1,14 +1,9 @@
 from . import unittest
 from shapely.geometry import Polygon
 
-import pytest
-
-from tests.conftest import shapely20_todo
 
 class PolygonTestCase(unittest.TestCase):
 
-    # TODO(shapely-2.0) LinearRing doesn't do "ring closure" with all-equal coords
-    @shapely20_todo
     def test_polygon_3(self):
         p = (1.0, 1.0)
         poly = Polygon([p, p, p])


### PR DESCRIPTION
Xref https://github.com/pygeos/pygeos/issues/213 and https://github.com/pygeos/pygeos/pull/431

This test was restored to it's previous state.