### PR TITLE
BUG: fixup the hash-ability of geometries

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -165,17 +165,6 @@ class BaseGeometry(shapely.Geometry):
     def __xor__(self, other):
         return self.symmetric_difference(other)
 
-    def __eq__(self, other):
-        return (
-            type(other) == type(self) and
-            bool(shapely.equals_exact(self, other))
-        )
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    __hash__ = None
-
     # Coordinate access
     # -----------------
 
@@ -752,8 +741,6 @@ class BaseMultipartGeometry(BaseGeometry):
 
     def __bool__(self):
         return self.is_empty is False
-
-    __hash__ = None
 
     def svg(self, scale_factor=1., color=None):
         """Returns a group of SVG elements for the multipart geometry.

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -284,8 +284,6 @@ class Polygon(BaseGeometry):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    __hash__ = None
-
     @property
     def coords(self):
         raise NotImplementedError(


### PR DESCRIPTION
On top of #1237, so only the last commit is relevant.

The tests for hash-ability were still failing, for two reasons:

- There was still a `__hash__ = None` in the code, effectively making a class unhashable
- We defined a `__eq__` in the python-level BaseGeometry class, and when you subclass, you need to implement neither or both of `__eq__` and `__hash__` (see https://docs.python.org/3/reference/datamodel.html#object.__hash__)
  - I now removed the `__eq__` in the python layer, keeping the `GeometryObject_richcompare` in the C extension type in `pygeos.c` (but in principle we could also do it the other way around I think)