### PR TITLE
Update MANIFEST.in to enable 'python -m build` to work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - ".github/workflows/release.yml"
       - "ci/*"
+      - "MANIFEST.in"
+      - "pyproject.toml"
+      - "setup.py"
 
 jobs:
   build_sdist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,8 @@ jobs:
 
       - name: Build a source tarball
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools
-          python setup.py sdist
+          python -m pip install --upgrade pip build
+          python -m build --sdist
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.c
 *.so
 
-VERSION.txt
 Shapely.egg-info/
 build/
 dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,11 @@ prune docs
 exclude *.txt
 exclude MANIFEST.in
 include CHANGES.txt CREDITS.txt LICENSE.txt README.rst VERSION.txt
+include versioneer.py
 recursive-include _vendor *.py
+recursive-include src *.c *.h
 recursive-include tests *.py *.txt
 recursive-include shapely/examples *.py
-recursive-include shapely *.pxi
+recursive-include shapely *.pxi *.pxd *.pyx
 recursive-include shapely/DLLs *.dll *.rst *.txt
 include docs/*.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,5 +10,6 @@ recursive-include src *.c *.h
 recursive-include tests *.py *.txt
 recursive-include shapely/examples *.py
 recursive-include shapely *.pxi *.pxd *.pyx
+recursive-exclude shapely *.c
 recursive-include shapely/DLLs *.dll *.rst *.txt
 include docs/*.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,8 @@ prune debian
 prune docs
 exclude *.txt
 exclude MANIFEST.in
-include CHANGES.txt CREDITS.txt LICENSE.txt README.rst VERSION.txt
-include versioneer.py
+include CHANGES.txt CREDITS.txt LICENSE.txt README.rst
+include pyproject.toml versioneer.py
 recursive-include _vendor *.py
 recursive-include src *.c *.h
 recursive-include tests *.py *.txt

--- a/MANIFEST_pygeos.in
+++ b/MANIFEST_pygeos.in
@@ -1,8 +1,0 @@
-include src/*
-include pygeos/*.pyx pygeos/*.pxd
-include versioneer.py
-include pygeos/_version.py
-include LICENSE
-include pyproject.toml
-exclude pygeos/*.c
-exclude MANIFEST.in


### PR DESCRIPTION
A few edits to `MANIFEST.in` were necessary to get `python -m build` to work as expected.

This should probably be integrated into the CI at some point.