### PR TITLE
BUG/TST: fix hashing for Polygon + update tests

### DIFF
--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -263,27 +263,6 @@ class Polygon(BaseGeometry):
             return []
         return InteriorRingSequence(self)
 
-    def __eq__(self, other):
-        if not isinstance(other, Polygon):
-            return False
-        check_empty = (self.is_empty, other.is_empty)
-        if all(check_empty):
-            return True
-        elif any(check_empty):
-            return False
-        my_coords = [
-            tuple(self.exterior.coords),
-            [tuple(interior.coords) for interior in self.interiors]
-        ]
-        other_coords = [
-            tuple(other.exterior.coords),
-            [tuple(interior.coords) for interior in other.interiors]
-        ]
-        return my_coords == other_coords
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     @property
     def coords(self):
         raise NotImplementedError(

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,37 +1,35 @@
-from shapely.geometry import Point, MultiPoint, Polygon, GeometryCollection
+from shapely.geometry import Point, MultiPoint, LineString, Polygon, GeometryCollection
 
 
 def test_point():
-    g = Point(0, 0)
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
+    g = Point(1, 2)
+    assert hash(g) == hash(Point(1, 2))
+    assert hash(g) != hash(Point(1, 3))
 
 
 def test_multipoint():
-    g = MultiPoint([(0, 0)])
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
+    g = MultiPoint([(1, 2), (3, 4)])
+    assert hash(g) == hash(MultiPoint([(1, 2), (3, 4)]))
+    assert hash(g) != hash(MultiPoint([(1, 2), (3, 3)]))
+
+
+def test_linestring():
+    g = LineString([(1, 2), (3, 4)])
+    assert hash(g) == hash(LineString([(1, 2), (3, 4)]))
+    assert hash(g) != hash(LineString([(1, 2), (3, 3)]))
 
 
 def test_polygon():
     g = Point(0, 0).buffer(1.0)
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
+    assert hash(g) == hash(Point(0, 0).buffer(1.0))
+    assert hash(g) != hash(Point(0, 0).buffer(1.1))
 
 
 def test_collection():
-    g = GeometryCollection([Point(0, 0)])
-    try:
-        assert hash(g)
-        return False
-    except TypeError:
-        return True
+    g = GeometryCollection([Point(1, 2), LineString([(1, 2), (3, 4)])])
+    assert hash(g) == hash(
+        GeometryCollection([Point(1, 2), LineString([(1, 2), (3, 4)])])
+    )
+    assert hash(g) != hash(
+        GeometryCollection([Point(1, 2), LineString([(1, 2), (3, 3)])])
+    )


### PR DESCRIPTION
Supersedes #985

The hash implementation is better than the previous one that existed in shapely several versions ago, as it is now based on WKB.

Now geometries can be used as dict keys to do things like this:
```
>>> from shapely.geometry import Point
>>> d = {}
>>> d[Point(1, 2)] = "X"
>>> d[Point(1.0, 2.0)]
'X'
```