### PR TITLE
TST: fix search/replace mistake in test_empty

### DIFF
--- a/shapely/tests/test_creation.py
+++ b/shapely/tests/test_creation.py
@@ -518,6 +518,6 @@ def test_empty_missing(geom_type):
 @pytest.mark.parametrize("geom_type", range(8))
 def test_empty(geom_type):
     actual = shapely.empty((2,), geom_type=geom_type)
-    assert (shapely.is_missing(actual)).all()
+    assert (~shapely.is_missing(actual)).all()
     assert shapely.is_empty(actual).all()
     assert (shapely.get_type_id(actual) == geom_type).all()


### PR DESCRIPTION
Small error in my pygeos -> shapely renaming which caused some test failures