### PR TITLE
Fix the array_interface_base property

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -323,7 +323,7 @@ class BaseGeometry:
             "The 'array_interface_base' property is deprecated and will be "
             "removed in Shapely 2.0.",
             ShapelyDeprecationWarning, stacklevel=2)
-        return self._array_interface_base()
+        return self._array_interface_base
 
     @property
     def __array_interface__(self):


### PR DESCRIPTION
Same as https://github.com/Toblerity/Shapely/pull/1214 but based on the right branch.

Just for your information `geoviews` was using this property in a couple of internal utils and in its test suite.