### PR TITLE
Minimal pygeos->shapely renaming in C code to get cython API working

### DIFF
--- a/shapely/_geometry_helpers.pyx
+++ b/shapely/_geometry_helpers.pyx
@@ -29,14 +29,14 @@ from shapely._geos cimport (
     get_geos_handle,
 )
 from shapely._pygeos_api cimport (
-    import_pygeos_c_api,
+    import_shapely_c_api,
     PyGEOS_CoordSeq_FromBuffer,
     PyGEOS_CreateGeometry,
     PyGEOS_GetGEOSGeometry,
 )
 
 # initialize Shapely C API
-import_pygeos_c_api()
+import_shapely_c_api()
 
 
 def _check_out_array(object out, Py_ssize_t size):

--- a/shapely/_pygeos_api.pxd
+++ b/shapely/_pygeos_api.pxd
@@ -4,7 +4,7 @@ Internally, the shapely C extension uses a PyCapsule to provide run-time access
 to function pointers within the C API.
 
 To use these functions, you must first call the following function in each Cython module:
-`import_pygeos_c_api()`
+`import_shapely_c_api()`
 
 This uses a macro to dynamically load the functions from pointers in the PyCapsule.
 Each C function in shapely.lib exposed in the C API must be specially-wrapped to enable
@@ -22,7 +22,7 @@ from shapely._geos cimport GEOSContextHandle_t, GEOSCoordSequence, GEOSGeometry
 cdef extern from "c_api.h":
     # shapely.lib C API loader; returns -1 on error
     # MUST be called before calling other C API functions
-    int import_pygeos_c_api() except -1
+    int import_shapely_c_api() except -1
 
     # C functions provided by the shapely.lib C API
     # Note: GeometryObjects are always managed as Python objects

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -42,7 +42,7 @@
 #define PyGEOS_API_num_pointers 3
 
 #ifdef PyGEOS_API_Module
-/* This section is used when compiling pygeos.lib C extension.
+/* This section is used when compiling shapely.lib C extension.
  * Each API function needs to provide a corresponding *_PROTO here.
  */
 
@@ -75,9 +75,9 @@ static void **PyGEOS_API;
  * PyCapsule_Import will set an exception on error.
  */
 static int
-import_pygeos_c_api(void)
+import_shapely_c_api(void)
 {
-    PyGEOS_API = (void **)PyCapsule_Import("pygeos.lib._C_API", 0);
+    PyGEOS_API = (void **)PyCapsule_Import("shapely.lib._C_API", 0);
     return (PyGEOS_API == NULL) ? -1 : 0;
 }
 

--- a/src/coords.c
+++ b/src/coords.c
@@ -5,7 +5,7 @@
 #include <math.h>
 
 #define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
 
 #include <numpy/arrayobject.h>
 #include <numpy/ndarraytypes.h>

--- a/src/geos.c
+++ b/src/geos.c
@@ -12,7 +12,7 @@
 PyObject* geos_exception[1] = {NULL};
 
 int init_geos(PyObject* m) {
-  geos_exception[0] = PyErr_NewException("pygeos.GEOSException", NULL, NULL);
+  geos_exception[0] = PyErr_NewException("shapely.GEOSException", NULL, NULL);
   PyModule_AddObject(m, "GEOSException", geos_exception[0]);
   return 0;
 }

--- a/src/lib.c
+++ b/src/lib.c
@@ -5,8 +5,8 @@
 
 #define PyGEOS_API_Module
 
-#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
-#define PY_UFUNC_UNIQUE_SYMBOL pygeos_UFUNC_API
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL shapely_UFUNC_API
 #include <numpy/ndarraytypes.h>
 #include <numpy/npy_3kcompat.h>
 #include <numpy/ufuncobject.h>
@@ -92,7 +92,7 @@ PyMODINIT_FUNC PyInit_lib(void) {
   PyGEOS_API[PyGEOS_CoordSeq_FromBuffer_NUM] = (void*)PyGEOS_CoordSeq_FromBuffer;
 
   /* Create a Capsule containing the API pointer array's address */
-  c_api_object = PyCapsule_New((void*)PyGEOS_API, "pygeos.lib._C_API", NULL);
+  c_api_object = PyCapsule_New((void*)PyGEOS_API, "shapely.lib._C_API", NULL);
   if (c_api_object != NULL) {
     PyModule_AddObject(m, "_C_API", c_api_object);
   }

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -204,15 +204,15 @@ static PyObject* GeometryObject_repr(GeometryObject* self) {
   // we never want a repr() to fail; that can be very confusing
   if (wkt == NULL) {
     PyErr_Clear();
-    return PyUnicode_FromString("<pygeos.Geometry Exception in WKT writer>");
+    return PyUnicode_FromString("<shapely.Geometry Exception in WKT writer>");
   }
   // the total length is limited to 80 characters
   if (PyUnicode_GET_LENGTH(wkt) > 62) {
     truncated = PyUnicode_Substring(wkt, 0, 59);
-    result = PyUnicode_FromFormat("<pygeos.Geometry %U...>", truncated);
+    result = PyUnicode_FromFormat("<shapely.Geometry %U...>", truncated);
     Py_XDECREF(truncated);
   } else {
-    result = PyUnicode_FromFormat("<pygeos.Geometry %U>", wkt);
+    result = PyUnicode_FromFormat("<shapely.Geometry %U>", wkt);
   }
   Py_XDECREF(wkt);
   return result;
@@ -410,7 +410,7 @@ static PyMethodDef GeometryObject_methods[] = {
 };
 
 PyTypeObject GeometryType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pygeos.lib.Geometry",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "shapely.lib.Geometry",
     .tp_doc = "Geometry type",
     .tp_basicsize = sizeof(GeometryObject),
     .tp_itemsize = 0,

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -7,7 +7,7 @@
 #include <structmember.h>
 
 #define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
 
 #include <numpy/arrayobject.h>
 #include <numpy/ndarraytypes.h>
@@ -333,7 +333,7 @@ static char evaluate_predicate(void* context, FuncGEOS_YpY_b* predicate_func,
  * satisfy the predicate function are returned.
  *
  * args must be:
- * - pygeos geometry object
+ * - shapely geometry object
  * - predicate id (see strtree.py for list of ids)
  * */
 
@@ -426,7 +426,7 @@ static PyObject* STRtree_query(STRtreeObject* self, PyObject* args) {
  * and second is indexes of tree geometries that meet the above conditions.
  *
  * args must be:
- * - ndarray of pygeos geometries
+ * - ndarray of shapely geometries
  * - predicate id (see strtree.py for list of ids)
  *
  * */
@@ -496,7 +496,7 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
   GEOS_INIT_THREADS;
 
   for (i = 0; i < n; i++) {
-    // get pygeos geometry from input geometry array
+    // get shapely geometry from input geometry array
     pg_geom = *(GeometryObject**)PyArray_GETPTR1(pg_geoms, i);
     if (!get_geom_with_prepared(pg_geom, &geom, &prepared_geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
@@ -762,7 +762,7 @@ static PyObject* STRtree_nearest(STRtreeObject* self, PyObject* arr) {
   GEOS_INIT_THREADS;
 
   for (i = 0; i < n; i++) {
-    // get pygeos geometry from input geometry array
+    // get shapely geometry from input geometry array
     pg_geom = *(GeometryObject**)PyArray_GETPTR1(pg_geoms, i);
     if (!get_geom(pg_geom, &geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
@@ -928,7 +928,7 @@ static PyObject* STRtree_nearest_all(STRtreeObject* self, PyObject* args) {
   userdata.dist_pairs = &dist_pairs;
 
   for (i = 0; i < n; i++) {
-    // get pygeos geometry from input geometry array
+    // get shapely geometry from input geometry array
     pg_geom = *(GeometryObject**)PyArray_GETPTR1(pg_geoms, i);
     if (!get_geom(pg_geom, &geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
@@ -1149,7 +1149,7 @@ static PyObject* STRtree_dwithin(STRtreeObject* self, PyObject* args) {
   GEOS_INIT_THREADS;
 
   for (i = 0; i < n; i++) {
-    // get pygeos geometry from input geometry array
+    // get shapely geometry from input geometry array
     pg_geom = *(GeometryObject**)PyArray_GETPTR1(pg_geoms, i);
     if (!get_geom_with_prepared(pg_geom, &geom, &prepared_geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
@@ -1311,7 +1311,7 @@ static PyMethodDef STRtree_methods[] = {
 };
 
 PyTypeObject STRtreeType = {
-    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "pygeos.lib.STRtree",
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "shapely.lib.STRtree",
     .tp_doc =
         "A query-only R-tree created using the Sort-Tile-Recursive (STR) algorithm.",
     .tp_basicsize = sizeof(STRtreeObject),

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -6,8 +6,8 @@
 
 #define NO_IMPORT_ARRAY
 #define NO_IMPORT_UFUNC
-#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
-#define PY_UFUNC_UNIQUE_SYMBOL pygeos_UFUNC_API
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL shapely_UFUNC_API
 #include <numpy/ndarraytypes.h>
 #include <numpy/npy_3kcompat.h>
 #include <numpy/ufuncobject.h>

--- a/src/vector.c
+++ b/src/vector.c
@@ -5,7 +5,7 @@
 #include <structmember.h>
 
 #define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#define PY_ARRAY_UNIQUE_SYMBOL shapely_ARRAY_API
 
 #include <numpy/arrayobject.h>
 #include <numpy/ndarraytypes.h>


### PR DESCRIPTION
I missed one aspect in https://github.com/Toblerity/Shapely/pull/1237 to get a basic working package (due to testing it in an environment in which I still had pygeos installed, so the cython code was picking up the pygeos package instead ..).

I didn't yet do a full rename of all PyGEOS_.. functions.

cc @caspervdw 